### PR TITLE
[TS]LPS-160305 Check if type is null, continue upgrade if null

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_1_0/DDMFieldUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_1_0/DDMFieldUpgradeProcess.java
@@ -531,11 +531,23 @@ public class DDMFieldUpgradeProcess extends UpgradeProcess {
 
 		List<DDMFormFieldValue> newDDMFormFieldValues = new ArrayList<>();
 
+		String type = null;
+
 		for (DDMFormFieldValue ddmFormFieldValue : ddmFormFieldValues) {
+			try {
+				type = ddmFormFieldValue.getType();
+			}
+			catch (Exception exception) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(exception);
+				}
+			}
+
 			if (!ListUtil.isEmpty(
 					ddmFormFieldValue.getNestedDDMFormFieldValues()) &&
+				(type != null) &&
 				!com.liferay.portal.kernel.util.StringUtil.equals(
-					ddmFormFieldValue.getType(), "fieldset")) {
+					type, "fieldset")) {
 
 				DDMFormFieldValue newDDMFormFieldValue =
 					new DDMFormFieldValue() {


### PR DESCRIPTION
Ticket:
[LPS-160305](https://issues.liferay.com/browse/LPS-160305)

Issue:
Assume that a form exists with multiple fields and multiple entries have been added for that form.  If a field from that form is removed, then during the upgrade, when the type for that entry is fetched, it will return a null exception since it no longer exists on the form.

Solution:
We determined that it would be better to allow the upgrade to continue in the event the type of the field cannot be retrieved.  The data will still be saved in DDMFieldAttributes.