### PR TITLE
LPS-160370 Sharded cache must use one single portal ehcache for both default company and system

### DIFF
--- a/modules/apps/portal-cache/portal-cache-ehcache-impl/src/main/java/com/liferay/portal/cache/ehcache/internal/ShardedEhcachePortalCache.java
+++ b/modules/apps/portal-cache/portal-cache-ehcache-impl/src/main/java/com/liferay/portal/cache/ehcache/internal/ShardedEhcachePortalCache.java
@@ -15,7 +15,9 @@
 package com.liferay.portal.cache.ehcache.internal;
 
 import com.liferay.portal.cache.ehcache.internal.event.PortalCacheCacheEventListener;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.PortalUtil;
 
 import java.io.Serializable;
 
@@ -47,7 +49,7 @@ public class ShardedEhcachePortalCache<K extends Serializable, V>
 	@Override
 	public Ehcache getEhcache() {
 		return _ehcaches.computeIfAbsent(
-			CompanyThreadLocal.getCompanyId(),
+			_getCompanyId(),
 			key -> {
 				String shardedPortalCacheName =
 					getPortalCacheName() + _SHARDED_SEPARATOR + key;
@@ -118,6 +120,20 @@ public class ShardedEhcachePortalCache<K extends Serializable, V>
 	@Override
 	protected void resetEhcache() {
 		_ehcaches.clear();
+	}
+
+	private Long _getCompanyId() {
+		Long companyId = CompanyThreadLocal.getCompanyId();
+
+		if (companyId == CompanyConstants.SYSTEM) {
+			return companyId;
+		}
+
+		if (companyId == PortalUtil.getDefaultCompanyId()) {
+			return CompanyConstants.SYSTEM;
+		}
+
+		return companyId;
 	}
 
 	private static final String _SHARDED_SEPARATOR = "_SHARDED_SEPARATOR_";

--- a/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/ShardedEhcachePortalCacheTest.java
+++ b/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/ShardedEhcachePortalCacheTest.java
@@ -17,12 +17,16 @@ package com.liferay.portal.cache.ehcache.internal;
 import com.liferay.portal.cache.AggregatedPortalCacheListener;
 import com.liferay.portal.kernel.cache.PortalCacheListener;
 import com.liferay.portal.kernel.cache.PortalCacheListenerScope;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ProxyFactory;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.Arrays;
@@ -47,6 +51,9 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * @author Tina Tian
@@ -102,6 +109,7 @@ public class ShardedEhcachePortalCacheTest {
 	@After
 	public void tearDown() {
 		_cacheManager.shutdown();
+		_portalUtilMockedStatic.close();
 	}
 
 	@Test
@@ -177,6 +185,11 @@ public class ShardedEhcachePortalCacheTest {
 	}
 
 	@Test
+	public void testGetDefaultCompanyEhcacheName() {
+		_assertEhcacheName(_TEST_COMPANY_ID_1);
+	}
+
+	@Test
 	public void testGetKeys() {
 		_companyIdThreadLocal.set(_TEST_COMPANY_ID_1);
 
@@ -189,6 +202,16 @@ public class ShardedEhcachePortalCacheTest {
 		Assert.assertEquals(
 			Collections.singletonList(_TEST_KEY_2),
 			_shardedEhcachePortalCache.getKeys());
+	}
+
+	@Test
+	public void testGetNondefaultCompanyEhcacheName() {
+		_assertEhcacheName(_TEST_COMPANY_ID_2);
+	}
+
+	@Test
+	public void testGetSystemCompanyEhcacheName() {
+		_assertEhcacheName(CompanyConstants.SYSTEM);
 	}
 
 	@Test
@@ -544,6 +567,25 @@ public class ShardedEhcachePortalCacheTest {
 			maxEntriesLocalHeap, cacheConfiguration.getMaxEntriesLocalHeap());
 	}
 
+	private void _assertEhcacheName(long companyId) {
+		_portalUtilMockedStatic.when(
+			PortalUtil::getDefaultCompanyId
+		).thenReturn(
+			_TEST_COMPANY_ID_1
+		);
+
+		_companyIdThreadLocal.set(companyId);
+
+		Ehcache ehcache = _shardedEhcachePortalCache.getEhcache();
+
+		Assert.assertEquals(
+			_getShardedCacheName(
+				_TEST_CACHE_NAME,
+				(companyId == _TEST_COMPANY_ID_1) ? CompanyConstants.SYSTEM :
+					companyId),
+			ehcache.getName());
+	}
+
 	private void _assertPortalCacheListener(
 		String cacheName,
 		PortalCacheListener<?, ?>... registeredPortalCacheListeners) {
@@ -630,6 +672,11 @@ public class ShardedEhcachePortalCacheTest {
 	private static ThreadLocal<Long> _companyIdThreadLocal;
 	private static EhcachePortalCacheManager _ehcachePortalCacheManager;
 
+	@Inject
+	private Portal _portal;
+
+	private final MockedStatic<PortalUtil> _portalUtilMockedStatic =
+		Mockito.mockStatic(PortalUtil.class);
 	private ShardedEhcachePortalCache _shardedEhcachePortalCache;
 
 }

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/BaseDBPartitionTestCase.java
@@ -184,8 +184,6 @@ public abstract class BaseDBPartitionTestCase {
 			DBPartitionUtil.class, "_DATABASE_PARTITION_THREAD_POOL_ENABLED",
 			true);
 
-		DBPartitionUtil.setDefaultCompanyId(portal.getDefaultCompanyId());
-
 		DataSource dbPartitionDataSource = _wrapDataSource(
 			DBPartitionUtil.wrapDataSource(_currentDataSource));
 

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 52.1.4
+Bundle-Version: 53.0.0
 Export-Package:\
 	com.liferay.portal.bean,\
 	com.liferay.portal.dao.orm.hibernate,\

--- a/portal-impl/src/com/liferay/portal/dao/init/DBInitUtil.java
+++ b/portal-impl/src/com/liferay/portal/dao/init/DBInitUtil.java
@@ -78,7 +78,7 @@ public class DBInitUtil {
 			_init(DBManagerUtil.getDB(), connection);
 
 			PortalInstances.addDefaultCompanyId(
-				PortalInstances.getDefaultCompanyIdBySQL());
+				PortalInstances.getDefaultCompanyIdBySQL(connection));
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/dao/init/DBInitUtil.java
+++ b/portal-impl/src/com/liferay/portal/dao/init/DBInitUtil.java
@@ -79,8 +79,6 @@ public class DBInitUtil {
 
 			PortalInstances.addDefaultCompanyId(
 				PortalInstances.getDefaultCompanyIdBySQL());
-
-			DBPartitionUtil.setDefaultCompanyId(connection);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/dao/init/DBInitUtil.java
+++ b/portal-impl/src/com/liferay/portal/dao/init/DBInitUtil.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.spring.hibernate.DialectDetector;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
+import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsUtil;
 
 import java.sql.Connection;
@@ -75,6 +76,9 @@ public class DBInitUtil {
 
 		try (Connection connection = _dataSource.getConnection()) {
 			_init(DBManagerUtil.getDB(), connection);
+
+			PortalInstances.addDefaultCompanyId(
+				PortalInstances.getDefaultCompanyIdBySQL());
 
 			DBPartitionUtil.setDefaultCompanyId(connection);
 		}

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -40,7 +40,6 @@ import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.spring.hibernate.DialectDetector;
 import com.liferay.portal.util.PortalInstances;
-import com.liferay.portal.util.PropsValues;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -68,7 +67,9 @@ public class DBPartitionUtil {
 	public static boolean addDBPartition(long companyId)
 		throws PortalException {
 
-		if (!_DATABASE_PARTITION_ENABLED || (companyId == _defaultCompanyId)) {
+		if (!_DATABASE_PARTITION_ENABLED ||
+			(companyId == PortalInstances.getDefaultCompanyId())) {
+
 			return false;
 		}
 
@@ -148,7 +149,9 @@ public class DBPartitionUtil {
 	public static boolean removeDBPartition(long companyId)
 		throws PortalException {
 
-		if (!_DATABASE_PARTITION_ENABLED || (companyId == _defaultCompanyId)) {
+		if (!_DATABASE_PARTITION_ENABLED ||
+			(companyId == PortalInstances.getDefaultCompanyId())) {
+
 			return false;
 		}
 
@@ -157,29 +160,6 @@ public class DBPartitionUtil {
 		}
 
 		return _dropDBPartition(companyId);
-	}
-
-	public static void setDefaultCompanyId(Connection connection)
-		throws SQLException {
-
-		if (_DATABASE_PARTITION_ENABLED) {
-			try (PreparedStatement preparedStatement =
-					connection.prepareStatement(
-						"select companyId from Company where webId = '" +
-							PropsValues.COMPANY_DEFAULT_WEB_ID + "'");
-				ResultSet resultSet = preparedStatement.executeQuery()) {
-
-				if (resultSet.next()) {
-					_defaultCompanyId = resultSet.getLong(1);
-				}
-			}
-		}
-	}
-
-	public static void setDefaultCompanyId(long companyId) {
-		if (_DATABASE_PARTITION_ENABLED) {
-			_defaultCompanyId = companyId;
-		}
 	}
 
 	public static DataSource wrapDataSource(DataSource dataSource)
@@ -284,7 +264,7 @@ public class DBPartitionUtil {
 
 		try {
 			for (long companyId : PortalInstances.getCompanyIdsBySQL()) {
-				if (companyId == _defaultCompanyId) {
+				if (companyId == PortalInstances.getDefaultCompanyId()) {
 					try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
 							companyId)) {
 
@@ -474,7 +454,7 @@ public class DBPartitionUtil {
 
 	private static String _getSchemaName(long companyId) {
 		if ((companyId == CompanyConstants.SYSTEM) ||
-			(companyId == _defaultCompanyId)) {
+			(companyId == PortalInstances.getDefaultCompanyId())) {
 
 			return _defaultSchemaName;
 		}
@@ -535,7 +515,8 @@ public class DBPartitionUtil {
 			DBInspector dbInspector = new DBInspector(connection);
 
 			if (_isControlTable(dbInspector, tableName) &&
-				!(CompanyThreadLocal.getCompanyId() == _defaultCompanyId)) {
+				!(CompanyThreadLocal.getCompanyId() ==
+					PortalInstances.getDefaultCompanyId())) {
 
 				return true;
 			}
@@ -703,7 +684,9 @@ public class DBPartitionUtil {
 					long[] companyIds = PortalInstances.getCompanyIdsBySQL();
 
 					for (long companyId : companyIds) {
-						if (companyId == _defaultCompanyId) {
+						if (companyId ==
+								PortalInstances.getDefaultCompanyId()) {
+
 							continue;
 						}
 
@@ -741,7 +724,6 @@ public class DBPartitionUtil {
 
 	private static final Set<String> _controlTableNames = new HashSet<>(
 		Arrays.asList("Company", "VirtualHost"));
-	private static volatile long _defaultCompanyId;
 	private static String _defaultSchemaName;
 
 }

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -68,7 +68,7 @@ public class DBPartitionUtil {
 		throws PortalException {
 
 		if (!_DATABASE_PARTITION_ENABLED ||
-			(companyId == PortalInstances.getDefaultCompanyId())) {
+			(companyId == _getDefaultCompanyId())) {
 
 			return false;
 		}
@@ -150,7 +150,7 @@ public class DBPartitionUtil {
 		throws PortalException {
 
 		if (!_DATABASE_PARTITION_ENABLED ||
-			(companyId == PortalInstances.getDefaultCompanyId())) {
+			(companyId == _getDefaultCompanyId())) {
 
 			return false;
 		}
@@ -264,7 +264,7 @@ public class DBPartitionUtil {
 
 		try {
 			for (long companyId : PortalInstances.getCompanyIdsBySQL()) {
-				if (companyId == PortalInstances.getDefaultCompanyId()) {
+				if (companyId == _getDefaultCompanyId()) {
 					try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
 							companyId)) {
 
@@ -440,6 +440,15 @@ public class DBPartitionUtil {
 			_defaultSchemaName, StringPool.PERIOD, viewName);
 	}
 
+	private static Long _getDefaultCompanyId() {
+		try {
+			return PortalInstances.getDefaultCompanyId();
+		}
+		catch (Exception exception) {
+			return CompanyConstants.SYSTEM;
+		}
+	}
+
 	private static String _getDropTableSQL(long companyId, String tableName) {
 		return StringBundler.concat(
 			"drop table if exists ", _getSchemaName(companyId),
@@ -454,7 +463,7 @@ public class DBPartitionUtil {
 
 	private static String _getSchemaName(long companyId) {
 		if ((companyId == CompanyConstants.SYSTEM) ||
-			(companyId == PortalInstances.getDefaultCompanyId())) {
+			(companyId == _getDefaultCompanyId())) {
 
 			return _defaultSchemaName;
 		}
@@ -516,7 +525,7 @@ public class DBPartitionUtil {
 
 			if (_isControlTable(dbInspector, tableName) &&
 				!(CompanyThreadLocal.getCompanyId() ==
-					PortalInstances.getDefaultCompanyId())) {
+					_getDefaultCompanyId())) {
 
 				return true;
 			}
@@ -684,9 +693,7 @@ public class DBPartitionUtil {
 					long[] companyIds = PortalInstances.getCompanyIdsBySQL();
 
 					for (long companyId : companyIds) {
-						if (companyId ==
-								PortalInstances.getDefaultCompanyId()) {
-
+						if (companyId == _getDefaultCompanyId()) {
 							continue;
 						}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -217,7 +217,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		company.setModifiedDate(new Date());
 
 		if (webId.equals(PropsValues.COMPANY_DEFAULT_WEB_ID)) {
-			DBPartitionUtil.setDefaultCompanyId(company.getCompanyId());
+			PortalInstances.addDefaultCompanyId(companyId);
 		}
 
 		boolean newDBPartitionAdded = DBPartitionUtil.addDBPartition(

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -200,22 +200,23 @@ public class PortalInstances {
 	public static long[] getCompanyIdsBySQL() throws SQLException {
 		List<Long> companyIds = new ArrayList<>();
 
-		long defaultCompanyId = getDefaultCompanyIdBySQL();
+		try (Connection connection = DataAccess.getConnection()) {
+			long defaultCompanyId = getDefaultCompanyIdBySQL(connection);
 
-		if (defaultCompanyId != 0) {
-			companyIds.add(defaultCompanyId);
-		}
+			if (defaultCompanyId != 0) {
+				companyIds.add(defaultCompanyId);
+			}
 
-		try (Connection connection = DataAccess.getConnection();
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				_GET_COMPANY_IDS);
-			ResultSet resultSet = preparedStatement.executeQuery()) {
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(_GET_COMPANY_IDS);
+				ResultSet resultSet = preparedStatement.executeQuery()) {
 
-			while (resultSet.next()) {
-				long companyId = resultSet.getLong("companyId");
+				while (resultSet.next()) {
+					long companyId = resultSet.getLong("companyId");
 
-				if (companyId != defaultCompanyId) {
-					companyIds.add(companyId);
+					if (companyId != defaultCompanyId) {
+						companyIds.add(companyId);
+					}
 				}
 			}
 		}
@@ -227,9 +228,10 @@ public class PortalInstances {
 		return _companyIds.get(0);
 	}
 
-	public static long getDefaultCompanyIdBySQL() throws SQLException {
-		try (Connection connection = DataAccess.getConnection();
-			PreparedStatement preparedStatement = connection.prepareStatement(
+	public static long getDefaultCompanyIdBySQL(Connection connection)
+		throws SQLException {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select companyId from Company where webId = '" +
 					PropsValues.COMPANY_DEFAULT_WEB_ID + "'");
 			ResultSet resultSet = preparedStatement.executeQuery()) {

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -73,6 +73,10 @@ public class PortalInstances {
 		_companyIds.addIfAbsent(companyId);
 	}
 
+	public static void addDefaultCompanyId(long companyId) {
+		_companyIds.add(0, companyId);
+	}
+
 	public static long getCompanyId(HttpServletRequest httpServletRequest) {
 		try {
 			return getCompanyId(httpServletRequest, false);

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 34.3.0
+version 35.0.0


### PR DESCRIPTION
- LPS-160370 Init default companyId as soon as possible during the startup
- LPS-160370 Old logic is not longer needed. We must use the global method
- LPS-160370 System and defaultCompany must have the same cache. We use 0 as key since we create the Ehcache before creating the first company during the initial startup, it is also useful to recognize the defaultCompany cache easily. We check if company is System first since PortalUtil is not ready until a company is added.
- LPS-160370 We must pass the connection since the DataAccess is not ready at that point
- LPS-160370 Baseline
- LPS-160370 When the defaultCompanyId is not initialized yet we must return 0 in case DB Partition
