### PR TITLE
LPS-161648 Add portletId for softwarecatalog

### DIFF
--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/SoftwareCatalogUpgradeProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/SoftwareCatalogUpgradeProcess.java
@@ -45,7 +45,7 @@ public class SoftwareCatalogUpgradeProcess extends BaseUpgradeProcess {
 		_deleteSocial();
 
 		removePortletData(
-			null, new String[] {"98"},
+			null, new String[] {"98", "com.liferay.portlet.softwarecatalog"},
 			new String[] {"com.liferay.portlet.softwarecatalog"});
 
 		removeServiceData(


### PR DESCRIPTION
Ticket:
[LPS-161648](https://issues.liferay.com/browse/LPS-161648)

Issue:
Residual entries in resourceActions table for softwarecatalog after utilizing Database Cleanup

Solution:
Added "com.liferay.portlet.softwarecatalog" as the portlet uses both "98" and "com.liferay.portlet.softwarecatalog" as an ID in resourceActions. 

