### PR TITLE
LPS-163728 If the ObjectDefinition could not be found in one partition, try looking for it in the other partitions

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.object.rest.internal.openapi.v1_0;
 
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.exception.NoSuchObjectDefinitionException;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
@@ -26,6 +27,7 @@ import com.liferay.object.rest.openapi.v1_0.ObjectEntryOpenAPIResource;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -136,8 +138,27 @@ public class ObjectEntryOpenAPIResourceImpl
 			long objectDefinitionId, String type, UriInfo uriInfo)
 		throws Exception {
 
-		_objectDefinition = _objectDefinitionLocalService.getObjectDefinition(
+		_objectDefinition = _objectDefinitionLocalService.fetchObjectDefinition(
 			objectDefinitionId);
+
+		if (_objectDefinition == null) {
+			DBPartitionUtil.forEachCompanyId(
+				companyId -> {
+					ObjectDefinition objectDefinition =
+						_objectDefinitionLocalService.fetchObjectDefinition(
+							objectDefinitionId);
+
+					if (objectDefinition != null) {
+						_objectDefinition = objectDefinition;
+					}
+				});
+		}
+
+		if (_objectDefinition == null) {
+			throw new NoSuchObjectDefinitionException(
+				"Unable to find object definition with ID " +
+					objectDefinitionId);
+		}
 
 		Map<ObjectRelationship, ObjectDefinition> relatedObjectDefinitionsMap =
 			_getRelatedObjectDefinitionsMap();


### PR DESCRIPTION
Ticket: https://issues.liferay.com/browse/LPS-163728

Hi Uniform Team,

I am not very experienced with partitioning, so I would like someone who knows about partitions to review this and tell me if there's a better way to implement this solution.

I'm also wondering, is it possible for there to be a primary key collision between two different partitions? If so, then this may not be the correct solution.

I did test this and it worked correctly. I also verified that running the GET API on each virtual instance returned only data specific to the object definition on that virtual instance, so it seems that that aspect of it works correctly. It's only here (where the ObjectDefinition only needs to be retrieved to use its RESTpath and its short name) that it seemed to be having trouble.