### PR TITLE
LPS-161609/LPS-163807/LRQA-76800  Uniform | Datacleanup 

### DIFF
--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/ShoppingUpgradeProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/ShoppingUpgradeProcess.java
@@ -37,7 +37,8 @@ public class ShoppingUpgradeProcess extends BaseUpgradeProcess {
 		_deleteFromShoppingItem("largeImage");
 
 		removePortletData(
-			new String[] {"com.liferay.shopping.web"}, new String[] {"34"},
+			new String[] {"com.liferay.shopping.web"},
+			new String[] {"34", "com.liferay.portlet.shopping"},
 			new String[] {
 				"com_liferay_shopping_web_portlet_ShoppingPortlet",
 				"com.liferay.portlet.shopping"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/datacleanup/DataCleanup.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/datacleanup/DataCleanup.testcase
@@ -15,6 +15,76 @@ definition {
 		PortalInstances.tearDownCP();
 	}
 
+	@description = "LPS-163807 This is a test to cover LPS-158824 | Data cleanup does not remove portlet preferences"
+	@priority = "4"
+	test CanCleanupHelloWorldDataAfterUpgrade {
+		property data.archive.type = "data-archive-portal";
+		property database.types = "mysql";
+		property portal.version = "6.2.10.21";
+
+		var classNameQuery = "SELECT * FROM ClassName_ WHERE value LIKE '%com.liferay.hello.world.web%';";
+		var releaseQuery = "SELECT * FROM Release_ WHERE servletContextName LIKE '%com.liferay.hello.world.web%';";
+		var resourceActionQuery = "SELECT * FROM ResourceAction WHERE name LIKE '%com.liferay.hello.world.web%';";
+
+		AssertConsoleTextNotPresent(value1 = "Completed upgrade process com.liferay.data.cleanup.internal.upgrade.UpgradeHelloWorld");
+
+		var classNameTable = SQL.executeMySQLStatement(mysqlStatement = "${classNameQuery}");
+		var releaseTable = SQL.executeMySQLStatement(mysqlStatement = "${releaseQuery}");
+		var resourceActionTable = SQL.executeMySQLStatement(mysqlStatement = "${resourceActionQuery}");
+
+		if (!(contains("${classNameTable}", "com.liferay.hello.world.web"))) {
+			echo("${classNameTable} - Failed to find Hello World in ClassName_ table.");
+		}
+		else if (!(contains("${releaseTable}", "com.liferay.hello.world.web"))) {
+			echo("${releaseTable}");
+
+			fail("Failed to find Hello World in Release_ table.");
+		}
+		else if (!(contains("${resourceActionTable}", "com.liferay.hello.world.web"))) {
+			echo("${resourceActionTable} - Failed to find Hello World in ResourceAction table.");
+		}
+
+		ApplicationsMenu.gotoPortlet(
+			category = "Configuration",
+			panel = "Control Panel",
+			portlet = "System Settings");
+
+		SystemSettings.gotoConfiguration(
+			configurationCategory = "Upgrades",
+			configurationName = "Data Cleanup",
+			configurationScope = "System Scope");
+
+		var key_settingFieldName = "Clean up hello world module data.";
+
+		Check.toggleSwitch(locator1 = "SystemSettings#SETTING_FIELD_NAME_CHECKBOX");
+
+		SystemSettings.saveConfiguration();
+
+		AssertConsoleTextPresent(value1 = "Completed upgrade process com.liferay.data.cleanup.internal.upgrade.UpgradeHelloWorld");
+
+		var classNameTable = SQL.executeMySQLStatement(mysqlStatement = "${classNameQuery}");
+		var releaseTable = SQL.executeMySQLStatement(mysqlStatement = "${releaseQuery}");
+		var resourceActionTable = SQL.executeMySQLStatement(mysqlStatement = "${resourceActionQuery}");
+
+		if (contains("${classNameTable}", "com.liferay.hello.world.web")) {
+			echo("${classNameTable}");
+
+			fail("Failed: Hello World data still present in ClassName_ table.");
+		}
+		else if (contains("${releaseTable}", "com.liferay.hello.world.web")) {
+			echo("${releaseTable}");
+
+			fail("Failed: Hello World data still present in Release_ table.");
+		}
+		else if (contains("${resourceActionTable}", "com.liferay.hello.world.web")) {
+			echo("${resourceActionTable}");
+
+			fail("Failed: Hello World data still present in ResourceAction table.");
+		}
+
+
+	}
+
 	@priority = "3"
 	test CanCleanupOpensocialDataAfterUpgrade {
 		property data.archive.type = "data-archive-opensocial";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/datacleanup/DataCleanup.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/datacleanup/DataCleanup.testcase
@@ -81,8 +81,6 @@ definition {
 
 			fail("Failed: Hello World data still present in ResourceAction table.");
 		}
-
-
 	}
 
 	@priority = "3"
@@ -169,7 +167,6 @@ definition {
 		}
 	}
 
-	@ignore = "true"
 	@priority = "3"
 	test CanCleanupShoppingDataAfterUpgrade {
 		property data.archive.type = "data-archive-portal";
@@ -241,7 +238,6 @@ definition {
 		}
 	}
 
-	@ignore = "true"
 	@priority = "3"
 	test CanCleanupSoftwareCatalogDataAfterUpgrade {
 		property data.archive.type = "data-archive-portal";


### PR DESCRIPTION
- Bug : [LPS-161609](https://issues.liferay.com/browse/LPS-161609) (Leftovers data from shopping database tables after data cleanup.)
- Test automation ticket : [LPS-163807](https://issues.liferay.com/browse/LPS-163807) (Automate test to remove Hello World portled with data cleanup after Upgrade | Test to cover [LPS-158824](https://issues.liferay.com/browse/LPS-158824))
- Testing ticket : [LRQA-76800](https://issues.liferay.com/browse/LRQA-76800) (Turn ignored Datacleanup tests on
 | After all fixes, the Data Cleanup tests can be turned on again)