### PR TITLE
LPS-158994 When creating new database partitions, default company Objects tables should not be recreated in the new partition

### DIFF
--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/BaseDBPartitionTestCase.java
@@ -118,11 +118,15 @@ public abstract class BaseDBPartitionTestCase {
 	protected static void deletePartitionRequiredData() throws Exception {
 		try (Statement statement = connection.createStatement()) {
 			for (long companyId : COMPANY_IDS) {
-				statement.execute(
-					"delete from Company where companyId = " + companyId);
+				try (SafeCloseable safeCloseable =
+						CompanyThreadLocal.setWithSafeCloseable(companyId)) {
 
-				statement.execute(
-					"delete from User_ where companyId = " + companyId);
+					statement.execute(
+						"delete from Company where companyId = " + companyId);
+
+					statement.execute(
+						"delete from User_ where companyId = " + companyId);
+				}
 			}
 		}
 	}

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.util.PortalInstances;
 
 import java.util.Arrays;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -52,7 +53,7 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	public static void tearDownClass() throws Exception {
 		deletePartitionRequiredData();
 
-		dropSchemas();
+		removeDBPartitions(false);
 
 		dropTable(TEST_CONTROL_TABLE_NAME);
 
@@ -204,16 +205,16 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	public class DBPartitionUpgradeProcess extends UpgradeProcess {
 
 		public long[] getCompanyIds() {
-			return _companyIds;
+			return ArrayUtil.toArray(_companyIds.toArray(new Long[0]));
 		}
 
 		@Override
 		protected void doUpgrade() throws Exception {
-			_companyIds = ArrayUtil.append(
-				_companyIds, CompanyThreadLocal.getCompanyId());
+			_companyIds.add(CompanyThreadLocal.getCompanyId());
 		}
 
-		private long[] _companyIds = new long[0];
+		private volatile CopyOnWriteArrayList<Long> _companyIds =
+			new CopyOnWriteArrayList<>();
 
 	}
 

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -92,6 +92,10 @@ public class DBPartitionUtil {
 				while (resultSet.next()) {
 					String tableName = resultSet.getString("TABLE_NAME");
 
+					if (_isObjectsTable(tableName)) {
+						continue;
+					}
+
 					if (_isControlTable(dbInspector, tableName)) {
 						statement.executeUpdate(
 							_getCreateViewSQL(companyId, tableName));
@@ -518,9 +522,18 @@ public class DBPartitionUtil {
 			DBInspector dbInspector, String tableName)
 		throws Exception {
 
-		if (_controlTableNames.contains(StringUtil.toLowerCase(tableName)) ||
-			!dbInspector.hasColumn(tableName, "companyId")) {
+		if (!_isObjectsTable(tableName) &&
+			(_controlTableNames.contains(StringUtil.toLowerCase(tableName)) ||
+			 !dbInspector.hasColumn(tableName, "companyId"))) {
 
+			return true;
+		}
+
+		return false;
+	}
+
+	private static boolean _isObjectsTable(String tableName) {
+		if (tableName.endsWith("_x") || tableName.contains("_x_")) {
 			return true;
 		}
 

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -532,9 +532,13 @@ public class DBPartitionUtil {
 		return false;
 	}
 
-	private static boolean _isObjectsTable(String tableName) {
-		if (tableName.endsWith("_x") || tableName.contains("_x_")) {
-			return true;
+	private static boolean _isObjectsTable(String tableName)
+		throws SQLException {
+
+		for (long companyId : PortalInstances.getCompanyIdsBySQL()) {
+			if (tableName.contains(String.valueOf(companyId))) {
+				return true;
+			}
 		}
 
 		return false;


### PR DESCRIPTION
- LPS-158994 When creating new database partitions, default company Objects tables should not be recreated in the new partition
- LPS-158994 Database tables containing a companyId on their names are Objects tables specifically created for a company. They should not be recreated on new instances when creating a new DB partition, nor considered control tables
- LPS-158994 Optimizing the DBPartitionUtil class to not execute database queries frequently to obtain the company IDs
- LPS-158994 Fixing integration tests due to bad cleanup
