### PR TITLE
LPS-164404 Getting the right defaultCompanyId on DefaultGuestGroupLogoSwapper when DB Partitioning is active

### DIFF
--- a/modules/dxp/apps/portal/portal-properties-swapper/src/main/java/com/liferay/portal/properties/swapper/internal/DefaultGuestGroupLogoSwapper.java
+++ b/modules/dxp/apps/portal/portal-properties-swapper/src/main/java/com/liferay/portal/properties/swapper/internal/DefaultGuestGroupLogoSwapper.java
@@ -22,12 +22,11 @@ import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
+import com.liferay.portal.kernel.util.Portal;
 
 import java.io.InputStream;
 
 import java.net.URL;
-
-import java.util.List;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -43,9 +42,9 @@ public class DefaultGuestGroupLogoSwapper {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) throws Exception {
-		List<Company> companies = _companyLocalService.getCompanies();
+		long companyId = _portal.getDefaultCompanyId();
 
-		Company company = companies.get(0);
+		Company company = _companyLocalService.getCompany(companyId);
 
 		Group group = _groupLocalService.getGroup(
 			company.getCompanyId(), GroupConstants.GUEST);
@@ -80,5 +79,8 @@ public class DefaultGuestGroupLogoSwapper {
 
 	@Reference(target = ModuleServiceLifecycle.PORTLETS_INITIALIZED)
 	private ModuleServiceLifecycle _moduleServiceLifecycle;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -220,6 +220,18 @@ public class PortalInstances {
 	}
 
 	public static long getDefaultCompanyId() {
+		if (_companyIds.isEmpty()) {
+			try {
+				return getDefaultCompanyIdBySQL();
+			}
+			catch (SQLException sqlException) {
+				_log.error(
+					"Unable to get the default companyId by SQL", sqlException);
+
+				throw new RuntimeException(sqlException);
+			}
+		}
+
 		return _companyIds.get(0);
 	}
 


### PR DESCRIPTION
- LPS-164404 If the array is empty, go for the default companyId to the database
- LPS-164404 Getting the default companyId from the Portal class and not directly from the CompanyLocalService to avoid issues when the default companyId is not the one with the lowest companyID
