### PR TITLE
LPS-165430 DataCleanupTest: Leftover data in com.liferay.portal.kernel.model.ResourcePermission

### DIFF
--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/closure/test/CTClosureFactoryImplTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/closure/test/CTClosureFactoryImplTest.java
@@ -194,8 +194,7 @@ public class CTClosureFactoryImplTest {
 					"CTCollectionLocalServiceImpl",
 				LoggerTestUtil.WARN)) {
 
-			_ctCollectionLocalService.deleteCTCollection(
-				_ctCollection.getCtCollectionId());
+			_ctCollectionLocalService.deleteCTCollection(_ctCollection);
 		}
 
 		_db.runSQL("drop table GrandParentTable");

--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/BaseUpgradeProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/BaseUpgradeProcess.java
@@ -15,6 +15,7 @@
 package com.liferay.data.cleanup.internal.upgrade;
 
 import com.liferay.data.cleanup.internal.upgrade.util.LayoutTypeSettingsUtil;
+import com.liferay.expando.kernel.service.ExpandoTableLocalServiceUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -22,39 +23,24 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
-import java.util.ArrayList;
-
 /**
  * @author Alberto Chaparro
  */
 public abstract class BaseUpgradeProcess extends UpgradeProcess {
 
 	protected void removeExpandoData(String expandoTableName) throws Exception {
-		String[] expandoTableIds = null;
-
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select tableId from ExpandoTable where name = ?")) {
 
 			preparedStatement.setString(1, expandoTableName);
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				ArrayList<String> ids = new ArrayList<>();
-
 				while (resultSet.next()) {
-					ids.add(resultSet.getString("tableId"));
+					ExpandoTableLocalServiceUtil.deleteTable(
+						resultSet.getLong("tableId"));
 				}
-
-				expandoTableIds = ids.toArray(new String[0]);
 			}
 		}
-
-		_deleteFrom("ExpandoColumn", "tableId", expandoTableIds);
-
-		_deleteFrom("ExpandoRow", "tableId", expandoTableIds);
-
-		_deleteFrom("ExpandoTable", "tableId", expandoTableIds);
-
-		_deleteFrom("ExpandoValue", "tableId", expandoTableIds);
 	}
 
 	protected void removePortletData(

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 14.0.2
+Bundle-Version: 14.1.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.search.Indexer;
@@ -277,7 +278,12 @@ public class DataGuardTestRuleUtil {
 						ResourcePermission resourcePermission =
 							(ResourcePermission)leftoverBaseModel;
 
-						if (resourcePermission.getPrimKeyId() != 0) {
+						if ((resourcePermission.getScope() ==
+								ResourceConstants.SCOPE_INDIVIDUAL) &&
+							(resourcePermission.getPrimKeyId() != 0) &&
+							persistedModelLocalServices.containsKey(
+								resourcePermission.getName())) {
+
 							continue;
 						}
 					}

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -638,20 +638,6 @@ public class DataGuardTestRuleUtil {
 	private static class RecordingSessionWrapper extends SessionWrapper {
 
 		@Override
-		public void delete(Object object) throws ORMException {
-			super.delete(object);
-
-			BaseModel<?> baseModel = (BaseModel<?>)object;
-
-			Map<Serializable, String> map = _records.get(
-				baseModel.getModelClassName());
-
-			if (map != null) {
-				map.remove(baseModel.getPrimaryKeyObj());
-			}
-		}
-
-		@Override
 		public Serializable save(Object object) throws ORMException {
 			_record(object);
 

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
@@ -39,6 +40,7 @@ import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceWrapper;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.ResourcePermissionTestUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
@@ -271,6 +273,15 @@ public class DataGuardTestRuleUtil {
 				}
 
 				for (BaseModel<?> leftoverBaseModel : leftoverBaseModels) {
+					if (className.equals(ResourcePermission.class.getName())) {
+						ResourcePermission resourcePermission =
+							(ResourcePermission)leftoverBaseModel;
+
+						if (resourcePermission.getPrimKeyId() != 0) {
+							continue;
+						}
+					}
+
 					_smartDelete(
 						persistedModelLocalService, modelClass,
 						(PersistedModel)leftoverBaseModel);
@@ -556,6 +567,9 @@ public class DataGuardTestRuleUtil {
 			}
 		}
 		catch (Throwable throwable1) {
+			ResourcePermissionTestUtil.deleteResourcePermissions(
+				persistedModel);
+
 			BasePersistence<?> basePersistence = _getBasePersistence(
 				persistedModelLocalService);
 

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DeleteAfterTestRunMethodTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DeleteAfterTestRunMethodTestRule.java
@@ -244,8 +244,9 @@ public class DeleteAfterTestRunMethodTestRule extends MethodTestRule<Void> {
 						continue;
 					}
 
-					persistedModelLocalService.deletePersistedModel(
-						persistedModel);
+					DataGuardTestRuleUtil.smartDelete(
+						persistedModelLocalService, fieldClass,
+						(PersistedModel)persistedModel);
 				}
 			}
 			else if (Collection.class.isAssignableFrom(objectClass)) {
@@ -253,12 +254,14 @@ public class DeleteAfterTestRunMethodTestRule extends MethodTestRule<Void> {
 					(Collection<? extends PersistedModel>)object;
 
 				for (PersistedModel persistedModel : collection) {
-					persistedModelLocalService.deletePersistedModel(
-						persistedModel);
+					DataGuardTestRuleUtil.smartDelete(
+						persistedModelLocalService, fieldClass,
+						(PersistedModel)persistedModel);
 				}
 			}
 			else {
-				persistedModelLocalService.deletePersistedModel(
+				DataGuardTestRuleUtil.smartDelete(
+					persistedModelLocalService, fieldClass,
 					(PersistedModel)object);
 			}
 

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/portal-test/src/com/liferay/portal/kernel/test/util/ResourcePermissionTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/ResourcePermissionTestUtil.java
@@ -15,7 +15,12 @@
 package com.liferay.portal.kernel.test.util;
 
 import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.PersistedModel;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.portal.kernel.model.ResourcedModel;
+import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
@@ -63,6 +68,36 @@ public class ResourcePermissionTestUtil {
 
 		return ResourcePermissionLocalServiceUtil.addResourcePermission(
 			resourcePermission);
+	}
+
+	public static void deleteResourcePermissions(PersistedModel persistedModel)
+		throws Exception {
+
+		if (!(persistedModel instanceof BaseModel) ||
+			!(persistedModel instanceof ShardedModel)) {
+
+			return;
+		}
+
+		BaseModel<?> baseModel = (BaseModel)persistedModel;
+
+		ShardedModel shardedModel = (ShardedModel)baseModel;
+
+		ResourcePermissionLocalServiceUtil.deleteResourcePermissions(
+			shardedModel.getCompanyId(), baseModel.getModelClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(baseModel.getPrimaryKeyObj()));
+
+		if (!(persistedModel instanceof ResourcedModel)) {
+			return;
+		}
+
+		ResourcedModel resourcedModel = (ResourcedModel)baseModel;
+
+		ResourcePermissionLocalServiceUtil.deleteResourcePermissions(
+			shardedModel.getCompanyId(), baseModel.getModelClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourcedModel.getResourcePrimKey()));
 	}
 
 }

--- a/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 5.2.0
+version 5.3.0


### PR DESCRIPTION
[LPS-145396](https://issues.liferay.com/browse/LPS-145396) added some code changes to **DataGuardTestRuleUtil.java** that detects orphan ResourcePermission entries after any test is executed.

This [LPS-165430](https://issues.liferay.com/browse/LPS-165430) issue was detected by [LPS-145396](https://issues.liferay.com/browse/LPS-145396) changes: the `com.liferay.data.cleanup.internal.upgrade.BaseUpgradeProcess` is leaving orphan ResourcePermission entries when it deletes a ExpandoTable and its children objects (ExpandoColumn, ExpandoRow, ExpandoValue).

In this PR:
 - I am fixing the orphan ResourcePermission that are left by `com.liferay.data.cleanup.internal.upgrade.BaseUpgradeProcess`, see commit https://github.com/liferay-uniform/liferay-portal/commit/38115161f2fda3174407300a74713c575d5f0974
 - I am adding again the LPS-145396 commits that were reverted in https://github.com/brianchandotcom/liferay-portal/pull/124484

@vicnate5 can you check that after adding LPS-145396 again, it is not broken any other test?

About the OOM error reported in LPS-165442, I wasn't able to reproduce it in my computer, please, send me more information if this error is caused by my changes.

Thank you,
Jorge

