### PR TITLE
LPS-165430 DataCleanupTest: Leftover data in com.liferay.portal.kernel.model.ResourcePermission

### DIFF
--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/BaseUpgradeProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/BaseUpgradeProcess.java
@@ -15,6 +15,7 @@
 package com.liferay.data.cleanup.internal.upgrade;
 
 import com.liferay.data.cleanup.internal.upgrade.util.LayoutTypeSettingsUtil;
+import com.liferay.expando.kernel.service.ExpandoTableLocalServiceUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -22,39 +23,24 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
-import java.util.ArrayList;
-
 /**
  * @author Alberto Chaparro
  */
 public abstract class BaseUpgradeProcess extends UpgradeProcess {
 
 	protected void removeExpandoData(String expandoTableName) throws Exception {
-		String[] expandoTableIds = null;
-
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select tableId from ExpandoTable where name = ?")) {
 
 			preparedStatement.setString(1, expandoTableName);
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				ArrayList<String> ids = new ArrayList<>();
-
 				while (resultSet.next()) {
-					ids.add(resultSet.getString("tableId"));
+					ExpandoTableLocalServiceUtil.deleteTable(
+						resultSet.getLong("tableId"));
 				}
-
-				expandoTableIds = ids.toArray(new String[0]);
 			}
 		}
-
-		_deleteFrom("ExpandoColumn", "tableId", expandoTableIds);
-
-		_deleteFrom("ExpandoRow", "tableId", expandoTableIds);
-
-		_deleteFrom("ExpandoTable", "tableId", expandoTableIds);
-
-		_deleteFrom("ExpandoValue", "tableId", expandoTableIds);
 	}
 
 	protected void removePortletData(


### PR DESCRIPTION
This [LPS-165430](https://issues.liferay.com/browse/LPS-165430) issue was detected by [LPS-145396](https://issues.liferay.com/browse/LPS-145396) DataGuard changes: _the `com.liferay.data.cleanup.internal.upgrade.BaseUpgradeProcess` is leaving orphan ResourcePermission entries when it deletes a ExpandoTable and its children objects (ExpandoColumn, ExpandoRow, ExpandoValue)._

To avoid the orphan ResourcePermission that are left by `com.liferay.data.cleanup.internal.upgrade.BaseUpgradeProcess`, I am replacing current logic with a call to **ExpandoTableLocalServiceUtil.deleteTable**

**Note:** LPS-145396 commits were reverted in https://github.com/brianchandotcom/liferay-portal/pull/124484 due to a OOM problem, I will send them again in a separate PR.

Thank you,
Jorge

