### PR TITLE
LPS-160250 Support for initial deployment verifiers in non-service modules

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
@@ -261,11 +261,7 @@ public class UpgradeExecutor {
 
 		String fromSchemaVersion = upgradeInfo.getFromSchemaVersionString();
 
-		String upgradeStepName = String.valueOf(upgradeInfo.getUpgradeStep());
-
-		if (fromSchemaVersion.equals("0.0.0") &&
-			upgradeStepName.equals("Initial Database Creation")) {
-
+		if (fromSchemaVersion.equals("0.0.0")) {
 			return true;
 		}
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistry.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistry.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.upgrade.internal.registry;
 
+import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
@@ -46,8 +47,8 @@ public class UpgradeStepRegistry implements UpgradeStepRegistrator.Registry {
 			if (_upgradeInfos.isEmpty()) {
 				return Arrays.asList(
 					new UpgradeInfo(
-						"0.0.0", "1.0.0", _buildNumber,
-						new DummyUpgradeStep()));
+						"0.0.0", ReleaseConstants.INITIAL_SCHEMA_VERSION,
+						_buildNumber, new DummyUpgradeStep()));
 			}
 
 			return ListUtil.concat(

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -307,6 +307,12 @@ public class VerifyProcessTrackerOSGiCommands {
 
 		Bundle bundle = FrameworkUtil.getBundle(verifyProcess.getClass());
 
+		if (_releaseLocalService.fetchRelease(bundle.getSymbolicName()) ==
+				null) {
+
+			return true;
+		}
+
 		try {
 			Collection<ServiceReference<Release>> releases =
 				_bundleContext.getServiceReferences(

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -241,7 +241,8 @@ public class VerifyProcessTrackerOSGiCommands {
 					_counterLocalService.increment());
 
 				release.setServletContextName(verifyProcessName);
-				release.setSchemaVersion("1.0.0");
+				release.setSchemaVersion(
+					ReleaseConstants.INITIAL_SCHEMA_VERSION);
 				release.setVerified(false);
 			}
 

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -241,6 +241,7 @@ public class VerifyProcessTrackerOSGiCommands {
 					_counterLocalService.increment());
 
 				release.setServletContextName(verifyProcessName);
+				release.setSchemaVersion("1.0.0");
 				release.setVerified(false);
 			}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/model/ReleaseConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/ReleaseConstants.java
@@ -25,6 +25,8 @@ public class ReleaseConstants {
 
 	public static final String DEFAULT_SERVLET_CONTEXT_NAME = "portal";
 
+	public static final String INITIAL_SCHEMA_VERSION = "1.0.0";
+
 	public static final int STATE_GOOD = 0;
 
 	public static final int STATE_UPGRADE_FAILURE = 1;


### PR DESCRIPTION
- LPS-160250 isInitialRelease support for non-service modules
- LPS-160250 Non-service modules with no upgrades can also have a verify to be executed on initial deployment
- LPS-160250 Set the initial schema version when there is no release record. With this we avoid that upgrades are marked as initial when they are added
- LPS-160250 Make a constant
