### PR TITLE
LPS-160250 Allow initial deployment verify processes for non-service modules

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
@@ -261,11 +261,7 @@ public class UpgradeExecutor {
 
 		String fromSchemaVersion = upgradeInfo.getFromSchemaVersionString();
 
-		String upgradeStepName = String.valueOf(upgradeInfo.getUpgradeStep());
-
-		if (fromSchemaVersion.equals("0.0.0") &&
-			upgradeStepName.equals("Initial Database Creation")) {
-
+		if (fromSchemaVersion.equals("0.0.0")) {
 			return true;
 		}
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.upgrade.internal.executor;
 
+import com.liferay.osgi.util.BundleUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -271,7 +272,7 @@ public class UpgradeExecutor {
 	private boolean _requiresUpdateIndexes(
 		Bundle bundle, List<UpgradeInfo> upgradeInfos) {
 
-		if (!IndexUpdaterUtil.isLiferayServiceBundle(bundle)) {
+		if (!BundleUtil.isLiferayServiceBundle(bundle)) {
 			return false;
 		}
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/index/updater/IndexUpdaterUtil.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/index/updater/IndexUpdaterUtil.java
@@ -14,13 +14,11 @@
 
 package com.liferay.portal.upgrade.internal.index.updater;
 
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -31,8 +29,6 @@ import java.io.InputStream;
 import java.net.URL;
 
 import java.sql.Connection;
-
-import java.util.Dictionary;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -74,13 +70,6 @@ public class IndexUpdaterUtil {
 
 			return null;
 		}
-	}
-
-	public static boolean isLiferayServiceBundle(Bundle bundle) {
-		Dictionary<String, String> headers = bundle.getHeaders(
-			StringPool.BLANK);
-
-		return GetterUtil.getBoolean(headers.get("Liferay-Service"));
 	}
 
 	public static void updateIndexes(Bundle bundle) throws Exception {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/index/updater/osgi/commands/IndexUpdaterOSGiCommands.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/index/updater/osgi/commands/IndexUpdaterOSGiCommands.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.upgrade.internal.index.updater.osgi.commands;
 
+import com.liferay.osgi.util.BundleUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.upgrade.internal.index.updater.IndexUpdaterUtil;
 
@@ -46,7 +47,7 @@ public class IndexUpdaterOSGiCommands {
 				"Module " + bundleId + " does not exist");
 		}
 
-		if (IndexUpdaterUtil.isLiferayServiceBundle(bundle)) {
+		if (BundleUtil.isLiferayServiceBundle(bundle)) {
 			IndexUpdaterUtil.updateIndexes(bundle);
 
 			return "Completed update of indexes for module " + bundleId;
@@ -62,7 +63,7 @@ public class IndexUpdaterOSGiCommands {
 		Bundle bundle = IndexUpdaterUtil.getBundle(
 			_bundleContext, bundleSymbolicName);
 
-		if (IndexUpdaterUtil.isLiferayServiceBundle(bundle)) {
+		if (BundleUtil.isLiferayServiceBundle(bundle)) {
 			IndexUpdaterUtil.updateIndexes(bundle);
 
 			return "Completed update of indexes for module " +

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistry.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistry.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.upgrade.internal.registry;
 
+import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
@@ -46,8 +47,8 @@ public class UpgradeStepRegistry implements UpgradeStepRegistrator.Registry {
 			if (_upgradeInfos.isEmpty()) {
 				return Arrays.asList(
 					new UpgradeInfo(
-						"0.0.0", "1.0.0", _buildNumber,
-						new DummyUpgradeStep()));
+						"0.0.0", ReleaseConstants.INITIAL_SCHEMA_VERSION,
+						_buildNumber, new DummyUpgradeStep()));
 			}
 
 			return ListUtil.concat(

--- a/modules/apps/portal/portal-verify-extender/build.gradle
+++ b/modules/apps/portal/portal-verify-extender/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:gogo-shell:gogo-shell-logging")
 	compileOnly project(":apps:portal-search:portal-search-api")
+	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 }

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -306,6 +306,12 @@ public class VerifyProcessTrackerOSGiCommands {
 
 		Bundle bundle = FrameworkUtil.getBundle(verifyProcess.getClass());
 
+		if (_releaseLocalService.fetchRelease(bundle.getSymbolicName()) ==
+				null) {
+
+			return true;
+		}
+
 		try {
 			Collection<ServiceReference<Release>> releases =
 				_bundleContext.getServiceReferences(

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -262,7 +262,8 @@ public class VerifyProcessTrackerOSGiCommands {
 
 			if (verifyException1 == null) {
 				if (Validator.isNull(release.getSchemaVersion())) {
-					release.setSchemaVersion("1.0.0");
+					release.setSchemaVersion(
+						ReleaseConstants.INITIAL_SCHEMA_VERSION);
 				}
 
 				release.setVerified(true);

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -18,6 +18,7 @@ import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.gogo.shell.logging.TeeLoggingUtil;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.osgi.util.BundleUtil;
 import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -307,8 +308,9 @@ public class VerifyProcessTrackerOSGiCommands {
 	private boolean _isInitialDeployment(VerifyProcess verifyProcess) {
 		Bundle bundle = FrameworkUtil.getBundle(verifyProcess.getClass());
 
-		if (_releaseLocalService.fetchRelease(bundle.getSymbolicName()) ==
-				null) {
+		if (!BundleUtil.isLiferayServiceBundle(bundle) &&
+			(_releaseLocalService.fetchRelease(bundle.getSymbolicName()) ==
+				null)) {
 
 			return true;
 		}

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -177,11 +177,15 @@ public class VerifyProcessTrackerOSGiCommands {
 				public VerifyProcess addingService(
 					ServiceReference<VerifyProcess> serviceReference) {
 
+					boolean initialDeploymentProperty = GetterUtil.getBoolean(
+						serviceReference.getProperty("initial.deployment"));
+
 					VerifyProcess verifyProcess = _bundleContext.getService(
 						serviceReference);
 
-					if (upgrading ||
-						_isInitialDeployment(serviceReference, verifyProcess)) {
+					if ((initialDeploymentProperty &&
+						 _isInitialDeployment(verifyProcess)) ||
+						(!initialDeploymentProperty && upgrading)) {
 
 						_executeVerifyProcesses(
 							Collections.singletonList(verifyProcess),
@@ -300,16 +304,7 @@ public class VerifyProcessTrackerOSGiCommands {
 		return verifyProcesses;
 	}
 
-	private boolean _isInitialDeployment(
-		ServiceReference<VerifyProcess> serviceReference,
-		VerifyProcess verifyProcess) {
-
-		if (!GetterUtil.getBoolean(
-				serviceReference.getProperty("initial.deployment"))) {
-
-			return false;
-		}
-
+	private boolean _isInitialDeployment(VerifyProcess verifyProcess) {
 		Bundle bundle = FrameworkUtil.getBundle(verifyProcess.getClass());
 
 		if (_releaseLocalService.fetchRelease(bundle.getSymbolicName()) ==

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.service.ReleaseLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.NotificationThreadLocal;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowThreadLocal;
 import com.liferay.portal.verify.VerifyException;
 import com.liferay.portal.verify.VerifyProcess;
@@ -260,6 +261,10 @@ public class VerifyProcessTrackerOSGiCommands {
 			}
 
 			if (verifyException1 == null) {
+				if (Validator.isNull(release.getSchemaVersion())) {
+					release.setSchemaVersion("1.0.0");
+				}
+
 				release.setVerified(true);
 				release.setState(ReleaseConstants.STATE_GOOD);
 

--- a/modules/apps/static/osgi/osgi-util/src/main/java/com/liferay/osgi/util/BundleUtil.java
+++ b/modules/apps/static/osgi/osgi-util/src/main/java/com/liferay/osgi/util/BundleUtil.java
@@ -20,6 +20,7 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.concurrent.DefaultNoticeableFuture;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.lpkg.deployer.LPKGDeployer;
@@ -152,6 +153,13 @@ public class BundleUtil {
 
 		BundleStartLevelUtil.setStartLevelAndStart(
 			bundle, startLevel, bundleContext);
+	}
+
+	public static boolean isLiferayServiceBundle(Bundle bundle) {
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
+
+		return GetterUtil.getBoolean(headers.get("Liferay-Service"));
 	}
 
 	public static void refreshBundles(

--- a/portal-kernel/src/com/liferay/portal/kernel/model/ReleaseConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/ReleaseConstants.java
@@ -25,6 +25,8 @@ public class ReleaseConstants {
 
 	public static final String DEFAULT_SERVLET_CONTEXT_NAME = "portal";
 
+	public static final String INITIAL_SCHEMA_VERSION = "1.0.0";
+
 	public static final int STATE_GOOD = 0;
 
 	public static final int STATE_UPGRADE_FAILURE = 1;

--- a/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 24.0.0
+version 24.1.0


### PR DESCRIPTION
- LPS-160250 isInitialRelease support for non-service modules
- LPS-160250 Non-service modules with no upgrades can also have a verify to be executed on initial deployment
- LPS-160250 Set the initial schema version when no upgrades run for this module. With this we avoid that upgrades are marked as initial when they are added
- LPS-160250 Add a constant and use it
- LPS-160250 Baseline
- LPS-160250 As before when we used upgrades, initial deployment verifiers should only run once
- LPS-160250 Move this method a more generic place
- LPS-160250 This commit is only to avoid that CommerceAccountServiceVerifyProcess is executed before the initial upgrade process is finished. That verify is always available because it depends on several CommerceAccount services but they are always available even when there are pending upgrades to run. The problem is that this module does not have Persistence impl classes and these are the classes that have unresolved dependencies until the upgrades are completed
