### PR TITLE
LPS-160250 Support adding initial.deployment property to non-service modules verifiers

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
@@ -261,11 +261,7 @@ public class UpgradeExecutor {
 
 		String fromSchemaVersion = upgradeInfo.getFromSchemaVersionString();
 
-		String upgradeStepName = String.valueOf(upgradeInfo.getUpgradeStep());
-
-		if (fromSchemaVersion.equals("0.0.0") &&
-			upgradeStepName.equals("Initial Database Creation")) {
-
+		if (fromSchemaVersion.equals("0.0.0")) {
 			return true;
 		}
 

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -176,11 +176,15 @@ public class VerifyProcessTrackerOSGiCommands {
 				public VerifyProcess addingService(
 					ServiceReference<VerifyProcess> serviceReference) {
 
+					boolean initialDeploymentProperty = GetterUtil.getBoolean(
+						serviceReference.getProperty("initial.deployment"));
+
 					VerifyProcess verifyProcess = _bundleContext.getService(
 						serviceReference);
 
-					if (upgrading ||
-						_isInitialDeployment(serviceReference, verifyProcess)) {
+					if ((initialDeploymentProperty &&
+						 _isInitialDeployment(verifyProcess)) ||
+						(!initialDeploymentProperty && upgrading)) {
 
 						_executeVerifyProcesses(
 							Collections.singletonList(verifyProcess),
@@ -294,16 +298,7 @@ public class VerifyProcessTrackerOSGiCommands {
 		return verifyProcesses;
 	}
 
-	private boolean _isInitialDeployment(
-		ServiceReference<VerifyProcess> serviceReference,
-		VerifyProcess verifyProcess) {
-
-		if (!GetterUtil.getBoolean(
-				serviceReference.getProperty("initial.deployment"))) {
-
-			return false;
-		}
-
+	private boolean _isInitialDeployment(VerifyProcess verifyProcess) {
 		Bundle bundle = FrameworkUtil.getBundle(verifyProcess.getClass());
 
 		if (_releaseLocalService.fetchRelease(bundle.getSymbolicName()) ==

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -306,6 +306,12 @@ public class VerifyProcessTrackerOSGiCommands {
 
 		Bundle bundle = FrameworkUtil.getBundle(verifyProcess.getClass());
 
+		if (_releaseLocalService.fetchRelease(bundle.getSymbolicName()) ==
+				null) {
+
+			return true;
+		}
+
 		try {
 			Collection<ServiceReference<Release>> releases =
 				_bundleContext.getServiceReferences(


### PR DESCRIPTION
- LPS-160250 isInitialRelease support for non-service modules
- LPS-160250 Non-service modules with no upgrades can also have a verify to be executed on initial deployment
- LPS-160250 As before when we used upgrades, initial deployment verifiers should only run once
