### PR TITLE
LPS-143728 Do not run upgrade process if additional portal-ext.proper…

### DIFF
--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/UpgradeClient.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/UpgradeClient.java
@@ -700,6 +700,19 @@ public class UpgradeClient {
 	}
 
 	private void _verifyPortalUpgradeExtProperties() throws IOException {
+		String userHome = System.getProperty("user.home");
+
+		File userHomePropsFile = new File(userHome + "/portal-ext.properties");
+
+		if (userHomePropsFile.exists()) {
+			System.err.println(
+				"portal-ext.properties file detected in user home directory. " +
+					"Please remove prior to running the upgrade process to " +
+						"prevent conflicts.");
+
+			System.exit(0);
+		}
+
 		String value = _portalUpgradeExtProperties.getProperty("liferay.home");
 
 		File baseDir = new File(".");


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-143728

To prevent any conflicting portal properties being set, we should only accept the portal-upgrade-ext.properties file when using the upgrade tool.

Resending with changes requested here: https://github.com/liferay-uniform/liferay-portal/pull/741