### PR TITLE
[TS]LPS-164521

### DIFF
--- a/modules/dxp/apps/saml/saml-persistence-service/bnd.bnd
+++ b/modules/dxp/apps/saml/saml-persistence-service/bnd.bnd
@@ -28,6 +28,6 @@ Import-Package:\
 	\
 	*
 Liferay-Releng-Module-Group-Title: SAML
-Liferay-Require-SchemaVersion: 3.0.1
+Liferay-Require-SchemaVersion: 3.0.2
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/registry/SamlServiceUpgradeStepRegistrator.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/registry/SamlServiceUpgradeStepRegistrator.java
@@ -134,6 +134,15 @@ public class SamlServiceUpgradeStepRegistrator
 
 		registry.register(
 			"3.0.0", "3.0.1", new SamlSpIdpConnectionDataUpgradeProcess());
+
+		registry.register(
+			"3.0.1", "3.0.2",
+			UpgradeProcessFactory.alterColumnType(
+				"SamlPeerBinding", "samlPeerEntityId", "VARCHAR(1024) null"),
+			UpgradeProcessFactory.alterColumnType(
+				"SamlPeerBinding", "samlNameIdFormat", "VARCHAR(1024) null"),
+			UpgradeProcessFactory.alterColumnType(
+				"SamlPeerBinding", "samlNameIdValue", "VARCHAR(1024) null"));
 	}
 
 	@Reference

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v2_4_0/util/SamlPeerBindingTable.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v2_4_0/util/SamlPeerBindingTable.java
@@ -37,8 +37,6 @@ public class SamlPeerBindingTable {
 	}
 
 	private static final String _TABLE_NAME = "SamlPeerBinding";
-
 	private static final String _TABLE_SQL_CREATE =
-		"create table SamlPeerBinding (samlPeerBindingId LONG not null primary key,companyId LONG,createDate DATE null,userId LONG,userName VARCHAR(75) null,deleted BOOLEAN,samlNameIdFormat VARCHAR(75) null,samlNameIdNameQualifier VARCHAR(75) null,samlNameIdSpNameQualifier VARCHAR(75) null,samlNameIdSpProvidedId VARCHAR(75) null,samlNameIdValue VARCHAR(75) null,samlPeerEntityId VARCHAR(75) null)";
-
+		"create table SamlPeerBinding (samlPeerBindingId LONG not null primary key,companyId LONG,createDate DATE null,userId LONG,userName VARCHAR(75) null,deleted BOOLEAN,samlNameIdFormat VARCHAR(1024) null,samlNameIdNameQualifier VARCHAR(75) null,samlNameIdSpNameQualifier VARCHAR(75) null,samlNameIdSpProvidedId VARCHAR(75) null,samlNameIdValue VARCHAR(1024) null,samlPeerEntityId VARCHAR(1024) null)";
 }

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/model/impl/SamlPeerBindingModelImpl.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/model/impl/SamlPeerBindingModelImpl.java
@@ -98,7 +98,7 @@ public class SamlPeerBindingModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table SamlPeerBinding (samlPeerBindingId LONG not null primary key,companyId LONG,createDate DATE null,userId LONG,userName VARCHAR(75) null,deleted BOOLEAN,samlNameIdFormat VARCHAR(75) null,samlNameIdNameQualifier VARCHAR(75) null,samlNameIdSpNameQualifier VARCHAR(75) null,samlNameIdSpProvidedId VARCHAR(75) null,samlNameIdValue VARCHAR(75) null,samlPeerEntityId VARCHAR(75) null)";
+		"create table SamlPeerBinding (samlPeerBindingId LONG not null primary key,companyId LONG,createDate DATE null,userId LONG,userName VARCHAR(75) null,deleted BOOLEAN,samlNameIdFormat VARCHAR(1024) null,samlNameIdNameQualifier VARCHAR(75) null,samlNameIdSpNameQualifier VARCHAR(75) null,samlNameIdSpProvidedId VARCHAR(75) null,samlNameIdValue VARCHAR(1024) null,samlPeerEntityId VARCHAR(1024) null)";
 
 	public static final String TABLE_SQL_DROP = "drop table SamlPeerBinding";
 

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -64,16 +64,16 @@
 		<field name="userName" type="String" />
 		<field name="deleted" type="boolean" />
 		<field name="samlNameIdFormat" type="String">
-			<hint name="max-length">1024</hint>
+			<hint-collection name="ENTITY-ID" />
 		</field>
 		<field name="samlNameIdNameQualifier" type="String" />
 		<field name="samlNameIdSpNameQualifier" type="String" />
 		<field name="samlNameIdSpProvidedId" type="String" />
 		<field name="samlNameIdValue" type="String">
-			<hint name="max-length">1024</hint>
+			<hint-collection name="ENTITY-ID" />
 		</field>
 		<field name="samlPeerEntityId" type="String">
-			<hint name="max-length">1024</hint>
+			<hint-collection name="ENTITY-ID" />
 		</field>
 	</model>
 	<model name="com.liferay.saml.persistence.model.SamlSpAuthRequest">

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -63,12 +63,18 @@
 		<field name="userId" type="long" />
 		<field name="userName" type="String" />
 		<field name="deleted" type="boolean" />
-		<field name="samlNameIdFormat" type="String" />
+		<field name="samlNameIdFormat" type="String">
+			<hint name="max-length">1024</hint>
+		</field>
 		<field name="samlNameIdNameQualifier" type="String" />
 		<field name="samlNameIdSpNameQualifier" type="String" />
 		<field name="samlNameIdSpProvidedId" type="String" />
-		<field name="samlNameIdValue" type="String" />
-		<field name="samlPeerEntityId" type="String" />
+		<field name="samlNameIdValue" type="String">
+			<hint name="max-length">1024</hint>
+		</field>
+		<field name="samlPeerEntityId" type="String">
+			<hint name="max-length">1024</hint>
+		</field>
 	</model>
 	<model name="com.liferay.saml.persistence.model.SamlSpAuthRequest">
 		<field name="samlSpAuthnRequestId" type="long" />

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/indexes.sql
@@ -6,9 +6,9 @@ create index IX_713E871E on SamlIdpSpSession (samlIdpSsoSessionId, samlPeerBindi
 create index IX_E5D1CDD3 on SamlIdpSsoSession (createDate);
 create index IX_5E8BFDF9 on SamlIdpSsoSession (samlIdpSsoSessionKey[$COLUMN_LENGTH:75$]);
 
-create index IX_E642E1AE on SamlPeerBinding (companyId, deleted, samlNameIdFormat[$COLUMN_LENGTH:75$], samlNameIdNameQualifier[$COLUMN_LENGTH:75$], samlNameIdValue[$COLUMN_LENGTH:75$], samlPeerEntityId[$COLUMN_LENGTH:75$]);
-create index IX_81ACF542 on SamlPeerBinding (companyId, deleted, samlNameIdFormat[$COLUMN_LENGTH:75$], samlNameIdNameQualifier[$COLUMN_LENGTH:75$], samlPeerEntityId[$COLUMN_LENGTH:75$]);
-create index IX_BC82BDFC on SamlPeerBinding (companyId, userId, deleted, samlNameIdFormat[$COLUMN_LENGTH:75$], samlNameIdNameQualifier[$COLUMN_LENGTH:75$], samlPeerEntityId[$COLUMN_LENGTH:75$]);
+create index IX_E642E1AE on SamlPeerBinding (companyId, deleted, samlNameIdFormat[$COLUMN_LENGTH:1024$], samlNameIdNameQualifier[$COLUMN_LENGTH:75$], samlNameIdValue[$COLUMN_LENGTH:1024$], samlPeerEntityId[$COLUMN_LENGTH:1024$]);
+create index IX_81ACF542 on SamlPeerBinding (companyId, deleted, samlNameIdFormat[$COLUMN_LENGTH:1024$], samlNameIdNameQualifier[$COLUMN_LENGTH:75$], samlPeerEntityId[$COLUMN_LENGTH:1024$]);
+create index IX_BC82BDFC on SamlPeerBinding (companyId, userId, deleted, samlNameIdFormat[$COLUMN_LENGTH:1024$], samlNameIdNameQualifier[$COLUMN_LENGTH:75$], samlPeerEntityId[$COLUMN_LENGTH:1024$]);
 
 create index IX_49073861 on SamlSpAuthRequest (createDate);
 create index IX_10D77E09 on SamlSpAuthRequest (samlIdpEntityId[$COLUMN_LENGTH:1024$], samlSpAuthRequestKey[$COLUMN_LENGTH:75$]);

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/tables.sql
@@ -48,12 +48,12 @@ create table SamlPeerBinding (
 	userId LONG,
 	userName VARCHAR(75) null,
 	deleted BOOLEAN,
-	samlNameIdFormat VARCHAR(75) null,
+	samlNameIdFormat VARCHAR(1024) null,
 	samlNameIdNameQualifier VARCHAR(75) null,
 	samlNameIdSpNameQualifier VARCHAR(75) null,
 	samlNameIdSpProvidedId VARCHAR(75) null,
-	samlNameIdValue VARCHAR(75) null,
-	samlPeerEntityId VARCHAR(75) null
+	samlNameIdValue VARCHAR(1024) null,
+	samlPeerEntityId VARCHAR(1024) null
 );
 
 create table SamlSpAuthRequest (

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1425,9 +1425,11 @@
     #
     # Env: LIFERAY_DATABASE_PERIOD_STRING_PERIOD_INDEX_PERIOD_MAX_PERIOD_LENGTH_OPENBRACKET_MARIADB_CLOSEBRACKET_
     # Env: LIFERAY_DATABASE_PERIOD_STRING_PERIOD_INDEX_PERIOD_MAX_PERIOD_LENGTH_OPENBRACKET_MYSQL_CLOSEBRACKET_
+    # Env: LIFERAY_DATABASE_PERIOD_STRING_PERIOD_INDEX_PERIOD_MAX_PERIOD_LENGTH_OPENBRACKET_ORACLE_CLOSEBRACKET_
     #
     database.string.index.max.length[mariadb]=255
     database.string.index.max.length[mysql]=255
+    database.string.index.max.length[oracle]=255
 
     #
     # Specify any database vendor specific settings.


### PR DESCRIPTION
Previous PR:
https://github.com/liferay-appsec/liferay-portal/pull/865

Ticket:
[LPS-164521](https://issues.liferay.com/browse/LPS-164521)

Issue:
A customer attempted to upgrade from 7.2 however ran into an issue with column length violations as prior 7.4, the table the entries are fetched from, SamlIdpSpSession, had column sizes of 1024. Currently, the column size for some of the receiving columns in SAMLPeerBinding is 75.

Solution:
Incrementing it to 1024should resolve the issue as incrementing the column length to 1024 will cause an error with creating the index.  We also need to turn on a column length type restriction in order to support certain databases due to an index using some of the modified columns. 




