### PR TITLE
LPS-168372 Using the same stopWatch to avoid upgrade execution time mismatchs between logs and upgrade report

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.internal.release.osgi.commands.ReleaseManagerOSGiCommands;
 import com.liferay.portal.util.PropsValues;
@@ -64,7 +65,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.time.StopWatch;
 import org.apache.felix.cm.PersistenceManager;
 
 /**
@@ -73,8 +73,6 @@ import org.apache.felix.cm.PersistenceManager;
 public class UpgradeReport {
 
 	public UpgradeReport() {
-		_stopWatch.start();
-
 		_initialBuildNumber = _getBuildNumber();
 		_initialSchemaVersion = _getSchemaVersion();
 		_initialTableCounts = _getTableCounts();
@@ -112,8 +110,6 @@ public class UpgradeReport {
 	public void generateReport(
 		PersistenceManager persistenceManager,
 		ReleaseManagerOSGiCommands releaseManagerOSGiCommands) {
-
-		_stopWatch.stop();
 
 		_persistenceManager = persistenceManager;
 
@@ -617,7 +613,7 @@ public class UpgradeReport {
 	private String _getUpgradeTimeInfo() {
 		return String.format(
 			"Upgrade completed in %s seconds",
-			_stopWatch.getTime() / Time.SECOND);
+			DBUpgrader.getUpgradeTime() / Time.SECOND);
 	}
 
 	private Map<String, Integer> _sort(Map<String, Integer> map) {
@@ -666,7 +662,6 @@ public class UpgradeReport {
 	private final Map<String, Integer> _initialTableCounts;
 	private PersistenceManager _persistenceManager;
 	private String _rootDir;
-	private final StopWatch _stopWatch = new StopWatch();
 	private final Map<String, Map<String, Integer>> _warningMessages =
 		new ConcurrentHashMap<>();
 

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -115,11 +115,19 @@ public class DBUpgrader {
 		}
 	}
 
+	public static long getUpgradeTime() {
+		if (_stopWatch == null) {
+			return 0;
+		}
+
+		return _stopWatch.getTime();
+	}
+
 	public static void main(String[] args) {
 		try {
-			StopWatch stopWatch = new StopWatch();
+			_stopWatch = new StopWatch();
 
-			stopWatch.start();
+			_stopWatch.start();
 
 			PortalClassPathUtil.initializeClassPaths(null);
 
@@ -147,9 +155,11 @@ public class DBUpgrader {
 						"\" is not available");
 			}
 
+			_stopWatch.stop();
+
 			System.out.println(
 				"\nCompleted Liferay core upgrade process in " +
-					(stopWatch.getTime() / Time.SECOND) + " seconds");
+					(_stopWatch.getTime() / Time.SECOND) + " seconds");
 		}
 		catch (Exception exception) {
 			_log.error(exception);
@@ -408,5 +418,6 @@ public class DBUpgrader {
 	private static volatile Appender _appender;
 	private static volatile ServiceReference<Appender>
 		_appenderServiceReference;
+	private static volatile StopWatch _stopWatch;
 
 }

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -154,12 +154,6 @@ public class DBUpgrader {
 					"Store \"" + PropsValues.DL_STORE_IMPL +
 						"\" is not available");
 			}
-
-			_stopWatch.stop();
-
-			System.out.println(
-				"\nCompleted Liferay core upgrade process in " +
-					(_stopWatch.getTime() / Time.SECOND) + " seconds");
 		}
 		catch (Exception exception) {
 			_log.error(exception);
@@ -167,6 +161,12 @@ public class DBUpgrader {
 			System.exit(1);
 		}
 		finally {
+			_stopWatch.stop();
+
+			System.out.println(
+				"\nCompleted Liferay upgrade process in " +
+					(_stopWatch.getTime() / Time.SECOND) + " seconds");
+
 			if (PropsValues.UPGRADE_REPORT_ENABLED) {
 				_stopUpgradeReportLogAppender();
 			}

--- a/portal-impl/src/com/liferay/portal/tools/packageinfo
+++ b/portal-impl/src/com/liferay/portal/tools/packageinfo
@@ -1,1 +1,1 @@
-version 10.1.0
+version 10.2.0


### PR DESCRIPTION
- LPS-168372 Making DBUpgrader and UpgradeReport to use the same StopWatch to avoid disrepancies on the upgrade time between the logs and the upgrade report
- LPS-168732 Baseline
- LPS-168372 Return the UpgradeTime even when an exception is thrown
