### PR TITLE
LPS-163975 Adding support for batch statements on processConcurrently

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradePortletPreferences.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradePortletPreferences.java
@@ -16,7 +16,6 @@ package com.liferay.portal.upgrade.v7_4_x;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.dao.orm.common.SQLTransformer;
-import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.model.PortletConstants;
 import com.liferay.portal.kernel.model.PortletPreferenceValue;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -52,13 +51,18 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 					"preferences from PortletPreferences where preferences ",
 					"not like '", PortletConstants.DEFAULT_PREFERENCES,
 					"%' and preferences is not null")),
+			StringBundler.concat(
+				"insert into PortletPreferenceValue (mvccVersion, ",
+				"ctCollectionId, portletPreferenceValueId, companyId, ",
+				"portletPreferencesId, index_, largeValue, name, readOnly, ",
+				"smallValue) values (0, ?, ?, ?, ?, ?, ?, ?, ?, ?)"),
 			resultSet -> new Object[] {
 				resultSet.getLong("ctCollectionId"),
 				resultSet.getLong("portletPreferencesId"),
 				resultSet.getLong("companyId"),
 				resultSet.getString("preferences")
 			},
-			values -> {
+			(values, preparedStatement) -> {
 				long ctCollectionId = (Long)values[0];
 				long portletPreferencesId = (Long)values[1];
 				long companyId = (Long)values[2];
@@ -66,7 +70,7 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 
 				_upgradePortletPreferences(
 					ctCollectionId, portletPreferencesId, companyId,
-					preferences);
+					preferences, preparedStatement);
 			},
 			null);
 
@@ -75,7 +79,7 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 
 	private void _upgradePortletPreferences(
 			long ctCollectionId, long portletPreferencesId, long companyId,
-			String preferences)
+			String preferences, PreparedStatement preparedStatement)
 		throws Exception {
 
 		if (preferences.isEmpty()) {
@@ -89,50 +93,37 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 			return;
 		}
 
-		try (PreparedStatement preparedStatement =
-				AutoBatchPreparedStatementUtil.autoBatch(
-					connection,
-					StringBundler.concat(
-						"insert into PortletPreferenceValue (mvccVersion, ",
-						"ctCollectionId, portletPreferenceValueId, companyId, ",
-						"portletPreferencesId, index_, largeValue, name, ",
-						"readOnly, smallValue) values (0, ?, ?, ?, ?, ?, ?, ",
-						"?, ?, ?)"))) {
+		for (Preference preference : preferenceMap.values()) {
+			String[] values = preference.getValues();
 
-			for (Preference preference : preferenceMap.values()) {
-				String[] values = preference.getValues();
+			for (int i = 0; i < values.length; i++) {
+				String value = values[i];
 
-				for (int i = 0; i < values.length; i++) {
-					String value = values[i];
+				String largeValue = null;
+				String smallValue = null;
 
-					String largeValue = null;
-					String smallValue = null;
+				if (value.length() >
+						PortletPreferenceValueImpl.SMALL_VALUE_MAX_LENGTH) {
 
-					if (value.length() >
-							PortletPreferenceValueImpl.SMALL_VALUE_MAX_LENGTH) {
-
-						largeValue = value;
-					}
-					else {
-						smallValue = value;
-					}
-
-					preparedStatement.setLong(1, ctCollectionId);
-					preparedStatement.setLong(
-						2, increment(PortletPreferenceValue.class.getName()));
-					preparedStatement.setLong(3, companyId);
-					preparedStatement.setLong(4, portletPreferencesId);
-					preparedStatement.setInt(5, i);
-					preparedStatement.setString(6, largeValue);
-					preparedStatement.setString(7, preference.getName());
-					preparedStatement.setBoolean(8, preference.isReadOnly());
-					preparedStatement.setString(9, smallValue);
-
-					preparedStatement.addBatch();
+					largeValue = value;
 				}
-			}
+				else {
+					smallValue = value;
+				}
 
-			preparedStatement.executeBatch();
+				preparedStatement.setLong(1, ctCollectionId);
+				preparedStatement.setLong(
+					2, increment(PortletPreferenceValue.class.getName()));
+				preparedStatement.setLong(3, companyId);
+				preparedStatement.setLong(4, portletPreferencesId);
+				preparedStatement.setInt(5, i);
+				preparedStatement.setString(6, largeValue);
+				preparedStatement.setString(7, preference.getName());
+				preparedStatement.setBoolean(8, preference.isReadOnly());
+				preparedStatement.setString(9, smallValue);
+
+				preparedStatement.addBatch();
+			}
 		}
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -53,7 +53,6 @@ import java.sql.Statement;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -473,7 +472,7 @@ public abstract class BaseDBProcess implements DBProcess {
 
 	private PreparedStatement _getConcurrentPreparedStatement(
 		String updateSqlQuery,
-		HashMap<Thread, PreparedStatement> preparedStatementHashMap) {
+		Map<Thread, PreparedStatement> preparedStatementHashMap) {
 
 		return preparedStatementHashMap.computeIfAbsent(
 			Thread.currentThread(),
@@ -552,8 +551,8 @@ public abstract class BaseDBProcess implements DBProcess {
 
 		List<Future<Void>> futures = new ArrayList<>();
 
-		HashMap<Thread, PreparedStatement> preparedStatementHashMap =
-			new HashMap<>();
+		Map<Thread, PreparedStatement> preparedStatementHashMap =
+			new ConcurrentHashMap<>();
 
 		try {
 			boolean notificationEnabled = NotificationThreadLocal.isEnabled();

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
@@ -1,1 +1,1 @@
-version 10.1.0
+version 10.2.0

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
@@ -1,1 +1,1 @@
-version 19.0.0
+version 19.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/packageinfo
@@ -1,1 +1,1 @@
-version 10.2.0
+version 10.3.0


### PR DESCRIPTION
- LPS-163975 Adding proper AutoBatch support to processConcurrenly method
- LPS-163975 Making each thread to have its own prepared statement and renaming some methods for more clarity
- LPS-163975 Reuse code having one single private _processConcurrently method
- LPS-163975 Applying change to an existing upgrade process
- LPS-163975 Baseline
- LPS-163975 Applying to more cases in the portal
- LPS-163975 Adding integration tests for processConcurrently methods
- LPS-163975 Changing HashMap for ConcurrentHashMap to avoid error due to concurrency
