### PR TITLE
LPS-87855 Remove unused portlet preference 190

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/upgrade/v1_0_0/PortletPreferencesUpgradeProcess.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/upgrade/v1_0_0/PortletPreferencesUpgradeProcess.java
@@ -27,6 +27,7 @@ public class PortletPreferencesUpgradeProcess extends UpgradeProcess {
 	protected void doUpgrade() throws Exception {
 		_deletePortletPreferences("145");
 		_deletePortletPreferences("160");
+		_deletePortletPreferences("190");
 	}
 
 	private void _deletePortletPreferences(String portletId) throws Exception {


### PR DESCRIPTION
Portlet ID 190 is the control panel menu for 6.2, which is no longer needed.