### PR TITLE
LPS-168721 Generate the Upgrade Report even when an exception is thrown

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -128,7 +128,9 @@ public class UpgradeReport {
 						_getDatabaseTablesInfo(), _getUpgradeProcessesInfo(),
 						_getLogEventsInfo("errors"),
 						_getLogEventsInfo("warnings"),
-						releaseManagerOSGiCommands.check()
+						(releaseManagerOSGiCommands == null) ?
+							StringPool.BLANK :
+								releaseManagerOSGiCommands.check()
 					},
 					StringPool.NEW_LINE + StringPool.NEW_LINE));
 		}

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/UpgradeClient.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/UpgradeClient.java
@@ -234,9 +234,7 @@ public class UpgradeClient {
 		}
 
 		try (GogoShellClient gogoShellClient = _initGogoShellClient()) {
-			boolean finished = _isFinished(gogoShellClient);
-
-			if (!finished || _shell) {
+			if (!_isModuleUpgradesFinished(gogoShellClient) || _shell) {
 				System.out.println("Connecting to Gogo shell...");
 
 				_printHelp();
@@ -398,7 +396,7 @@ public class UpgradeClient {
 		return new GogoShellClient(host, port);
 	}
 
-	private boolean _isFinished(GogoShellClient gogoShellClient)
+	private boolean _isModuleUpgradesFinished(GogoShellClient gogoShellClient)
 		throws IOException {
 
 		String upgradeCheck = gogoShellClient.send("upgrade:check");
@@ -409,7 +407,7 @@ public class UpgradeClient {
 			return true;
 		}
 
-		System.out.print("Checking to see if all upgrades have completed...");
+		System.out.println("Checking to see if all upgrades have completed...");
 
 		String upgradeSteps = gogoShellClient.send(
 			"upgrade:list | grep Registered | grep step");
@@ -418,13 +416,13 @@ public class UpgradeClient {
 			upgradeSteps.contains("true")) {
 
 			System.out.println(
-				" your upgrades have failed, have not started, or are still " +
+				"Module upgrades have failed, have not started, or are still " +
 					"running.");
 
 			return false;
 		}
 
-		System.out.println(" done.");
+		System.out.println("Looks good.");
 
 		return true;
 	}

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/UpgradeClient.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/UpgradeClient.java
@@ -401,9 +401,15 @@ public class UpgradeClient {
 	private boolean _isFinished(GogoShellClient gogoShellClient)
 		throws IOException {
 
-		System.out.print("Checking to see if all upgrades have completed...");
-
 		String upgradeCheck = gogoShellClient.send("upgrade:check");
+
+		if (upgradeCheck.contains("CommandNotFoundException")) {
+			System.out.print("Portal upgrade failed. Fix the issue and retry.");
+
+			return true;
+		}
+
+		System.out.print("Checking to see if all upgrades have completed...");
 
 		String upgradeSteps = gogoShellClient.send(
 			"upgrade:list | grep Registered | grep step");

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -153,8 +153,6 @@ public class DBUpgrader {
 		}
 		catch (Exception exception) {
 			_log.error(exception);
-
-			System.exit(1);
 		}
 		finally {
 			if (PropsValues.UPGRADE_REPORT_ENABLED) {


### PR DESCRIPTION
Hi @susanchen3,

The behavior should be the same as before except for some changes in the output. Now when it fails the Core upgrade we print:
> _Portal upgrade failed. Fix the issue and retry._

But we do not open the Gogo Shell.

I am not sure if you will need to change something in the tests because we check the output, let me know if you need anything from my side. It is likely that Brian changes the output a bit in his review.

Thanks!

cc/ @luisortiz89