### PR TITLE
LPS-171011 Fix warnings when creating a company and accesing to CompanyThreadLocal from other threads

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -1825,7 +1825,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 	}
 
-	private User _addDefaultUser(Company company) {
+	private User _addDefaultUser(Company company) throws PortalException {
 		Date date = new Date();
 
 		User defaultUser = _userPersistence.create(
@@ -1863,7 +1863,11 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		// Invoke updateImpl so that we do not trigger model listeners. See
 		// LPS-108239.
 
-		defaultUser = _userPersistence.updateImpl(defaultUser);
+		_userPersistence.updateImpl(defaultUser);
+
+		// Force update _defaultUsers map
+
+		defaultUser = _userLocalService.getDefaultUser(company.getCompanyId());
 
 		// Contact
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/LocaleThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/LocaleThreadLocal.java
@@ -15,6 +15,10 @@
 package com.liferay.portal.kernel.util;
 
 import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 
 import java.util.Locale;
 
@@ -24,6 +28,17 @@ import java.util.Locale;
 public class LocaleThreadLocal {
 
 	public static Locale getDefaultLocale() {
+		if ((_defaultLocale.get() == null) &&
+			(CompanyThreadLocal.getCompanyId() != CompanyConstants.SYSTEM)) {
+
+			User defaultUser = UserLocalServiceUtil.fetchDefaultUser(
+				CompanyThreadLocal.getCompanyId());
+
+			if (defaultUser != null) {
+				_defaultLocale.set(defaultUser.getLocale());
+			}
+		}
+
 		return _defaultLocale.get();
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/TimeZoneThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TimeZoneThreadLocal.java
@@ -15,6 +15,10 @@
 package com.liferay.portal.kernel.util;
 
 import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 
 import java.util.TimeZone;
 
@@ -24,6 +28,17 @@ import java.util.TimeZone;
 public class TimeZoneThreadLocal {
 
 	public static TimeZone getDefaultTimeZone() {
+		if ((_defaultTimeZone.get() == null) &&
+			(CompanyThreadLocal.getCompanyId() != CompanyConstants.SYSTEM)) {
+
+			User defaultUser = UserLocalServiceUtil.fetchDefaultUser(
+				CompanyThreadLocal.getCompanyId());
+
+			if (defaultUser != null) {
+				_defaultTimeZone.set(defaultUser.getTimeZone());
+			}
+		}
+
 		return _defaultTimeZone.get();
 	}
 


### PR DESCRIPTION
- LPS-171011 Lazy approach to simplify the CompanyThreadLocal logic and avoid errors and warnings while creating a company and accessing to the CompanyThreadLocal from a different thread. This also improves the performance since CompanyThreadLocal is much more used than Locale and TimeZone ThreadLocal and getDefaultUser method uses a local(but cluster sync) map to retrive the defaultUser.
- LPS-171011 Update the map as soon as possible so other Threads are aware too
