### PR TITLE
LPS-160250 Define proper behavior for Verify Processes

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
@@ -237,6 +237,7 @@ public class UpgradeExecutor {
 				}
 
 				release.setState(state);
+				release.setVerified(false);
 
 				_releaseLocalService.updateRelease(release);
 			}

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
@@ -236,8 +236,8 @@ public class UpgradeExecutor {
 					release.setBuildNumber(buildNumber);
 				}
 
-				release.setState(state);
 				release.setVerified(false);
+				release.setState(state);
 
 				_releaseLocalService.updateRelease(release);
 			}

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
@@ -262,11 +262,7 @@ public class UpgradeExecutor {
 
 		String fromSchemaVersion = upgradeInfo.getFromSchemaVersionString();
 
-		String upgradeStepName = String.valueOf(upgradeInfo.getUpgradeStep());
-
-		if (fromSchemaVersion.equals("0.0.0") &&
-			upgradeStepName.equals("Initial Database Creation")) {
-
+		if (fromSchemaVersion.equals("0.0.0")) {
 			return true;
 		}
 

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -306,6 +306,12 @@ public class VerifyProcessTrackerOSGiCommands {
 
 		Bundle bundle = FrameworkUtil.getBundle(verifyProcess.getClass());
 
+		if (_releaseLocalService.fetchRelease(bundle.getSymbolicName()) ==
+				null) {
+
+			return true;
+		}
+
 		try {
 			Collection<ServiceReference<Release>> releases =
 				_bundleContext.getServiceReferences(

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -185,8 +185,15 @@ public class VerifyProcessTrackerOSGiCommands {
 					Release release = _releaseLocalService.fetchRelease(
 						verifyProcessName);
 
-					if (((release != null) && !release.isVerified()) ||
-						_isInitialDeployment(serviceReference, verifyProcess) ||
+					boolean initialDeployment = _isInitialDeployment(
+						verifyProcess);
+
+					if ((!initialDeployment && (release != null) &&
+						 !release.isVerified()) ||
+						(GetterUtil.getBoolean(
+							serviceReference.getProperty(
+								"initial.deployment")) &&
+						 initialDeployment) ||
 						(upgrading &&
 						 GetterUtil.getBoolean(
 							 serviceReference.getProperty(
@@ -296,16 +303,7 @@ public class VerifyProcessTrackerOSGiCommands {
 		return verifyProcesses;
 	}
 
-	private boolean _isInitialDeployment(
-		ServiceReference<VerifyProcess> serviceReference,
-		VerifyProcess verifyProcess) {
-
-		if (!GetterUtil.getBoolean(
-				serviceReference.getProperty("initial.deployment"))) {
-
-			return false;
-		}
-
+	private boolean _isInitialDeployment(VerifyProcess verifyProcess) {
 		Bundle bundle = FrameworkUtil.getBundle(verifyProcess.getClass());
 
 		if (_releaseLocalService.fetchRelease(bundle.getSymbolicName()) ==

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -118,7 +118,7 @@ public class VerifyProcessTrackerOSGiCommands {
 		TeeLoggingUtil.runWithTeeLogging(
 			() -> _executeVerifyProcesses(
 				_getVerifyProcesses(_serviceTrackerMap, verifyProcessName),
-				verifyProcessName, true));
+				verifyProcessName));
 	}
 
 	@Descriptor("Execute all verify processes")
@@ -129,7 +129,7 @@ public class VerifyProcessTrackerOSGiCommands {
 					_executeVerifyProcesses(
 						_getVerifyProcesses(
 							_serviceTrackerMap, verifyProcessName),
-						verifyProcessName, true);
+						verifyProcessName);
 				}
 			});
 	}
@@ -179,15 +179,18 @@ public class VerifyProcessTrackerOSGiCommands {
 					VerifyProcess verifyProcess = _bundleContext.getService(
 						serviceReference);
 
-					if (upgrading ||
+					String verifyProcessName = String.valueOf(
+						serviceReference.getProperty("verify.process.name"));
+
+					Release release = _releaseLocalService.fetchRelease(
+						verifyProcessName);
+
+					if (((release != null) && !release.isVerified()) ||
 						_isInitialDeployment(serviceReference, verifyProcess)) {
 
 						_executeVerifyProcesses(
 							Collections.singletonList(verifyProcess),
-							String.valueOf(
-								serviceReference.getProperty(
-									"verify.process.name")),
-							false);
+							verifyProcessName);
 					}
 
 					return verifyProcess;
@@ -216,8 +219,7 @@ public class VerifyProcessTrackerOSGiCommands {
 	}
 
 	private void _executeVerifyProcesses(
-		List<VerifyProcess> verifyProcesses, String verifyProcessName,
-		boolean force) {
+		List<VerifyProcess> verifyProcesses, String verifyProcessName) {
 
 		NotificationThreadLocal.setEnabled(false);
 		StagingAdvicesThreadLocal.setEnabled(false);
@@ -226,10 +228,6 @@ public class VerifyProcessTrackerOSGiCommands {
 		try {
 			Release release = _releaseLocalService.fetchRelease(
 				verifyProcessName);
-
-			if ((release != null) && !force && release.isVerified()) {
-				return;
-			}
 
 			if (release == null) {
 

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -166,8 +166,6 @@ public class VerifyProcessTrackerOSGiCommands {
 
 		_bundleContext = bundleContext;
 
-		boolean upgrading = StartupHelperUtil.isUpgrading();
-
 		_serviceTrackerMap = ServiceTrackerMapFactory.openMultiValueMap(
 			_bundleContext, VerifyProcess.class, "verify.process.name",
 			new EagerServiceTrackerCustomizer<VerifyProcess, VerifyProcess>() {
@@ -194,7 +192,7 @@ public class VerifyProcessTrackerOSGiCommands {
 							serviceReference.getProperty(
 								"initial.deployment")) &&
 						 initialDeployment) ||
-						(upgrading &&
+						(StartupHelperUtil.isUpgrading() &&
 						 GetterUtil.getBoolean(
 							 serviceReference.getProperty(
 								 "run.on.portal.upgrade")))) {

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -186,7 +186,11 @@ public class VerifyProcessTrackerOSGiCommands {
 						verifyProcessName);
 
 					if (((release != null) && !release.isVerified()) ||
-						_isInitialDeployment(serviceReference, verifyProcess)) {
+						_isInitialDeployment(serviceReference, verifyProcess) ||
+						(upgrading &&
+						 GetterUtil.getBoolean(
+							 serviceReference.getProperty(
+								 "run.on.portal.upgrade")))) {
 
 						_executeVerifyProcesses(
 							Collections.singletonList(verifyProcess),

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
@@ -1,0 +1,318 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.verify.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.counter.kernel.service.CounterLocalService;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.events.StartupHelperUtil;
+import com.liferay.portal.kernel.model.Release;
+import com.liferay.portal.kernel.service.ReleaseLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
+import com.liferay.portal.kernel.upgrade.UpgradeStep;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.verify.VerifyProcess;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Alberto Chaparro
+ */
+@RunWith(Arquillian.class)
+public class VerifyProcessTrackerOSGiCommandsTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() {
+		Bundle bundle = FrameworkUtil.getBundle(
+			VerifyProcessTrackerOSGiCommandsTest.class);
+
+		_symbolicName = bundle.getSymbolicName();
+
+		_bundleContext = bundle.getBundleContext();
+
+		_upgrading = StartupHelperUtil.isUpgrading();
+
+		StartupHelperUtil.setUpgrading(false);
+	}
+
+	@After
+	public void tearDown() {
+		StartupHelperUtil.setUpgrading(_upgrading);
+
+		Release release = _releaseLocalService.fetchRelease(_symbolicName);
+
+		if (release != null) {
+			_releaseLocalService.deleteRelease(release);
+		}
+
+		_verifyProcessRun = false;
+	}
+
+	@Test
+	public void testInitialDeploymentRegisterInitialDeploymentVerifyProcess() {
+		try (SafeCloseable safeCloseable = _registerInitialVerifyProcess()) {
+			Assert.assertTrue(_verifyProcessRun);
+		}
+	}
+
+	@Test
+	public void testInitialDeploymentRegisterRunOnPortalUpgradeVerifyProcess() {
+		try (SafeCloseable safeCloseable =
+				_registerRunOnPortalUpgradeVerifyProcess()) {
+
+			Assert.assertFalse(_verifyProcessRun);
+		}
+	}
+
+	@Test
+	public void testInitialDeploymentRegisterVerifyProcess() {
+		try (SafeCloseable safeCloseable = _registerVerifyProcess()) {
+			Assert.assertFalse(_verifyProcessRun);
+		}
+	}
+
+	@Test
+	public void testInitialDeploymentUpgradeProcessRegisterInitialDeploymentVerifyProcess() {
+		try (SafeCloseable safeCloseable1 = _executeInitialUpgradeProcess();
+			SafeCloseable safeCloseable2 = _registerInitialVerifyProcess()) {
+
+			Assert.assertTrue(_verifyProcessRun);
+		}
+	}
+
+	@Test
+	public void testInitialDeploymentUpgradeProcessRegisterRunOnPortalUpgradeVerifyProcess() {
+		try (SafeCloseable safeCloseable1 = _executeInitialUpgradeProcess();
+			SafeCloseable safeCloseable2 =
+				_registerRunOnPortalUpgradeVerifyProcess()) {
+
+			Assert.assertFalse(_verifyProcessRun);
+		}
+	}
+
+	@Test
+	public void testInitialDeploymentUpgradeProcessRegisterVerifyProcess() {
+		try (SafeCloseable safeCloseable1 = _executeInitialUpgradeProcess();
+			SafeCloseable safeCloseable2 = _registerVerifyProcess()) {
+
+			Assert.assertFalse(_verifyProcessRun);
+		}
+	}
+
+	@Test
+	public void testUpgradeModuleRegisterInitialDeploymentVerifyProcess() {
+		try (SafeCloseable safeCloseable1 = _executeUpgradeProcess();
+			SafeCloseable safeCloseable2 = _registerInitialVerifyProcess()) {
+
+			Assert.assertTrue(_verifyProcessRun);
+		}
+	}
+
+	@Test
+	public void testUpgradeModuleRegisterRunOnPortalUpgradeVerifyProcess() {
+		try (SafeCloseable safeCloseable1 = _executeUpgradeProcess();
+			SafeCloseable safeCloseable2 =
+				_registerRunOnPortalUpgradeVerifyProcess()) {
+
+			Assert.assertTrue(_verifyProcessRun);
+		}
+	}
+
+	@Test
+	public void testUpgradeModuleRegisterVerifyProcess() {
+		try (SafeCloseable safeCloseable1 = _executeUpgradeProcess();
+			SafeCloseable safeCloseable2 = _registerVerifyProcess()) {
+
+			Assert.assertTrue(_verifyProcessRun);
+		}
+	}
+
+	@Test
+	public void testUpgradePortalRegisterInitialDeploymentVerifyProcess() {
+		try (SafeCloseable safeCloseable1 = _upgradePortal();
+			SafeCloseable safeCloseable2 = _registerInitialVerifyProcess()) {
+
+			Assert.assertFalse(_verifyProcessRun);
+		}
+	}
+
+	@Test
+	public void testUpgradePortalRegisterRunOnPortalUpgradeVerifyProcess() {
+		try (SafeCloseable safeCloseable1 = _upgradePortal();
+			SafeCloseable safeCloseable2 =
+				_registerRunOnPortalUpgradeVerifyProcess()) {
+
+			Assert.assertTrue(_verifyProcessRun);
+		}
+	}
+
+	@Test
+	public void testUpgradePortalRegisterVerifyProcess() {
+		try (SafeCloseable safeCloseable1 = _upgradePortal();
+			SafeCloseable safeCloseable2 = _registerVerifyProcess()) {
+
+			Assert.assertFalse(_verifyProcessRun);
+		}
+	}
+
+	private SafeCloseable _executeInitialUpgradeProcess() {
+		ServiceRegistration<UpgradeStep> upgradeStepServiceRegistration =
+			_bundleContext.registerService(
+				UpgradeStep.class, new DummyUpgrade(),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"upgrade.bundle.symbolic.name", _symbolicName
+				).put(
+					"upgrade.from.schema.version", "0.0.0"
+				).put(
+					"upgrade.to.schema.version", "1.0.0"
+				).build());
+
+		return () -> upgradeStepServiceRegistration.unregister();
+	}
+
+	private SafeCloseable _executeUpgradeProcess() {
+		Release release = _releaseLocalService.createRelease(
+			_counterLocalService.increment());
+
+		release.setSchemaVersion("0.0.1");
+		release.setServletContextName(_symbolicName);
+		release.setVerified(true);
+
+		_releaseLocalService.updateRelease(release);
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_DATABASE_AUTO_RUN", true)) {
+
+			ServiceRegistration<UpgradeStep> upgradeStepServiceRegistration =
+				_bundleContext.registerService(
+					UpgradeStep.class, new DummyUpgrade(),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"upgrade.bundle.symbolic.name", _symbolicName
+					).put(
+						"upgrade.from.schema.version", "0.0.1"
+					).put(
+						"upgrade.to.schema.version", "1.0.0"
+					).build());
+
+			return () -> upgradeStepServiceRegistration.unregister();
+		}
+	}
+
+	private SafeCloseable _registerInitialVerifyProcess() {
+		ServiceRegistration<VerifyProcess>
+			initialDeploymentVerifyProcessRegistration =
+				_bundleContext.registerService(
+					VerifyProcess.class, _initialDeploymentVerifyProcess,
+					HashMapDictionaryBuilder.<String, Object>put(
+						"initial.deployment", true
+					).put(
+						"verify.process.name", _symbolicName
+					).build());
+
+		return () -> initialDeploymentVerifyProcessRegistration.unregister();
+	}
+
+	private SafeCloseable _registerRunOnPortalUpgradeVerifyProcess() {
+		ServiceRegistration<VerifyProcess>
+			runOnPortalUpgradeVerifyProcessRegistration =
+				_bundleContext.registerService(
+					VerifyProcess.class, _runOnPortalUpgradeVerifyProcess,
+					HashMapDictionaryBuilder.<String, Object>put(
+						"run.on.portal.upgrade", true
+					).put(
+						"verify.process.name", _symbolicName
+					).build());
+
+		return () -> runOnPortalUpgradeVerifyProcessRegistration.unregister();
+	}
+
+	private SafeCloseable _registerVerifyProcess() {
+		ServiceRegistration<VerifyProcess> verifyProcessRegistration =
+			_bundleContext.registerService(
+				VerifyProcess.class, _verifyProcess,
+				MapUtil.singletonDictionary(
+					"verify.process.name", _symbolicName));
+
+		return () -> verifyProcessRegistration.unregister();
+	}
+
+	private SafeCloseable _upgradePortal() {
+		Release release = _releaseLocalService.createRelease(
+			_counterLocalService.increment());
+
+		release.setSchemaVersion("0.0.1");
+		release.setServletContextName(_symbolicName);
+		release.setVerified(true);
+
+		_releaseLocalService.updateRelease(release);
+
+		StartupHelperUtil.setUpgrading(true);
+
+		return () -> StartupHelperUtil.setUpgrading(false);
+	}
+
+	private static BundleContext _bundleContext;
+	private static String _symbolicName;
+	private static boolean _upgrading;
+
+	@Inject
+	private CounterLocalService _counterLocalService;
+
+	private final VerifyProcessTest _initialDeploymentVerifyProcess =
+		new VerifyProcessTest();
+
+	@Inject
+	private ReleaseLocalService _releaseLocalService;
+
+	private final VerifyProcessTest _runOnPortalUpgradeVerifyProcess =
+		new VerifyProcessTest();
+	private final VerifyProcessTest _verifyProcess = new VerifyProcessTest();
+	private boolean _verifyProcessRun;
+
+	private class DummyUpgrade extends DummyUpgradeStep {
+	}
+
+	private class VerifyProcessTest extends VerifyProcess {
+
+		@Override
+		protected void doVerify() throws Exception {
+			_verifyProcessRun = true;
+		}
+
+	}
+
+}


### PR DESCRIPTION
- LPS-160250 isInitialRelease support for non-service modules
- LPS-160250 Non-service modules with no upgrades can also have a verify to be executed on initial deployment
- LPS-160250 Run verifiers when module upgrades are executed
- LPS-160250 Extract logic to decide if the execution is needed outside the execution method
- LPS-160250 Add a new flag to allow verifiers to run on every Liferay update
- LPS-160250 Do not run verifiers after the initial creation if they are not initial deployment verifiers
- LPS-160250 If we deploy new verifiers once we finished the upgrade, we should not run them
- LPS-160250 Adding tests
- LPS-160250 SF
