### PR TITLE
[TS] LPS-158085 Add dummy upgrade step to make 7.3.x backport possible

### DIFF
--- a/modules/apps/redirect/redirect-service/bnd.bnd
+++ b/modules/apps/redirect/redirect-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Redirect Service
 Bundle-SymbolicName: com.liferay.redirect.service
 Bundle-Version: 2.0.45
-Liferay-Require-SchemaVersion: 3.0.2
+Liferay-Require-SchemaVersion: 3.0.3
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/upgrade/registry/RedirectServiceUpgradeStepRegistrator.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/upgrade/registry/RedirectServiceUpgradeStepRegistrator.java
@@ -15,6 +15,7 @@
 package com.liferay.redirect.internal.upgrade.registry;
 
 import com.liferay.portal.configuration.upgrade.PrefsPropsToConfigurationUpgradeHelper;
+import com.liferay.portal.kernel.upgrade.DummyUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.redirect.internal.upgrade.v3_0_2.RedirectEntrySourceURLUpgradeProcess;
@@ -46,14 +47,16 @@ public class RedirectServiceUpgradeStepRegistrator
 			"2.0.1", "3.0.0",
 			UpgradeProcessFactory.dropColumns("RedirectNotFoundEntry", "hits"));
 
-		registry.register(
-			"3.0.0", "3.0.1",
-			new com.liferay.redirect.internal.upgrade.v3_0_1.
-				RedirectURLConfigurationUpgradeProcess(
-					_prefsPropsToConfigurationUpgradeHelper));
+		registry.register("3.0.0", "3.0.1", new DummyUpgradeProcess());
 
 		registry.register(
 			"3.0.1", "3.0.2", new RedirectEntrySourceURLUpgradeProcess());
+
+		registry.register(
+			"3.0.2", "3.0.3",
+			new com.liferay.redirect.internal.upgrade.v3_0_1.
+				RedirectURLConfigurationUpgradeProcess(
+					_prefsPropsToConfigurationUpgradeHelper));
 	}
 
 	@Reference


### PR DESCRIPTION
Hi Team,

I'm preparing to backport the LPS-158085 to 7.3.x and I have to move one of the upgrade steps to make it possible. 
Checked locally and asked the original creator of the moved upgrade step and we both think that moving it shouldn't cause an issue.
Could you check it?

Slack thread: https://liferay.slack.com/archives/CUQP9C673/p1669642220086429

Thanks!
Attila