### PR TITLE
LPS-171480 Fixing issue on scheduled jobs when auto upgrade is enabled because CompanyThreadLocal is initialized wrong

### DIFF
--- a/modules/apps/dispatch/dispatch-test/build.gradle
+++ b/modules/apps/dispatch/dispatch-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	testIntegrationCompile project(":apps:dispatch:dispatch-api")
 	testIntegrationCompile project(":apps:layout:layout-test-util")

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/internal/messaging/test/SchedulerResponseTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/internal/messaging/test/SchedulerResponseTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dispatch.internal.messaging.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
+import com.liferay.portal.kernel.scheduler.SchedulerException;
+import com.liferay.portal.kernel.scheduler.StorageType;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luis Ortiz
+ */
+@RunWith(Arquillian.class)
+public class SchedulerResponseTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testStartupScheduleJobCompanyId() throws SchedulerException {
+		SchedulerResponse schedulerResponse =
+			_schedulerEngineHelper.getScheduledJob(
+				_STARTUP_LISTENER_CLASS, _STARTUP_LISTENER_CLASS,
+				StorageType.MEMORY_CLUSTERED);
+
+		Message message = schedulerResponse.getMessage();
+
+		Assert.assertEquals(
+			CompanyConstants.SYSTEM, message.getLong("companyId"));
+	}
+
+	private static final String _STARTUP_LISTENER_CLASS =
+		"com.liferay.journal.web.internal.messaging." +
+			"CheckArticleMessageListener";
+
+	@Inject
+	private SchedulerEngineHelper _schedulerEngineHelper;
+
+}

--- a/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
@@ -45,7 +45,6 @@ import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.plugin.PluginPackage;
 import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletInstanceFactoryUtil;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
@@ -758,24 +757,18 @@ public class MainServlet extends HttpServlet {
 
 		ServletContext servletContext = getServletContext();
 
-		try {
-			String[] webIds = PortalInstances.getWebIds();
+		String[] webIds = PortalInstances.getWebIds();
 
-			for (String webId : webIds) {
-				boolean skipCheck = false;
+		for (String webId : webIds) {
+			boolean skipCheck = false;
 
-				if (StartupHelperUtil.isDBNew() &&
-					webId.equals(PropsValues.COMPANY_DEFAULT_WEB_ID)) {
+			if (StartupHelperUtil.isDBNew() &&
+				webId.equals(PropsValues.COMPANY_DEFAULT_WEB_ID)) {
 
-					skipCheck = true;
-				}
-
-				PortalInstances.initCompany(servletContext, webId, skipCheck);
+				skipCheck = true;
 			}
-		}
-		finally {
-			CompanyThreadLocal.setCompanyId(
-				PortalInstances.getDefaultCompanyId());
+
+			PortalInstances.initCompany(servletContext, webId, skipCheck);
 		}
 	}
 


### PR DESCRIPTION
- LPS-171480 Adding integration tests to verify scheduled jobs are registered with company ID SYSTEM
- LPS-171480 Removing CompanyThreadLocal value setting as we are not yet in any company. This is needed for the correct initialization of MessageListeners
