### PR TITLE
LPS-123391 verify Layout URLS before upgrade

### DIFF
--- a/portal-impl/src/com/liferay/portal/verify/VerifyLayout.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyLayout.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.verify;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.util.PropsValues;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * @author Jorge Avalos
+ */
+public class VerifyLayout extends VerifyProcess {
+
+	protected static String getReservedLayoutFriendlyURLS() {
+		String reservedLayoutFriendlyURLS = StringBundler.concat(
+			"\"/", PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS[0], "\"");
+
+		for (int i = 1; i < PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS.length;
+			 i++) {
+
+			reservedLayoutFriendlyURLS += StringBundler.concat(
+				",\"/", PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS[i], "\"");
+		}
+
+		return reservedLayoutFriendlyURLS;
+	}
+
+	@Override
+	protected void doVerify() throws Exception {
+		verifyLayoutFriendlyURL();
+	}
+
+	protected void verifyLayoutFriendlyURL() {
+		try {
+			String reservedURLS = getReservedLayoutFriendlyURLS();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"Select friendlyURL, plid from Layout where friendlyURL in",
+					"(", reservedURLS, ")"));
+
+			ResultSet resultSet = preparedStatement.executeQuery();
+
+			while (resultSet.next()) {
+				String invalidURL = resultSet.getString("friendlyURL");
+				long plid = resultSet.getLong("plid");
+
+				_log.error(
+					StringBundler.concat(
+						"Reserved layout URL detected \"", invalidURL,
+						"\" Please update Layout plid:", plid,
+						" after upgrade"));
+			}
+		}
+		catch (SQLException sqlException) {
+			throw new RuntimeException(sqlException);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(VerifyLayout.class);
+
+}

--- a/portal-impl/src/com/liferay/portal/verify/VerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProcessSuite.java
@@ -36,6 +36,7 @@ public class VerifyProcessSuite extends VerifyProcess {
 		}
 		else {
 			verify(new VerifyGroup());
+			verify(new VerifyLayout());
 
 			verify(new VerifyResourcePermissions());
 		}


### PR DESCRIPTION
LPS-123391 

Issue:
There are methods of getting Layout URLs to be set as reserved urls in previous versions of Liferay, making the site inaccessible.  

Solution:
During the upgrade, through an error indication that the user needs to update the URL of the layout.  