### PR TITLE
LPS-155228 Filter out unrelated WARNS when generating Upgrade Report

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -107,9 +107,18 @@ public class UpgradeReport {
 		warningMessages.put(message, count);
 	}
 
+	public void filterMessages() {
+		for (String filteredClass : _FILTERED_LOG_CLASSES) {
+			_warningMessages.remove(filteredClass);
+			_errorMessages.remove(filteredClass);
+		}
+	}
+
 	public void generateReport(
 		PersistenceManager persistenceManager,
 		ReleaseManagerOSGiCommands releaseManagerOSGiCommands) {
+
+		filterMessages();
 
 		_persistenceManager = persistenceManager;
 
@@ -648,6 +657,11 @@ public class UpgradeReport {
 	private static final String _CONFIGURATION_PID_FILE_SYSTEM_STORE =
 		"com.liferay.portal.store.file.system.configuration." +
 			"FileSystemStoreConfiguration";
+
+	private static final String[] _FILTERED_LOG_CLASSES = {
+		"com.liferay.portal.search.elasticsearch7.internal.sidecar." +
+			"SidecarManager"
+	};
 
 	private static final String _UNDERLINE = "--------------";
 


### PR DESCRIPTION
Issue:
During an upgrade, the Sidecar Manager will throw a Warn Log regarding using Elasticsearch Sidecar during production.  This is unrelated to the upgrade and should not be displayed in the upgrade report.

The behavior is only shown while using an Pre-Built bundle.

Solution:
Filter out unrelated logs based on the class.

[LPS-155228](https://issues.liferay.com/browse/LPS-155228)