### PR TITLE
[TS] LPS-173712 | master

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_7_3/DDMFormInstanceReportUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_7_3/DDMFormInstanceReportUpgradeProcess.java
@@ -114,7 +114,11 @@ public class DDMFormInstanceReportUpgradeProcess extends UpgradeProcess {
 
 				ResultSet resultSet2 = preparedStatement2.executeQuery();
 
-				while (resultSet2.next()) {
+				if (!resultSet2.next()) {
+					continue;
+				}
+
+				do {
 					dataJSONObject = _processDDMFormValues(
 						dataJSONObject,
 						_getDDMFormValues(
@@ -127,6 +131,7 @@ public class DDMFormInstanceReportUpgradeProcess extends UpgradeProcess {
 					dataJSONObject.put(
 						"totalItems", dataJSONObject.getInt("totalItems") + 1);
 				}
+				while (resultSet2.next());
 
 				long groupId = resultSet1.getLong("groupId");
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_7_3/DDMFormInstanceReportUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_7_3/DDMFormInstanceReportUpgradeProcess.java
@@ -128,6 +128,10 @@ public class DDMFormInstanceReportUpgradeProcess extends UpgradeProcess {
 						"totalItems", dataJSONObject.getInt("totalItems") + 1);
 				}
 
+				if (dataJSONObject.length() == 0) {
+					continue;
+				}
+
 				long groupId = resultSet1.getLong("groupId");
 
 				long companyId = resultSet1.getLong("companyId");

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_7_3/DDMFormInstanceReportUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_7_3/DDMFormInstanceReportUpgradeProcess.java
@@ -114,11 +114,7 @@ public class DDMFormInstanceReportUpgradeProcess extends UpgradeProcess {
 
 				ResultSet resultSet2 = preparedStatement2.executeQuery();
 
-				if (!resultSet2.next()) {
-					continue;
-				}
-
-				do {
+				while (resultSet2.next()) {
 					dataJSONObject = _processDDMFormValues(
 						dataJSONObject,
 						_getDDMFormValues(
@@ -131,7 +127,6 @@ public class DDMFormInstanceReportUpgradeProcess extends UpgradeProcess {
 					dataJSONObject.put(
 						"totalItems", dataJSONObject.getInt("totalItems") + 1);
 				}
-				while (resultSet2.next());
 
 				long groupId = resultSet1.getLong("groupId");
 


### PR DESCRIPTION

Under certain conditions (customer database records from DXP 7.1),

`DDMFormInstanceReportUpgradeProcess`

fails with NPE:

```
ERROR [main][ReleaseManagerImpl:185] Failed upgrade process for module com.liferay.dynamic.data.mapping.service
com.liferay.portal.kernel.upgrade.UpgradeException: java.lang.NullPointerException
	at com.liferay.portal.kernel.upgrade.UpgradeProcess.upgrade(UpgradeProcess.java:136) ~[portal-kernel.jar:?]
...
...
...
Caused by: java.lang.NullPointerException
	at com.liferay.dynamic.data.mapping.internal.upgrade.v3_10_2.DDMFormInstanceReportUpgradeProcess._getNormalizedValuesJSONObject(DDMFormInstanceReportUpgradeProcess.java:130) ~[?:?]
	at com.liferay.dynamic.data.mapping.internal.upgrade.v3_10_2.DDMFormInstanceReportUpgradeProcess._getNormalizedFieldJSONObject(DDMFormInstanceReportUpgradeProcess.java:120) ~[?:?]
	at com.liferay.dynamic.data.mapping.internal.upgrade.v3_10_2.DDMFormInstanceReportUpgradeProcess.upgradeDDMFormInstanceReportData(DDMFormInstanceReportUpgradeProcess.java:89) ~[?:?]
	at com.liferay.dynamic.data.mapping.internal.upgrade.v3_10_2.DDMFormInstanceReportUpgradeProcess.doUpgrade(DDMFormInstanceReportUpgradeProcess.java:56) ~[?:?]
...
...
...
```

Root cause is we do not check if JSON object is empty in

`com.liferay.dynamic.data.mapping.internal.upgrade.v3_7_3.DDMFormInstanceReportUpgradeProcess`

So, subsequent upgrade step v3_10_2 raises the NPE.
