### PR TITLE
LPS-158740 Adding support for the upgrade report when using auto upgrade on startup

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -455,7 +455,14 @@ public class UpgradeReport {
 	}
 
 	private File _getReportFile() {
-		File reportsDir = new File(".", "reports");
+		File reportsDir = null;
+
+		if (DBUpgrader.isUpgradeTool()) {
+			reportsDir = new File(".", "reports");
+		}
+		else {
+			reportsDir = new File(PropsValues.LIFERAY_HOME, "reports");
+		}
 
 		if ((reportsDir != null) && !reportsDir.exists()) {
 			reportsDir.mkdirs();

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeReportLogAppenderUpgradeOnStartupTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeReportLogAppenderUpgradeOnStartupTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.util.PropsValues;
+
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luis Ortiz
+ */
+@RunWith(Arquillian.class)
+public class UpgradeReportLogAppenderUpgradeOnStartupTest
+	extends BaseUpgradeReportLogAppenderTestCase {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		setUpClass(false);
+	}
+
+	@Override
+	protected String getFilePath() {
+		return PropsValues.LIFERAY_HOME;
+	}
+
+}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeReportLogAppenderUpgradeToolTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeReportLogAppenderUpgradeToolTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luis Ortiz
+ */
+@RunWith(Arquillian.class)
+public class UpgradeReportLogAppenderUpgradeToolTest
+	extends BaseUpgradeReportLogAppenderTestCase {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		setUpClass(true);
+	}
+
+	@Override
+	protected String getFilePath() {
+		return ".";
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
@@ -394,6 +394,10 @@ public class MainServlet extends HttpServlet {
 		if (PropsValues.UPGRADE_DATABASE_AUTO_RUN) {
 			DBUpgrader.upgradeModules();
 
+			if (PropsValues.UPGRADE_REPORT_ENABLED) {
+				DBUpgrader.stopUpgradeReportLogAppender();
+			}
+
 			StartupHelperUtil.setUpgrading(false);
 		}
 

--- a/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
+++ b/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
@@ -333,6 +333,10 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 		dynamicProxyCreator.clear();
 
 		if (PropsValues.UPGRADE_DATABASE_AUTO_RUN) {
+			if (PropsValues.UPGRADE_REPORT_ENABLED) {
+				DBUpgrader.startUpgradeReportLogAppender();
+			}
+
 			StartupHelperUtil.setUpgrading(true);
 
 			try {

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -130,9 +130,7 @@ public class DBUpgrader {
 		String result = "Completed";
 
 		try {
-			_stopWatch = new StopWatch();
-
-			_stopWatch.start();
+			_initUpgradeStopwatch();
 
 			PortalClassPathUtil.initializeClassPaths(null);
 
@@ -171,22 +169,24 @@ public class DBUpgrader {
 			result = "Failed";
 		}
 		finally {
-			_stopWatch.stop();
+			if (PropsValues.UPGRADE_REPORT_ENABLED) {
+				stopUpgradeReportLogAppender();
+			}
 
 			System.out.println(
 				StringBundler.concat(
 					"\n", result, " Liferay upgrade process in ",
 					_stopWatch.getTime() / Time.SECOND, " seconds"));
-
-			if (PropsValues.UPGRADE_REPORT_ENABLED) {
-				stopUpgradeReportLogAppender();
-			}
 		}
 
 		System.out.println("Exiting DBUpgrader#main(String[]).");
 	}
 
 	public static void startUpgradeReportLogAppender() {
+		if (_stopWatch == null) {
+			_initUpgradeStopwatch();
+		}
+
 		ServiceLatch serviceLatch = SystemBundleUtil.newServiceLatch();
 
 		serviceLatch.<Appender>waitFor(
@@ -205,6 +205,8 @@ public class DBUpgrader {
 
 	public static void stopUpgradeReportLogAppender() {
 		if (_appender != null) {
+			_stopWatch.stop();
+
 			_appender.stop();
 		}
 
@@ -364,6 +366,12 @@ public class DBUpgrader {
 				"No Release exists with the primary key " +
 					ReleaseConstants.DEFAULT_ID);
 		}
+	}
+
+	private static void _initUpgradeStopwatch() {
+		_stopWatch = new StopWatch();
+
+		_stopWatch.start();
 	}
 
 	private static void _registerModuleServiceLifecycle(

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -126,8 +126,14 @@ public class DBUpgrader {
 		return _stopWatch.getTime();
 	}
 
+	public static boolean isUpgradeTool() {
+		return _upgradeTool;
+	}
+
 	public static void main(String[] args) {
 		String result = "Completed";
+
+		_upgradeTool = true;
 
 		try {
 			_initUpgradeStopwatch();
@@ -438,5 +444,6 @@ public class DBUpgrader {
 	private static volatile ServiceReference<Appender>
 		_appenderServiceReference;
 	private static volatile StopWatch _stopWatch;
+	private static volatile boolean _upgradeTool;
 
 }

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -142,7 +142,7 @@ public class DBUpgrader {
 				true, false,
 				() -> {
 					if (PropsValues.UPGRADE_REPORT_ENABLED) {
-						_startUpgradeReportLogAppender();
+						startUpgradeReportLogAppender();
 					}
 				});
 
@@ -179,11 +179,40 @@ public class DBUpgrader {
 					_stopWatch.getTime() / Time.SECOND, " seconds"));
 
 			if (PropsValues.UPGRADE_REPORT_ENABLED) {
-				_stopUpgradeReportLogAppender();
+				stopUpgradeReportLogAppender();
 			}
 		}
 
 		System.out.println("Exiting DBUpgrader#main(String[]).");
+	}
+
+	public static void startUpgradeReportLogAppender() {
+		ServiceLatch serviceLatch = SystemBundleUtil.newServiceLatch();
+
+		serviceLatch.<Appender>waitFor(
+			StringBundler.concat(
+				"(&(appender.name=UpgradeReportLogAppender)(objectClass=",
+				Appender.class.getName(), "))"),
+			appender -> {
+				_appender = appender;
+
+				_appender.start();
+			});
+		serviceLatch.openOn(
+			() -> {
+			});
+	}
+
+	public static void stopUpgradeReportLogAppender() {
+		if (_appender != null) {
+			_appender.stop();
+		}
+
+		if (_appenderServiceReference != null) {
+			BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+			bundleContext.ungetService(_appenderServiceReference);
+		}
 	}
 
 	public static void upgradeModules() {
@@ -353,35 +382,6 @@ public class DBUpgrader {
 			).put(
 				"service.version", ReleaseInfo.getVersion()
 			).build());
-	}
-
-	private static void _startUpgradeReportLogAppender() {
-		ServiceLatch serviceLatch = SystemBundleUtil.newServiceLatch();
-
-		serviceLatch.<Appender>waitFor(
-			StringBundler.concat(
-				"(&(appender.name=UpgradeReportLogAppender)(objectClass=",
-				Appender.class.getName(), "))"),
-			appender -> {
-				_appender = appender;
-
-				_appender.start();
-			});
-		serviceLatch.openOn(
-			() -> {
-			});
-	}
-
-	private static void _stopUpgradeReportLogAppender() {
-		if (_appender != null) {
-			_appender.stop();
-		}
-
-		if (_appenderServiceReference != null) {
-			BundleContext bundleContext = SystemBundleUtil.getBundleContext();
-
-			bundleContext.ungetService(_appenderServiceReference);
-		}
 	}
 
 	private static void _updateCompanyKey() throws Exception {

--- a/portal-impl/src/com/liferay/portal/tools/packageinfo
+++ b/portal-impl/src/com/liferay/portal/tools/packageinfo
@@ -1,1 +1,1 @@
-version 11.1.0
+version 11.2.0


### PR DESCRIPTION
- LPS-158740 Adding support for the upgrade report for upgrade on startup
- LPS-158740 Refactor on the upgrade report stopwatch to make it work with the auto upgrade
- LPS-158740 Upgrade report should be generated in a folder at liferay home when using auto upgrade, and in a folder in the current directory when using the ugprade tool
- LPS-158740 Baseline
- LPS-158740 Updating tests to work on both upgrade tool and upgrade on startup configurations
