### PR TITLE
[TS] LPS-157194 Add upgrade process for 7.3 to clear out expired OAuth2Authorizations

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
@@ -16,10 +16,12 @@ package com.liferay.oauth2.provider.internal.upgrade.registry;
 
 import com.liferay.oauth2.provider.internal.upgrade.v2_0_0.OAuth2ApplicationScopeAliasesUpgradeProcess;
 import com.liferay.oauth2.provider.internal.upgrade.v3_0_0.OAuth2ApplicationClientCredentialUserUpgradeUser;
+import com.liferay.oauth2.provider.internal.upgrade.v3_0_1.OAuth2AuthorizationUpgradeProcess;
 import com.liferay.oauth2.provider.internal.upgrade.v3_2_0.OAuth2ApplicationFeatureUpgradeProcess;
 import com.liferay.oauth2.provider.internal.upgrade.v4_1_0.OAuth2ApplicationClientAuthenticationMethodUpgradeProcess;
 import com.liferay.oauth2.provider.internal.upgrade.v4_2_1.OAuth2ScopeGrantRemoveCompanyIdFromObjectsRelatedUpgradeProcess;
 import com.liferay.oauth2.provider.scope.liferay.ScopeLocator;
+import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.BaseUuidUpgradeProcess;
@@ -71,7 +73,11 @@ public class OAuth2ServiceUpgradeStepRegistrator
 			new OAuth2ApplicationClientCredentialUserUpgradeUser());
 
 		registry.register(
-			"3.0.0", "3.1.0",
+			"3.0.0", "3.0.1",
+			new OAuth2AuthorizationUpgradeProcess(_configurationProvider));
+
+		registry.register(
+			"3.0.1", "3.1.0",
 			UpgradeProcessFactory.addColumns(
 				"OAuth2Application", "rememberDevice BOOLEAN"),
 			UpgradeProcessFactory.addColumns(
@@ -125,6 +131,9 @@ public class OAuth2ServiceUpgradeStepRegistrator
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private ConfigurationProvider _configurationProvider;
 
 	@Reference
 	private ScopeLocator _scopeLocator;

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/v3_0_1/OAuth2AuthorizationUpgradeProcess.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/v3_0_1/OAuth2AuthorizationUpgradeProcess.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.internal.upgrade.v3_0_1;
+
+import com.liferay.oauth2.provider.configuration.OAuth2ProviderConfiguration;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.Time;
+
+import java.sql.Date;
+import java.sql.PreparedStatement;
+
+/**
+ * @author Jonathan McCann
+ */
+public class OAuth2AuthorizationUpgradeProcess extends UpgradeProcess {
+
+	public OAuth2AuthorizationUpgradeProcess(
+		ConfigurationProvider configurationProvider) {
+
+		_configurationProvider = configurationProvider;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		OAuth2ProviderConfiguration oAuth2ProviderConfiguration =
+			_configurationProvider.getSystemConfiguration(
+				OAuth2ProviderConfiguration.class);
+
+		int expiredAuthorizationsAfterlifeDuration = Math.max(
+			oAuth2ProviderConfiguration.
+				expiredAuthorizationsAfterlifeDuration(),
+			0);
+
+		long expiredAuthorizationsAfterlifeDurationMillis =
+			expiredAuthorizationsAfterlifeDuration * Time.SECOND;
+
+		Date purgeDate = new Date(System.currentTimeMillis());
+
+		purgeDate.setTime(
+			purgeDate.getTime() - expiredAuthorizationsAfterlifeDurationMillis);
+
+		String sql = StringBundler.concat(
+			"delete OAuth2Authorization, OA2Auths_OA2ScopeGrants from ",
+			"OAuth2Authorization INNER JOIN OA2Auths_OA2ScopeGrants where ",
+			"(OAuth2Authorization.accessTokenExpirationDate < ?) and ",
+			"(((OAuth2Authorization.refreshTokenExpirationDate is not null) ",
+			"and (OAuth2Authorization.refreshTokenExpirationDate < ?)) or ",
+			"(OAuth2Authorization.refreshTokenExpirationDate is null)) and ",
+			"OAuth2Authorization.oAuth2AuthorizationId = ",
+			"OA2Auths_OA2ScopeGrants.oAuth2AuthorizationId");
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				sql)) {
+
+			preparedStatement.setDate(1, purgeDate);
+			preparedStatement.setDate(2, purgeDate);
+
+			preparedStatement.executeUpdate();
+		}
+	}
+
+	private final ConfigurationProvider _configurationProvider;
+
+}


### PR DESCRIPTION
Dear colleagues,

I would like to ask for your help. We received this PR as https://github.com/liferay-appsec/liferay-portal/pull/1015 from @jonathanmccann. I reviewed it and I'm sure it would fix the issue described in the ticket, however we have concerns about a single SQL `DELETE` statement would be able to handle potentially millions of records without causing issues with "redo" logs of some DBs.

What do you think? Will it work in the current form? If not what do you suggest, what is the recommended way to handle this?

Thank you!

---

Original comment by @jonathanmccann:

This upgrade process is added to clean up expired authorizations because in 7.2 and below the scheduled job to do this automatically does not exist yet. Users upgrading from these versions may have millions of expired entries and this will lead to server instability when the scheduled job is finally run.

I added it as version 3.0.1 so that it could be backported to 7.3.x without issue as the latest versions of the module there is 3.0.0 (https://github.com/liferay/liferay-portal-ee/blob/7.3.x/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/OAuth2ServiceUpgrade.java#L63).

For testing purposes there is a SQL file attached to https://issues.liferay.com/browse/LPS-157194 that can be used.

Please let me know if there are any questions or concerns.