### PR TITLE
LPS-158743 Making it possible to generate the upgrade report in the standard log output as log context information

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -432,7 +432,7 @@ public class UpgradeReport {
 		).put(
 			"database.version", _getDialectInfo()
 		).put(
-			"property", _getPropertiesInfo()
+			_PROPERTY_KEY, _getPropertiesInfo()
 		).put(
 			"document.library.storage.size", _getDLStorageInfoNew()
 		).put(
@@ -628,6 +628,11 @@ public class UpgradeReport {
 	}
 
 	private String _getUpgradeReportHeaderFromKey(String key) {
+		if (key.startsWith(_PROPERTY_KEY)) {
+			return StringUtil.replaceFirst(
+				StringUtil.upperCaseFirstLetter(key), '.', ' ');
+		}
+
 		return StringUtil.replace(
 			StringUtil.upperCaseFirstLetter(key), '.', ' ');
 	}
@@ -769,6 +774,8 @@ public class UpgradeReport {
 	};
 
 	private static final String _LOG_CONTEXT_PREFIX = "upgrade.report.";
+
+	private static final String _PROPERTY_KEY = "property";
 
 	private static final int _UPGRADE_PROCESSES_COUNT = 20;
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -430,22 +430,22 @@ public class UpgradeReport {
 		).put(
 			"portal", _getPortalVersionInfo()
 		).put(
-			"using.database", _getDialectInfo()
+			"database.version", _getDialectInfo()
 		).put(
-			"properties", _getPropertiesInfo()
+			"property", _getPropertiesInfo()
 		).put(
 			"document.library.storage.size", _getDLStorageInfoNew()
 		).put(
 			"tables.initial.final.rows", _getDatabaseTableCounts()
 		).put(
-			"longest.running.upgrade.processes",
+			"longest.upgrade.processes",
 			_getLongestRunningUpgradeProcessesList()
 		).put(
 			"errors", _getSortedLogEvents("errors")
 		).put(
 			"warnings", _getSortedLogEvents("warnings")
 		).put(
-			"release.osgi.info",
+			"osgi.status",
 			() -> {
 				if (releaseManagerOSGiCommands == null) {
 					return "Not possible to check upgrades status";

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -628,7 +628,8 @@ public class UpgradeReport {
 	}
 
 	private String _getUpgradeReportHeaderFromKey(String key) {
-		return "Upgrade " + StringUtil.replace(key, '.', ' ');
+		return StringUtil.replace(
+			StringUtil.upperCaseFirstLetter(key), '.', ' ');
 	}
 
 	private String _getUpgradeReportSimpleValueLine(String key, Object value) {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -672,7 +672,9 @@ public class UpgradeReport {
 				sb.append(_printContextMap(key, (Map<?, ?>)value));
 			}
 			else if (value instanceof List<?>) {
-				sb.append(_getUpgradeReportHeaderFromKey(key));
+				String header = _getUpgradeReportHeaderFromKey(key);
+
+				sb.append(header);
 
 				List<Object> elements = (List<Object>)value;
 
@@ -683,7 +685,10 @@ public class UpgradeReport {
 				else {
 					sb.append(StringPool.NEW_LINE);
 					sb.append(
-						"-------------------------------------------------");
+						ListUtil.toString(
+							Collections.nCopies(
+								header.length(), StringPool.MINUS),
+							StringPool.NULL, StringPool.BLANK));
 					sb.append(StringPool.NEW_LINE);
 
 					for (Object object : (List<Object>)value) {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -483,7 +483,7 @@ public class UpgradeReport {
 		).put(
 			"document.library.storage.size", _getDLStorageInfoNew()
 		).put(
-			"tables.initial.final.rows", _getDatabaseTableCounts()
+			_TABLES_KEY + ".initial.final.rows", _getDatabaseTableCounts()
 		).put(
 			"longest.upgrade.processes",
 			_getLongestRunningUpgradeProcessesList()
@@ -543,6 +543,11 @@ public class UpgradeReport {
 		if (key.startsWith(_PROPERTY_KEY)) {
 			return StringUtil.replaceFirst(
 				StringUtil.upperCaseFirstLetter(key), '.', ' ');
+		}
+
+		if (key.startsWith(_TABLES_KEY)) {
+			return String.format(
+				TableCounts.FORMAT, "Table name", "Initial rows", "Final rows");
 		}
 
 		return StringUtil.replace(
@@ -784,6 +789,8 @@ public class UpgradeReport {
 
 	private static final String _PROPERTY_KEY = "property";
 
+	private static final String _TABLES_KEY = "tables";
+
 	private static final int _UPGRADE_PROCESSES_COUNT = 20;
 
 	private static final Log _log = LogFactoryUtil.getLog(UpgradeReport.class);
@@ -886,6 +893,8 @@ public class UpgradeReport {
 
 	private class TableCounts {
 
+		public static final String FORMAT = "%-30s %20s %20s";
+
 		public TableCounts(
 			String tableName, String initialCount, String finalCount) {
 
@@ -902,10 +911,8 @@ public class UpgradeReport {
 					StringPool.COLON, _finalCount);
 			}
 
-			String format = "%-30s %20s %20s";
-
 			return String.format(
-				format, _tableName, _initialCount, _finalCount);
+				FORMAT, _tableName, _initialCount, _finalCount);
 		}
 
 		private final String _finalCount;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -61,6 +61,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.felix.cm.PersistenceManager;
+import org.apache.logging.log4j.ThreadContext;
 
 /**
  * @author Sam Ziemer
@@ -117,6 +118,18 @@ public class UpgradeReport {
 
 		_persistenceManager = persistenceManager;
 
+		String dateInfo = _getDateInfo();
+		String timeInfo = _getUpgradeTimeInfo();
+		String portalVersionsInfo = _getPortalVersionsInfo();
+		String dialectInfo = _getDialectInfo();
+		String propertiesInfo = _getPropertiesInfo();
+		String dlStorageInfo = _getDLStorageInfo();
+		String databaseTablesInfo = _getDatabaseTablesInfo();
+		String upgradeProcessesInfo = _getUpgradeProcessesInfo();
+		String errorLogEventsInfo = _getLogEventsInfo("errors");
+		String warningLogEventsInfo = _getLogEventsInfo("warnings");
+		String releaseManagerOSGiInfo = (releaseManagerOSGiCommands == null) ? StringPool.BLANK : releaseManagerOSGiCommands.check();
+
 		try {
 			File reportFile = _getReportFile();
 
@@ -124,15 +137,10 @@ public class UpgradeReport {
 				reportFile,
 				StringUtil.merge(
 					new String[] {
-						_getDateInfo(), _getUpgradeTimeInfo(),
-						_getPortalVersionsInfo(), _getDialectInfo(),
-						_getPropertiesInfo(), _getDLStorageInfo(),
-						_getDatabaseTablesInfo(), _getUpgradeProcessesInfo(),
-						_getLogEventsInfo("errors"),
-						_getLogEventsInfo("warnings"),
-						(releaseManagerOSGiCommands == null) ?
-							StringPool.BLANK :
-								releaseManagerOSGiCommands.check()
+						dateInfo, timeInfo, portalVersionsInfo, dialectInfo,
+						propertiesInfo, dlStorageInfo, databaseTablesInfo,
+						upgradeProcessesInfo, errorLogEventsInfo,
+						warningLogEventsInfo, releaseManagerOSGiInfo
 					},
 					StringPool.NEW_LINE + StringPool.NEW_LINE));
 
@@ -144,6 +152,26 @@ public class UpgradeReport {
 		}
 		catch (IOException ioException) {
 			_log.error("Unable to generate the upgrade report", ioException);
+		}
+
+		if (PropsValues.UPGRADE_LOG_CONTEXT_ENABLED) {
+			ThreadContext.put("upgrade.report.date", dateInfo);
+			ThreadContext.put("upgrade.report.time", timeInfo);
+			ThreadContext.put("upgrade.report.portalVersion", portalVersionsInfo);
+			ThreadContext.put("upgrade.report.dialect", dialectInfo);
+			ThreadContext.put("upgrade.report.properties", propertiesInfo);
+			ThreadContext.put("upgrade.report.dlstorage", dlStorageInfo);
+			ThreadContext.put("upgrade.report.databasetables", databaseTablesInfo);
+			ThreadContext.put("upgrade.report.upgradeprocesses", upgradeProcessesInfo);
+			ThreadContext.put("upgrade.report.errorlogevents", errorLogEventsInfo);
+			ThreadContext.put("upgrade.report.warninglogevents", warningLogEventsInfo);
+			ThreadContext.put("upgrade.report.releasemanagerOSGi", releaseManagerOSGiInfo);
+
+			if (_log.isInfoEnabled()) {
+				_log.info("Upgrade report generated");
+			}
+
+			ThreadContext.clearMap();
 		}
 	}
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -363,7 +363,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	private static final Pattern _pattern = Pattern.compile(
 		"(\\w+_?)\\s+(\\d+|-)\\s+(\\d+|-)\n");
 
-	@Inject
+	@Inject (filter = "appender.name=UpgradeReportLogAppender")
 	private Appender _appender;
 
 	@Inject

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -77,6 +77,10 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		ReflectionTestUtil.setFieldValue(
 			DBUpgrader.class, "_upgradeClient", _originalUpgradeClient);
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_LOG_CONTEXT_ENABLED",
+			_originalUpgradeLogContextEnabled);
 	}
 
 	@Before
@@ -418,6 +422,12 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		ReflectionTestUtil.setFieldValue(
 			DBUpgrader.class, "_upgradeClient", upgradeClient);
+
+		_originalUpgradeLogContextEnabled = ReflectionTestUtil.getFieldValue(
+			PropsValues.class, "UPGRADE_LOG_CONTEXT_ENABLED");
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_LOG_CONTEXT_ENABLED", true);
 	}
 
 	protected abstract String getFilePath();
@@ -520,6 +530,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	private static final Pattern _logContextDatabaseTablePattern =
 		Pattern.compile("(\\w+_?):(\\d+|-):(\\d+|-)");
 	private static boolean _originalUpgradeClient;
+	private static boolean _originalUpgradeLogContextEnabled;
 	private static final Pattern _pattern = Pattern.compile(
 		"(\\w+_?)\\s+(\\d+|-)\\s+(\\d+|-)\n");
 	private static UnsyncStringWriter _unsyncStringWriter;

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -196,6 +196,8 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 			}
 		}
 
+		Assert.assertTrue(table1Exists && table2Exists);
+
 		_assertLogContextContains(
 			"upgrade.report.tables.initial.final.rows",
 			"UpgradeReportTable1:0:1");
@@ -452,7 +454,9 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	private void _assertLogContextContains(String key, String testString) {
 		String values = _getLogContextKey(key);
 
-		Assert.assertTrue(values.contains(testString));
+		Assert.assertTrue(
+			StringUtil.containsIgnoreCase(
+				values, testString, StringPool.BLANK));
 	}
 
 	private void _assertReport(String testString) throws Exception {

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -233,7 +233,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				reportContent.indexOf(fasterUpgradeProcessName));
 
 		String upgradeProcesses = _getLogContextKey(
-			"upgrade.report.longest.running.upgrade.processes");
+			"upgrade.report.longest.upgrade.processes");
 
 		Assert.assertTrue(
 			upgradeProcesses.indexOf(slowerUpgradeProcessName) <
@@ -264,7 +264,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_assertLogContextContains("upgrade.report.warnings", "2:Warning");
 		_assertLogContextContains(
-			"upgrade.report.longest.running.upgrade.processes",
+			"upgrade.report.longest.upgrade.processes",
 			"com.liferay.portal.UpgradeTest:20401 ms");
 	}
 
@@ -296,7 +296,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				bundleSymbolicName, " from 0.0.1 to ", currentSchemaVersion));
 
 		_assertLogContextContains(
-			"upgrade.report.release.osgi.info",
+			"upgrade.report.osgi.status",
 			StringBundler.concat(
 				"There are upgrade processes available for ",
 				bundleSymbolicName, " from 0.0.1 to ", currentSchemaVersion));
@@ -308,15 +308,14 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_appender.stop();
 
-		_assertReport("Upgrade errors: Nothing registered");
-		_assertReport(
-			"Upgrade longest running upgrade processes: Nothing registered");
-		_assertReport("Upgrade warnings: Nothing registered");
+		_assertReport("Errors: Nothing registered");
+		_assertReport("Longest upgrade processes: Nothing registered");
+		_assertReport("Warnings: Nothing registered");
 
 		_assertLogContextContains("upgrade.report.warnings", "[]");
 		_assertLogContextContains("upgrade.report.errors", "[]");
 		_assertLogContextContains(
-			"upgrade.report.longest.running.upgrade.processes", "[]");
+			"upgrade.report.longest.upgrade.processes", "[]");
 	}
 
 	@Test
@@ -327,26 +326,25 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_assertReport(
 			StringBundler.concat(
-				"Upgrade properties liferay home: ", PropsValues.LIFERAY_HOME,
-				StringPool.NEW_LINE, "Upgrade properties locales: ",
+				"Property liferay.home: ", PropsValues.LIFERAY_HOME,
+				StringPool.NEW_LINE, "Property locales: ",
 				Arrays.toString(PropsValues.LOCALES), StringPool.NEW_LINE,
-				"Upgrade properties locales enabled: ",
+				"Property locales.enabled: ",
 				Arrays.toString(PropsValues.LOCALES_ENABLED),
-				StringPool.NEW_LINE, "Upgrade properties ",
-				StringUtil.replace(PropsKeys.DL_STORE_IMPL, '.', ' '),
+				StringPool.NEW_LINE, "Property ", PropsKeys.DL_STORE_IMPL,
 				StringPool.COLON, StringPool.SPACE, PropsValues.DL_STORE_IMPL,
 				StringPool.NEW_LINE));
 
 		_assertLogContextContains(
-			"upgrade.report.properties.liferay.home", PropsValues.LIFERAY_HOME);
+			"upgrade.report.property.liferay.home", PropsValues.LIFERAY_HOME);
 		_assertLogContextContains(
-			"upgrade.report.properties.locales",
+			"upgrade.report.property.locales",
 			Arrays.toString(PropsValues.LOCALES));
 		_assertLogContextContains(
-			"upgrade.report.properties.locales.enabled",
+			"upgrade.report.property.locales.enabled",
 			Arrays.toString(PropsValues.LOCALES_ENABLED));
 		_assertLogContextContains(
-			"upgrade.report.properties." + PropsKeys.DL_STORE_IMPL,
+			"upgrade.report.property." + PropsKeys.DL_STORE_IMPL,
 			PropsValues.DL_STORE_IMPL);
 	}
 
@@ -380,15 +378,13 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_assertReport(
 			StringBundler.concat(
-				"Upgrade portal initial build number: 7100\n",
-				"Upgrade portal initial schema version: 1.0.0\n",
-				"Upgrade portal final build number: ",
-				ReleaseInfo.getBuildNumber(), StringPool.NEW_LINE,
-				"Upgrade portal final schema version: ",
+				"Portal initial build number: 7100\n",
+				"Portal initial schema version: 1.0.0\n",
+				"Portal final build number: ", ReleaseInfo.getBuildNumber(),
+				StringPool.NEW_LINE, "Portal final schema version: ",
 				latestSchemaVersion.toString(), StringPool.NEW_LINE,
-				"Upgrade portal expected build number: ",
-				ReleaseInfo.getBuildNumber(), StringPool.NEW_LINE,
-				"Upgrade portal expected schema version: ",
+				"Portal expected build number: ", ReleaseInfo.getBuildNumber(),
+				StringPool.NEW_LINE, "Portal expected schema version: ",
 				latestSchemaVersion.toString(), StringPool.NEW_LINE));
 
 		_assertLogContextContains(

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -143,7 +143,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 		_assertDatabaseTablesAreSorted(matcher);
 
 		String databaseTables = _getLogContextKey(
-			"upgrade.report.databaseTables");
+			"upgrade.report.tables.initial.final.rows");
 
 		matcher = _logContextDatabaseTablePattern.matcher(databaseTables);
 
@@ -197,9 +197,11 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 		}
 
 		_assertLogContextContains(
-			"upgrade.report.databaseTables", "UpgradeReportTable1:0:1");
+			"upgrade.report.tables.initial.final.rows",
+			"UpgradeReportTable1:0:1");
 		_assertLogContextContains(
-			"upgrade.report.databaseTables", "UpgradeReportTable2:1:0");
+			"upgrade.report.tables.initial.final.rows",
+			"UpgradeReportTable2:1:0");
 	}
 
 	@Test
@@ -231,7 +233,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				reportContent.indexOf(fasterUpgradeProcessName));
 
 		String upgradeProcesses = _getLogContextKey(
-			"upgrade.report.longestUpgradeProcesses");
+			"upgrade.report.longest.running.upgrade.processes");
 
 		Assert.assertTrue(
 			upgradeProcesses.indexOf(slowerUpgradeProcessName) <
@@ -256,14 +258,13 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_appender.stop();
 
-		_assertReport("2 occurrences of the following warnings: Warning");
+		_assertReport("2 occurrences of the following event: Warning");
 		_assertReport(
 			"com.liferay.portal.UpgradeTest took 20401 ms to complete");
 
+		_assertLogContextContains("upgrade.report.warnings", "2:Warning");
 		_assertLogContextContains(
-			"upgrade.report.warningsLogEvents", "2:Warning");
-		_assertLogContextContains(
-			"upgrade.report.longestUpgradeProcesses",
+			"upgrade.report.longest.running.upgrade.processes",
 			"com.liferay.portal.UpgradeTest:20401 ms");
 	}
 
@@ -295,7 +296,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				bundleSymbolicName, " from 0.0.1 to ", currentSchemaVersion));
 
 		_assertLogContextContains(
-			"upgrade.report.releasemanagerOSGi",
+			"upgrade.report.release.osgi.info",
 			StringBundler.concat(
 				"There are upgrade processes available for ",
 				bundleSymbolicName, " from 0.0.1 to ", currentSchemaVersion));
@@ -307,19 +308,15 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_appender.stop();
 
-		_assertReport("No errors thrown during upgrade");
-		_assertReport("No upgrade processes registered");
-		_assertReport("No warnings thrown during upgrade");
+		_assertReport("Upgrade errors: Nothing registered");
+		_assertReport(
+			"Upgrade longest running upgrade processes: Nothing registered");
+		_assertReport("Upgrade warnings: Nothing registered");
 
+		_assertLogContextContains("upgrade.report.warnings", "[]");
+		_assertLogContextContains("upgrade.report.errors", "[]");
 		_assertLogContextContains(
-			"upgrade.report.warningsLogEvents",
-			"No warnings thrown during upgrade");
-		_assertLogContextContains(
-			"upgrade.report.errorsLogEvents",
-			"No errors thrown during upgrade");
-		_assertLogContextContains(
-			"upgrade.report.longestUpgradeProcesses",
-			"No upgrade processes registered");
+			"upgrade.report.longest.running.upgrade.processes", "[]");
 	}
 
 	@Test
@@ -330,14 +327,15 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_assertReport(
 			StringBundler.concat(
-				PropsKeys.LIFERAY_HOME, StringPool.EQUAL,
-				PropsValues.LIFERAY_HOME, StringPool.NEW_LINE,
-				PropsKeys.LOCALES, StringPool.EQUAL,
+				"Upgrade properties liferay home: ", PropsValues.LIFERAY_HOME,
+				StringPool.NEW_LINE, "Upgrade properties locales: ",
 				Arrays.toString(PropsValues.LOCALES), StringPool.NEW_LINE,
-				PropsKeys.LOCALES_ENABLED, StringPool.EQUAL,
+				"Upgrade properties locales enabled: ",
 				Arrays.toString(PropsValues.LOCALES_ENABLED),
-				StringPool.NEW_LINE, PropsKeys.DL_STORE_IMPL, StringPool.EQUAL,
-				PropsValues.DL_STORE_IMPL));
+				StringPool.NEW_LINE, "Upgrade properties ",
+				StringUtil.replace(PropsKeys.DL_STORE_IMPL, '.', ' '),
+				StringPool.COLON, StringPool.SPACE, PropsValues.DL_STORE_IMPL,
+				StringPool.NEW_LINE));
 
 		_assertLogContextContains(
 			"upgrade.report.properties.liferay.home", PropsValues.LIFERAY_HOME);
@@ -382,30 +380,32 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_assertReport(
 			StringBundler.concat(
-				"Initial portal build number: 7100\n",
-				"Initial portal schema version: 1.0.0\n",
-				"Final portal build number: ", ReleaseInfo.getBuildNumber(),
-				StringPool.NEW_LINE, "Final portal schema version: ",
+				"Upgrade portal initial build number: 7100\n",
+				"Upgrade portal initial schema version: 1.0.0\n",
+				"Upgrade portal final build number: ",
+				ReleaseInfo.getBuildNumber(), StringPool.NEW_LINE,
+				"Upgrade portal final schema version: ",
 				latestSchemaVersion.toString(), StringPool.NEW_LINE,
-				"Expected portal build number: ", ReleaseInfo.getBuildNumber(),
-				StringPool.NEW_LINE, "Expected portal schema version: ",
+				"Upgrade portal expected build number: ",
+				ReleaseInfo.getBuildNumber(), StringPool.NEW_LINE,
+				"Upgrade portal expected schema version: ",
 				latestSchemaVersion.toString(), StringPool.NEW_LINE));
 
 		_assertLogContextContains(
-			"upgrade.report.initialPortalBuildNumber", "7100");
+			"upgrade.report.portal.initial.build.number", "7100");
 		_assertLogContextContains(
-			"upgrade.report.initialPortalSchemaVersion", "1.0.0");
+			"upgrade.report.portal.initial.schema.version", "1.0.0");
 		_assertLogContextContains(
-			"upgrade.report.finalPortalBuildNumber",
+			"upgrade.report.portal.final.build.number",
 			String.valueOf(ReleaseInfo.getBuildNumber()));
 		_assertLogContextContains(
-			"upgrade.report.finalPortalSchemaVersion",
+			"upgrade.report.portal.final.schema.version",
 			latestSchemaVersion.toString());
 		_assertLogContextContains(
-			"upgrade.report.expectedPortalBuildNumber",
+			"upgrade.report.portal.expected.build.number",
 			String.valueOf(ReleaseInfo.getBuildNumber()));
 		_assertLogContextContains(
-			"upgrade.report.expectedPortalSchemaVersion",
+			"upgrade.report.portal.expected.schema.version",
 			latestSchemaVersion.toString());
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/log/UpgradeLogContext.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/log/UpgradeLogContext.java
@@ -111,6 +111,7 @@ public class UpgradeLogContext implements LogContext {
 		VerifyProperties.class.getName(),
 		"com.liferay.portal.upgrade.internal.registry." +
 			"UpgradeStepRegistratorTracker",
-		"com.liferay.portal.upgrade.internal.release.ReleaseManagerImpl");
+		"com.liferay.portal.upgrade.internal.release.ReleaseManagerImpl",
+		"com.liferay.portal.upgrade.internal.report.UpgradeReport");
 
 }


### PR DESCRIPTION
- LPS-158743 Marking the UpgradeReport class as an upgrade related class for the log context
- LPS-158743 Printing the upgrade report in the console as thread context information
- LPS-158743 Improving parseability of the upgrade report when printed as log context information
- LPS-158743 Adding filter to inject to make sure we are getting the right component
- LPS-158743 Adding integration tests to check the upgrade log context information
- LPS-158743 Fixing tests due to missing property setup
- LPS-158743 Improving the UpgradeReport code to make it much more easy to add new sections to it in the future and have less code
- LPS-158743 Changing tests to fit the new upgrade report format
- LPS-158743 Omit Upgrade as first word for every piece of info in the Upgrade Report
- LPS-158743 Simpler keys
- LPS-158743 Do not remove period for properties
- LPS-158743 Underline with the exact number of chars
- LPS-158743 Manual SF
- LPS-158743 Fixing tests due to changes in upgrade report format
- LPS-158743 Improving upgrade report readability
