### PR TITLE
LPS-173358 UserGroupRole, UserGroupGroupRole and Users_UserGroups db tables mismatch on upgraded database

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -264,6 +264,26 @@ public class PortalUpgradeProcessRegistryImpl
 		upgradeVersionTreeMap.put(
 			new Version(25, 2, 0),
 			new CTModelUpgradeProcess("LayoutPrototype"));
+
+		upgradeVersionTreeMap.put(
+			new Version(25, 3, 0),
+			UpgradeProcessFactory.alterColumnType(
+				"UserGroupGroupRole", "groupId", "LONG null"),
+			UpgradeProcessFactory.alterColumnType(
+				"UserGroupGroupRole", "roleId", "LONG null"),
+			UpgradeProcessFactory.alterColumnType(
+				"UserGroupGroupRole", "userGroupGroupRoleId", "LONG not null"),
+			UpgradeProcessFactory.alterColumnType(
+				"UserGroupGroupRole", "userGroupId", "LONG null"),
+			UpgradeProcessFactory.alterColumnType(
+				"UserGroupRole", "groupId", "LONG null"),
+			UpgradeProcessFactory.alterColumnType(
+				"UserGroupRole", "roleId", "LONG null"),
+			UpgradeProcessFactory.alterColumnType(
+				"UserGroupRole", "userGroupRoleId", "LONG not null"),
+			UpgradeProcessFactory.alterColumnType(
+				"UserGroupRole", "userId", "LONG null"),
+			new UpgradeUsersUserGroups());
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeUsersUserGroups.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeUsersUserGroups.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v7_4_x;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.ArrayUtil;
+
+import java.util.Arrays;
+
+/**
+ * @author Drew Brokke
+ */
+public class UpgradeUsersUserGroups extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		String[] expectedPrimaryKeyColumnNames = {
+			"userId", "userGroupId", "ctCollectionId"
+		};
+
+		if (Arrays.equals(
+				expectedPrimaryKeyColumnNames,
+				getPrimaryKeyColumnNames(connection, "Users_UserGroups"))) {
+
+			return;
+		}
+
+		removePrimaryKey("Users_UserGroups");
+
+		runSQL(
+			String.format(
+				"alter table Users_UserGroups add primary key (%s)",
+				ArrayUtil.toString(
+					expectedPrimaryKeyColumnNames, (String)null)));
+	}
+
+}


### PR DESCRIPTION
This is an update for [LPS-173358](https://issues.liferay.com/browse/LPS-173358).

@achaparro these two statements don't run because [this check fails](https://github.com/liferay/liferay-portal/blob/b62bdf4ca4f3e411e4c0626193687eeeb497e0e3/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java#L254):
- [PortalUpgradeProcessRegistryImpl.java#L274-L275](https://github.com/drewbrokke/liferay-portal/blob/e85d73375a8d91577e892e377798a8d81e42d09e/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java#L274-L275)
- [PortalUpgradeProcessRegistryImpl.java#L282-L283](https://github.com/drewbrokke/liferay-portal/blob/e85d73375a8d91577e892e377798a8d81e42d09e/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java#L282-L283)

/cc @pei-jung @ChrisKian @patriciajeanperez @david-truong @gislayne-vitorino