### PR TITLE
LPS-158743 Making it possible to generate the upgrade report in the standard log output as log context information

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -16591,9 +16591,9 @@ the-connection-could-not-be-verified-because-the-provided-credentials-are-incorr
 the-connection-id-cannot-be-changed=لا يمكن تغيير معرف الاتصال.
 the-connection-to-the-remote-live-asset-library-cannot-be-established-due-to-a-network-problem=يتعذر تأسيس الاتصال بمكتبة الأصول المباشرة البعيدة بسبب مشكلة في الشبكة.
 the-connection-to-the-remote-live-site-cannot-be-established-due-to-a-network-problem=يتعذر تأسيس الاتصال بالموقع المباشر البعيد بسبب مشكلة في الشبكة.
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} more translations already exist in other sites or asset libraries. (Automatic Copy)
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=عنوان URL المستخدم في {0} موجود بالفعل في مواقع أخرى أو مكتبات أصول.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=عنوان URL المستخدم في {0} و{1} موجود بالفعل في مواقع أخرى أو مكتبات أصول.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=عنوان URL المستخدم في {0} و{1} من الترجمات الأخرى موجود بالفعل في مواقع أخرى أو مكتبات أصول.
 the-content-is-not-valid=المحتوى غير صالح.
 the-content-references-a-missing-file-entry=يشير المحتوى إلى إدخال ملف مفقود.
 the-content-references-a-missing-page=يشير المحتوى إلى صفحة مفقودة.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -16593,9 +16593,9 @@ the-connection-could-not-be-verified-because-the-provided-credentials-are-incorr
 the-connection-id-cannot-be-changed=L'ID de connexió no és pot canviar.
 the-connection-to-the-remote-live-asset-library-cannot-be-established-due-to-a-network-problem=No es pot establir la connexió amb la biblioteca remota de continguts Live per un problema de xarxa.
 the-connection-to-the-remote-live-site-cannot-be-established-due-to-a-network-problem=No es pot establir la connexió amb el lloc en viu remot per un problema de xarxa.
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} more translations already exist in other sites or asset libraries. (Automatic Copy)
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=L'URL utilitzat a {0} ja existeix en altres llocs web o biblioteques de continguts.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=L'URL utilitzat a {0} i a {1} ja existeix en altres llocs web o biblioteques de continguts.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=L'URL utilitzat a {0} i en {1} traduccions més ja existeix en altres llocs web o biblioteques de continguts.
 the-content-is-not-valid=El contingut no és vàlid.
 the-content-references-a-missing-file-entry=El contingut fa referència a un fitxer que no existeix.
 the-content-references-a-missing-page=El contingut fa referencia a una pàgina que no existeix.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -16593,9 +16593,9 @@ the-connection-could-not-be-verified-because-the-provided-credentials-are-incorr
 the-connection-id-cannot-be-changed=Die Verbindungs-ID kann nicht geändert werden.
 the-connection-to-the-remote-live-asset-library-cannot-be-established-due-to-a-network-problem=Die Verbindung zur Remote-Live-Repository kann aufgrund eines Netzwerkproblems nicht hergestellt werden.
 the-connection-to-the-remote-live-site-cannot-be-established-due-to-a-network-problem=Die Verbindung zur Remote-Live-Site kann aufgrund eines Netzwerkproblems nicht hergestellt werden.
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} more translations already exist in other sites or asset libraries. (Automatic Copy)
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=Die in {0} verwendete URL existiert bereits in anderen Sites oder Asset-Bibliotheken.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=Die in {0} und {1} verwendete URL existiert bereits in anderen Sites oder Asset-Bibliotheken.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=Die in {0} und {1} verwendete URL und weitere Übersetzungen existieren bereits in anderen Sites oder Asset-Bibliotheken.
 the-content-is-not-valid=Der Inhalt ist nicht gültig.
 the-content-references-a-missing-file-entry=Der Inhalt referenziert eine fehlende Datei.
 the-content-references-a-missing-page=Der Inhalt referenziert eine fehlende Seite.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -16593,9 +16593,9 @@ the-connection-could-not-be-verified-because-the-provided-credentials-are-incorr
 the-connection-id-cannot-be-changed=No se puede cambiar el identificador de la conexión.
 the-connection-to-the-remote-live-asset-library-cannot-be-established-due-to-a-network-problem=No se puede establecer la conexión al repositorio Live remoto debido a un problema de red.
 the-connection-to-the-remote-live-site-cannot-be-established-due-to-a-network-problem=No se puede establecer la conexión con el sitio remoto de producción debido a un problema de red.
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} more translations already exist in other sites or asset libraries. (Automatic Copy)
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=La URL utilizada en {0} ya existe en otros repositorios o sitios.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=La URL utilizada en {0} y {1} ya existe en otros repositorios o sitios.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=La URL utilizada en {0} y {1} traducciones más ya existe en otros repositorios o sitios.
 the-content-is-not-valid=El contenido no es válido.
 the-content-references-a-missing-file-entry=Este contenido hace referencia a un archivo que no existe.
 the-content-references-a-missing-page=Este contenido hace referencia a una página que no existe.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -16589,9 +16589,9 @@ the-connection-could-not-be-verified-because-the-provided-credentials-are-incorr
 the-connection-id-cannot-be-changed=Yhteyden tunnistetta ei voi vaihtaa.
 the-connection-to-the-remote-live-asset-library-cannot-be-established-due-to-a-network-problem=Yhteyttä julkiseen etäresurssikirjastoon ei voida muodostaa verkko-ongelman takia.
 the-connection-to-the-remote-live-site-cannot-be-established-due-to-a-network-problem=Yhteyttä etä julkiseen-sivustoon ei voida muodostaa verkko-ongelman takia.
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} more translations already exist in other sites or asset libraries. (Automatic Copy)
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=Kohteessa {0} käytetty URL on jo olemassa muilla sivustoilla tai resurssikirjastoissa.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=Kohteissa {0} ja {1} käytetty URL on jo olemassa muilla sivustoilla tai resurssikirjastoissa.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=Kohteessa {0} käytetty URL ja {1} käänöstä lisää on jo olemassa muilla sivustoilla tai resurssikirjastoissa.
 the-content-is-not-valid=Sisältö ei ole kelvollinen
 the-content-references-a-missing-file-entry=Tämä sisältö viittaa puuttuvaan tiedostoon.
 the-content-references-a-missing-page=Tämä sisältö viittaa puuttuvaan sivuun.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -16593,9 +16593,9 @@ the-connection-could-not-be-verified-because-the-provided-credentials-are-incorr
 the-connection-id-cannot-be-changed=L'ID de connexion ne peut pas être modifié.
 the-connection-to-the-remote-live-asset-library-cannot-be-established-due-to-a-network-problem=La connexion à la bibliothèque de contenus en production distants ne peut pas être établie en raison d'un problème de réseau.
 the-connection-to-the-remote-live-site-cannot-be-established-due-to-a-network-problem=La connexion au site en production à distance ne peut être établie à cause d'un problème de réseau.
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} more translations already exist in other sites or asset libraries. (Automatic Copy)
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=L'URL utilisée dans {0} existe déjà dans d'autres sites ou dépôts.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=L'URL utilisée dans {0} et {1} existe déjà dans d'autres sites ou dépôts.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=L'URL utilisée dans {0} et {1} autres traductions existent déjà dans d'autres sites ou dépôts.
 the-content-is-not-valid=Le contenu n'est pas valide.
 the-content-references-a-missing-file-entry=Le contenu référence un entrée de fichier manquante.
 the-content-references-a-missing-page=Le contenu référence une page manquante.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -16594,9 +16594,9 @@ the-connection-could-not-be-verified-because-the-provided-credentials-are-incorr
 the-connection-id-cannot-be-changed=A kapcsolat azonosítója nem módosítható.
 the-connection-to-the-remote-live-asset-library-cannot-be-established-due-to-a-network-problem=Nem létesíthető kapcsolat a távoli élő adattárral hálózati probléma miatt.
 the-connection-to-the-remote-live-site-cannot-be-established-due-to-a-network-problem=Nem létesíthető kapcsolat a távoli élő oldallal hálózati probléma miatt.
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} more translations already exist in other sites or asset libraries. (Automatic Copy)
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=A {0} által használt URL-cím már létezik más webhelyeken vagy adattárakban.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=A {0} és {1} által használt URL-cím már létezik más webhelyeken vagy adattárakban.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=A {0} és további {1} fordítás által használt URL-cím már létezik más webhelyeken vagy adattárakban.
 the-content-is-not-valid=A tartalom nem érvényes.
 the-content-references-a-missing-file-entry=A tartalom egy hiányzó fájl bejegyzésre hivatkozik.
 the-content-references-a-missing-page=A tartalom egy hiányzó oldalra hivatkozik.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -16593,9 +16593,9 @@ the-connection-could-not-be-verified-because-the-provided-credentials-are-incorr
 the-connection-id-cannot-be-changed=接続IDは変更できません。
 the-connection-to-the-remote-live-asset-library-cannot-be-established-due-to-a-network-problem=ネットワークの問題により、リモート本番アセットライブラリへの接続を確立できません。
 the-connection-to-the-remote-live-site-cannot-be-established-due-to-a-network-problem=ネットワークの問題により、リモート本番サイトへの接続を確立できません。
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} more translations already exist in other sites or asset libraries. (Automatic Copy)
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries={0} で使用されている URL はすでに他のサイトまたはアセットライブラリに存在します。
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries={0} と {1} で使用されている URL はすでに他のサイトまたはアセットライブラリに存在します。
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries={0} とその他 {1} 件の翻訳で使用されている URL はすでに他のサイトまたはアセットライブラリに存在します。
 the-content-is-not-valid=コンテンツが無効です。
 the-content-references-a-missing-file-entry=コンテンツが存在しないエントリーを参照しています
 the-content-references-a-missing-page=コンテンツが存在しないページを参照しています

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -16594,9 +16594,9 @@ the-connection-could-not-be-verified-because-the-provided-credentials-are-incorr
 the-connection-id-cannot-be-changed=De verbindings-ID kan niet gewijzigd worden.
 the-connection-to-the-remote-live-asset-library-cannot-be-established-due-to-a-network-problem=De verbinding met de externe live assetbibliotheek kan niet worden vastgesteld door een netwerkprobleem.
 the-connection-to-the-remote-live-site-cannot-be-established-due-to-a-network-problem=De verbinding met de externe live site kan niet worden vastgesteld door een netwerkprobleem.
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} more translations already exist in other sites or asset libraries. (Automatic Copy)
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=De URL gebruikt in {0} bestaat al in andere sites of assetbibliotheken.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=De URL gebruikt in {0} en {1} bestaat al in andere sites of assetbibliotheken.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=De URL gebruikt in {0} en nog {1} vertalingen bestaat al in andere sites of assetbibliotheken.
 the-content-is-not-valid=De content is niet geldig.
 the-content-references-a-missing-file-entry=De inhoud verwijst naar een ontbrekende bestandsingang.
 the-content-references-a-missing-page=De inhoud verwijst naar een ontbrekende pagina.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -16591,9 +16591,9 @@ the-connection-could-not-be-verified-because-the-provided-credentials-are-incorr
 the-connection-id-cannot-be-changed=O ID de conexão não pode ser alterado.
 the-connection-to-the-remote-live-asset-library-cannot-be-established-due-to-a-network-problem=Não foi possível estabelecer uma conexão com a biblioteca de ativos dinâmicos remota devido a um problema de rede.
 the-connection-to-the-remote-live-site-cannot-be-established-due-to-a-network-problem=Não foi possível estabelecer uma conexão com o site live remoto devido a um problema de rede.
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} more translations already exist in other sites or asset libraries. (Automatic Copy)
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=O URL utilizado em {0} já existe em outros sites ou bibliotecas de conteúdo.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=O URL utilizado em {0} e {1} já existe em outros sites ou bibliotecas de conteúdo.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=O URL utilizado em {0} e {1} traduções a mais já existe em outros sites ou bibliotecas de conteúdo.
 the-content-is-not-valid=O conteúdo não é válido.
 the-content-references-a-missing-file-entry=Este conteúdo faz referência a um arquivo inexistente.
 the-content-references-a-missing-page=Este conteúdo faz referência a uma página inexistente.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -16591,9 +16591,9 @@ the-connection-could-not-be-verified-because-the-provided-credentials-are-incorr
 the-connection-id-cannot-be-changed=Anslutnings-ID kan inte ändras.
 the-connection-to-the-remote-live-asset-library-cannot-be-established-due-to-a-network-problem=Det går inte att skapa en anslutning till fjärrtillgångsbibliotek på grund av ett nätverksproblem.
 the-connection-to-the-remote-live-site-cannot-be-established-due-to-a-network-problem=Det går inte att skapa en anslutning till fjärr-livewebbplatsen på grund av ett nätverksproblem.
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} more translations already exist in other sites or asset libraries. (Automatic Copy)
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=URL som används i {0} finns redan på andra webbplatser eller tillgångsbibliotek.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=URL som används i {0} och {1} finns redan på andra webbplatser eller tillgångsbibliotek.
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=URL som används i {0} och {1} översättningar till finns redan på andra webbplatser eller tillgångsbibliotek.
 the-content-is-not-valid=Innehållet är inte giltigt.
 the-content-references-a-missing-file-entry=Innehållet refererar en filpost som saknas.
 the-content-references-a-missing-page=Innehållet refererar en sida som saknas.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -16593,9 +16593,9 @@ the-connection-could-not-be-verified-because-the-provided-credentials-are-incorr
 the-connection-id-cannot-be-changed=无法更改连接 ID。
 the-connection-to-the-remote-live-asset-library-cannot-be-established-due-to-a-network-problem=由于网络问题，无法与远程实时资产库建立连接。
 the-connection-to-the-remote-live-site-cannot-be-established-due-to-a-network-problem=由于网络问题，无法建立到远程活动站点的连接。
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} already exists in other sites or asset libraries. (Automatic Copy)
-the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries=The content has been published but might cause errors. The URL used in {0} and {1} more translations already exist in other sites or asset libraries. (Automatic Copy)
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries={0} 中使用的 URL 在其他站点或资产库中已存在。
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-already-exists-in-other-sites-or-asset-libraries={0} 和 {1} 中使用的 URL 在其他站点或资产库中已存在。
+the-content-has-been-published-but-might-cause-errors.-the-url-used-in-x-and-x-more-translations-already-exists-in-other-sites-or-asset-libraries={0} 和其他 {1} 个翻译中使用的 URL 在其他站点或资产库中已存在。
 the-content-is-not-valid=内容无效。
 the-content-references-a-missing-file-entry=内容引用了一个丢失的文件项。
 the-content-references-a-missing-page=内容引用一个丢失的页面。

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -432,7 +432,7 @@ public class UpgradeReport {
 		).put(
 			"database.version", _getDialectInfo()
 		).put(
-			"property", _getPropertiesInfo()
+			_PROPERTY_KEY, _getPropertiesInfo()
 		).put(
 			"document.library.storage.size", _getDLStorageInfoNew()
 		).put(
@@ -628,6 +628,11 @@ public class UpgradeReport {
 	}
 
 	private String _getUpgradeReportHeaderFromKey(String key) {
+		if (key.startsWith(_PROPERTY_KEY)) {
+			return StringUtil.replaceFirst(
+				StringUtil.upperCaseFirstLetter(key), '.', ' ');
+		}
+
 		return StringUtil.replace(
 			StringUtil.upperCaseFirstLetter(key), '.', ' ');
 	}
@@ -769,6 +774,8 @@ public class UpgradeReport {
 	};
 
 	private static final String _LOG_CONTEXT_PREFIX = "upgrade.report.";
+
+	private static final String _PROPERTY_KEY = "property";
 
 	private static final int _UPGRADE_PROCESSES_COUNT = 20;
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -430,22 +430,22 @@ public class UpgradeReport {
 		).put(
 			"portal", _getPortalVersionInfo()
 		).put(
-			"using.database", _getDialectInfo()
+			"database.version", _getDialectInfo()
 		).put(
-			"properties", _getPropertiesInfo()
+			"property", _getPropertiesInfo()
 		).put(
 			"document.library.storage.size", _getDLStorageInfoNew()
 		).put(
 			"tables.initial.final.rows", _getDatabaseTableCounts()
 		).put(
-			"longest.running.upgrade.processes",
+			"longest.upgrade.processes",
 			_getLongestRunningUpgradeProcessesList()
 		).put(
 			"errors", _getSortedLogEvents("errors")
 		).put(
 			"warnings", _getSortedLogEvents("warnings")
 		).put(
-			"release.osgi.info",
+			"osgi.status",
 			() -> {
 				if (releaseManagerOSGiCommands == null) {
 					return "Not possible to check upgrades status";

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -628,7 +628,8 @@ public class UpgradeReport {
 	}
 
 	private String _getUpgradeReportHeaderFromKey(String key) {
-		return "Upgrade " + StringUtil.replace(key, '.', ' ');
+		return StringUtil.replace(
+			StringUtil.upperCaseFirstLetter(key), '.', ' ');
 	}
 
 	private String _getUpgradeReportSimpleValueLine(String key, Object value) {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -672,7 +672,9 @@ public class UpgradeReport {
 				sb.append(_printContextMap(key, (Map<?, ?>)value));
 			}
 			else if (value instanceof List<?>) {
-				sb.append(_getUpgradeReportHeaderFromKey(key));
+				String header = _getUpgradeReportHeaderFromKey(key);
+
+				sb.append(header);
 
 				List<Object> elements = (List<Object>)value;
 
@@ -683,7 +685,10 @@ public class UpgradeReport {
 				else {
 					sb.append(StringPool.NEW_LINE);
 					sb.append(
-						"-------------------------------------------------");
+						ListUtil.toString(
+							Collections.nCopies(
+								header.length(), StringPool.MINUS),
+							StringPool.NULL, StringPool.BLANK));
 					sb.append(StringPool.NEW_LINE);
 
 					for (Object object : (List<Object>)value) {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -483,7 +483,7 @@ public class UpgradeReport {
 		).put(
 			"document.library.storage.size", _getDLStorageInfoNew()
 		).put(
-			"tables.initial.final.rows", _getDatabaseTableCounts()
+			_TABLES_KEY + ".initial.final.rows", _getDatabaseTableCounts()
 		).put(
 			"longest.upgrade.processes",
 			_getLongestRunningUpgradeProcessesList()
@@ -543,6 +543,11 @@ public class UpgradeReport {
 		if (key.startsWith(_PROPERTY_KEY)) {
 			return StringUtil.replaceFirst(
 				StringUtil.upperCaseFirstLetter(key), '.', ' ');
+		}
+
+		if (key.startsWith(_TABLES_KEY)) {
+			return String.format(
+				TableCounts.FORMAT, "Table name", "Initial rows", "Final rows");
 		}
 
 		return StringUtil.replace(
@@ -784,6 +789,8 @@ public class UpgradeReport {
 
 	private static final String _PROPERTY_KEY = "property";
 
+	private static final String _TABLES_KEY = "tables";
+
 	private static final int _UPGRADE_PROCESSES_COUNT = 20;
 
 	private static final Log _log = LogFactoryUtil.getLog(UpgradeReport.class);
@@ -886,6 +893,8 @@ public class UpgradeReport {
 
 	private class TableCounts {
 
+		public static final String FORMAT = "%-30s %20s %20s";
+
 		public TableCounts(
 			String tableName, String initialCount, String finalCount) {
 
@@ -902,10 +911,8 @@ public class UpgradeReport {
 					StringPool.COLON, _finalCount);
 			}
 
-			String format = "%-30s %20s %20s";
-
 			return String.format(
-				format, _tableName, _initialCount, _finalCount);
+				FORMAT, _tableName, _initialCount, _finalCount);
 		}
 
 		private final String _finalCount;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -61,6 +61,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.felix.cm.PersistenceManager;
+import org.apache.logging.log4j.ThreadContext;
 
 /**
  * @author Sam Ziemer
@@ -117,6 +118,18 @@ public class UpgradeReport {
 
 		_persistenceManager = persistenceManager;
 
+		String dateInfo = _getDateInfo();
+		String timeInfo = _getUpgradeTimeInfo();
+		String portalVersionsInfo = _getPortalVersionsInfo();
+		String dialectInfo = _getDialectInfo();
+		String propertiesInfo = _getPropertiesInfo();
+		String dlStorageInfo = _getDLStorageInfo();
+		String databaseTablesInfo = _getDatabaseTablesInfo();
+		String upgradeProcessesInfo = _getUpgradeProcessesInfo();
+		String errorLogEventsInfo = _getLogEventsInfo("errors");
+		String warningLogEventsInfo = _getLogEventsInfo("warnings");
+		String releaseManagerOSGiInfo = (releaseManagerOSGiCommands == null) ? StringPool.BLANK : releaseManagerOSGiCommands.check();
+
 		try {
 			File reportFile = _getReportFile();
 
@@ -124,15 +137,10 @@ public class UpgradeReport {
 				reportFile,
 				StringUtil.merge(
 					new String[] {
-						_getDateInfo(), _getUpgradeTimeInfo(),
-						_getPortalVersionsInfo(), _getDialectInfo(),
-						_getPropertiesInfo(), _getDLStorageInfo(),
-						_getDatabaseTablesInfo(), _getUpgradeProcessesInfo(),
-						_getLogEventsInfo("errors"),
-						_getLogEventsInfo("warnings"),
-						(releaseManagerOSGiCommands == null) ?
-							StringPool.BLANK :
-								releaseManagerOSGiCommands.check()
+						dateInfo, timeInfo, portalVersionsInfo, dialectInfo,
+						propertiesInfo, dlStorageInfo, databaseTablesInfo,
+						upgradeProcessesInfo, errorLogEventsInfo,
+						warningLogEventsInfo, releaseManagerOSGiInfo
 					},
 					StringPool.NEW_LINE + StringPool.NEW_LINE));
 
@@ -144,6 +152,26 @@ public class UpgradeReport {
 		}
 		catch (IOException ioException) {
 			_log.error("Unable to generate the upgrade report", ioException);
+		}
+
+		if (PropsValues.UPGRADE_LOG_CONTEXT_ENABLED) {
+			ThreadContext.put("upgrade.report.date", dateInfo);
+			ThreadContext.put("upgrade.report.time", timeInfo);
+			ThreadContext.put("upgrade.report.portalVersion", portalVersionsInfo);
+			ThreadContext.put("upgrade.report.dialect", dialectInfo);
+			ThreadContext.put("upgrade.report.properties", propertiesInfo);
+			ThreadContext.put("upgrade.report.dlstorage", dlStorageInfo);
+			ThreadContext.put("upgrade.report.databasetables", databaseTablesInfo);
+			ThreadContext.put("upgrade.report.upgradeprocesses", upgradeProcessesInfo);
+			ThreadContext.put("upgrade.report.errorlogevents", errorLogEventsInfo);
+			ThreadContext.put("upgrade.report.warninglogevents", warningLogEventsInfo);
+			ThreadContext.put("upgrade.report.releasemanagerOSGi", releaseManagerOSGiInfo);
+
+			if (_log.isInfoEnabled()) {
+				_log.info("Upgrade report generated");
+			}
+
+			ThreadContext.clearMap();
 		}
 	}
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -363,7 +363,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	private static final Pattern _pattern = Pattern.compile(
 		"(\\w+_?)\\s+(\\d+|-)\\s+(\\d+|-)\n");
 
-	@Inject
+	@Inject (filter = "appender.name=UpgradeReportLogAppender")
 	private Appender _appender;
 
 	@Inject

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -77,6 +77,10 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		ReflectionTestUtil.setFieldValue(
 			DBUpgrader.class, "_upgradeClient", _originalUpgradeClient);
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_LOG_CONTEXT_ENABLED",
+			_originalUpgradeLogContextEnabled);
 	}
 
 	@Before
@@ -418,6 +422,12 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		ReflectionTestUtil.setFieldValue(
 			DBUpgrader.class, "_upgradeClient", upgradeClient);
+
+		_originalUpgradeLogContextEnabled = ReflectionTestUtil.getFieldValue(
+			PropsValues.class, "UPGRADE_LOG_CONTEXT_ENABLED");
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_LOG_CONTEXT_ENABLED", true);
 	}
 
 	protected abstract String getFilePath();
@@ -520,6 +530,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	private static final Pattern _logContextDatabaseTablePattern =
 		Pattern.compile("(\\w+_?):(\\d+|-):(\\d+|-)");
 	private static boolean _originalUpgradeClient;
+	private static boolean _originalUpgradeLogContextEnabled;
 	private static final Pattern _pattern = Pattern.compile(
 		"(\\w+_?)\\s+(\\d+|-)\\s+(\\d+|-)\n");
 	private static UnsyncStringWriter _unsyncStringWriter;

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -196,6 +196,8 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 			}
 		}
 
+		Assert.assertTrue(table1Exists && table2Exists);
+
 		_assertLogContextContains(
 			"upgrade.report.tables.initial.final.rows",
 			"UpgradeReportTable1:0:1");
@@ -452,7 +454,9 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	private void _assertLogContextContains(String key, String testString) {
 		String values = _getLogContextKey(key);
 
-		Assert.assertTrue(values.contains(testString));
+		Assert.assertTrue(
+			StringUtil.containsIgnoreCase(
+				values, testString, StringPool.BLANK));
 	}
 
 	private void _assertReport(String testString) throws Exception {

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -233,7 +233,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				reportContent.indexOf(fasterUpgradeProcessName));
 
 		String upgradeProcesses = _getLogContextKey(
-			"upgrade.report.longest.running.upgrade.processes");
+			"upgrade.report.longest.upgrade.processes");
 
 		Assert.assertTrue(
 			upgradeProcesses.indexOf(slowerUpgradeProcessName) <
@@ -264,7 +264,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_assertLogContextContains("upgrade.report.warnings", "2:Warning");
 		_assertLogContextContains(
-			"upgrade.report.longest.running.upgrade.processes",
+			"upgrade.report.longest.upgrade.processes",
 			"com.liferay.portal.UpgradeTest:20401 ms");
 	}
 
@@ -296,7 +296,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				bundleSymbolicName, " from 0.0.1 to ", currentSchemaVersion));
 
 		_assertLogContextContains(
-			"upgrade.report.release.osgi.info",
+			"upgrade.report.osgi.status",
 			StringBundler.concat(
 				"There are upgrade processes available for ",
 				bundleSymbolicName, " from 0.0.1 to ", currentSchemaVersion));
@@ -308,15 +308,14 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_appender.stop();
 
-		_assertReport("Upgrade errors: Nothing registered");
-		_assertReport(
-			"Upgrade longest running upgrade processes: Nothing registered");
-		_assertReport("Upgrade warnings: Nothing registered");
+		_assertReport("Errors: Nothing registered");
+		_assertReport("Longest upgrade processes: Nothing registered");
+		_assertReport("Warnings: Nothing registered");
 
 		_assertLogContextContains("upgrade.report.warnings", "[]");
 		_assertLogContextContains("upgrade.report.errors", "[]");
 		_assertLogContextContains(
-			"upgrade.report.longest.running.upgrade.processes", "[]");
+			"upgrade.report.longest.upgrade.processes", "[]");
 	}
 
 	@Test
@@ -327,26 +326,25 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_assertReport(
 			StringBundler.concat(
-				"Upgrade properties liferay home: ", PropsValues.LIFERAY_HOME,
-				StringPool.NEW_LINE, "Upgrade properties locales: ",
+				"Property liferay.home: ", PropsValues.LIFERAY_HOME,
+				StringPool.NEW_LINE, "Property locales: ",
 				Arrays.toString(PropsValues.LOCALES), StringPool.NEW_LINE,
-				"Upgrade properties locales enabled: ",
+				"Property locales.enabled: ",
 				Arrays.toString(PropsValues.LOCALES_ENABLED),
-				StringPool.NEW_LINE, "Upgrade properties ",
-				StringUtil.replace(PropsKeys.DL_STORE_IMPL, '.', ' '),
+				StringPool.NEW_LINE, "Property ", PropsKeys.DL_STORE_IMPL,
 				StringPool.COLON, StringPool.SPACE, PropsValues.DL_STORE_IMPL,
 				StringPool.NEW_LINE));
 
 		_assertLogContextContains(
-			"upgrade.report.properties.liferay.home", PropsValues.LIFERAY_HOME);
+			"upgrade.report.property.liferay.home", PropsValues.LIFERAY_HOME);
 		_assertLogContextContains(
-			"upgrade.report.properties.locales",
+			"upgrade.report.property.locales",
 			Arrays.toString(PropsValues.LOCALES));
 		_assertLogContextContains(
-			"upgrade.report.properties.locales.enabled",
+			"upgrade.report.property.locales.enabled",
 			Arrays.toString(PropsValues.LOCALES_ENABLED));
 		_assertLogContextContains(
-			"upgrade.report.properties." + PropsKeys.DL_STORE_IMPL,
+			"upgrade.report.property." + PropsKeys.DL_STORE_IMPL,
 			PropsValues.DL_STORE_IMPL);
 	}
 
@@ -380,15 +378,13 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_assertReport(
 			StringBundler.concat(
-				"Upgrade portal initial build number: 7100\n",
-				"Upgrade portal initial schema version: 1.0.0\n",
-				"Upgrade portal final build number: ",
-				ReleaseInfo.getBuildNumber(), StringPool.NEW_LINE,
-				"Upgrade portal final schema version: ",
+				"Portal initial build number: 7100\n",
+				"Portal initial schema version: 1.0.0\n",
+				"Portal final build number: ", ReleaseInfo.getBuildNumber(),
+				StringPool.NEW_LINE, "Portal final schema version: ",
 				latestSchemaVersion.toString(), StringPool.NEW_LINE,
-				"Upgrade portal expected build number: ",
-				ReleaseInfo.getBuildNumber(), StringPool.NEW_LINE,
-				"Upgrade portal expected schema version: ",
+				"Portal expected build number: ", ReleaseInfo.getBuildNumber(),
+				StringPool.NEW_LINE, "Portal expected schema version: ",
 				latestSchemaVersion.toString(), StringPool.NEW_LINE));
 
 		_assertLogContextContains(

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -143,7 +143,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 		_assertDatabaseTablesAreSorted(matcher);
 
 		String databaseTables = _getLogContextKey(
-			"upgrade.report.databaseTables");
+			"upgrade.report.tables.initial.final.rows");
 
 		matcher = _logContextDatabaseTablePattern.matcher(databaseTables);
 
@@ -197,9 +197,11 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 		}
 
 		_assertLogContextContains(
-			"upgrade.report.databaseTables", "UpgradeReportTable1:0:1");
+			"upgrade.report.tables.initial.final.rows",
+			"UpgradeReportTable1:0:1");
 		_assertLogContextContains(
-			"upgrade.report.databaseTables", "UpgradeReportTable2:1:0");
+			"upgrade.report.tables.initial.final.rows",
+			"UpgradeReportTable2:1:0");
 	}
 
 	@Test
@@ -231,7 +233,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				reportContent.indexOf(fasterUpgradeProcessName));
 
 		String upgradeProcesses = _getLogContextKey(
-			"upgrade.report.longestUpgradeProcesses");
+			"upgrade.report.longest.running.upgrade.processes");
 
 		Assert.assertTrue(
 			upgradeProcesses.indexOf(slowerUpgradeProcessName) <
@@ -256,14 +258,13 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_appender.stop();
 
-		_assertReport("2 occurrences of the following warnings: Warning");
+		_assertReport("2 occurrences of the following event: Warning");
 		_assertReport(
 			"com.liferay.portal.UpgradeTest took 20401 ms to complete");
 
+		_assertLogContextContains("upgrade.report.warnings", "2:Warning");
 		_assertLogContextContains(
-			"upgrade.report.warningsLogEvents", "2:Warning");
-		_assertLogContextContains(
-			"upgrade.report.longestUpgradeProcesses",
+			"upgrade.report.longest.running.upgrade.processes",
 			"com.liferay.portal.UpgradeTest:20401 ms");
 	}
 
@@ -295,7 +296,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				bundleSymbolicName, " from 0.0.1 to ", currentSchemaVersion));
 
 		_assertLogContextContains(
-			"upgrade.report.releasemanagerOSGi",
+			"upgrade.report.release.osgi.info",
 			StringBundler.concat(
 				"There are upgrade processes available for ",
 				bundleSymbolicName, " from 0.0.1 to ", currentSchemaVersion));
@@ -307,19 +308,15 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_appender.stop();
 
-		_assertReport("No errors thrown during upgrade");
-		_assertReport("No upgrade processes registered");
-		_assertReport("No warnings thrown during upgrade");
+		_assertReport("Upgrade errors: Nothing registered");
+		_assertReport(
+			"Upgrade longest running upgrade processes: Nothing registered");
+		_assertReport("Upgrade warnings: Nothing registered");
 
+		_assertLogContextContains("upgrade.report.warnings", "[]");
+		_assertLogContextContains("upgrade.report.errors", "[]");
 		_assertLogContextContains(
-			"upgrade.report.warningsLogEvents",
-			"No warnings thrown during upgrade");
-		_assertLogContextContains(
-			"upgrade.report.errorsLogEvents",
-			"No errors thrown during upgrade");
-		_assertLogContextContains(
-			"upgrade.report.longestUpgradeProcesses",
-			"No upgrade processes registered");
+			"upgrade.report.longest.running.upgrade.processes", "[]");
 	}
 
 	@Test
@@ -330,14 +327,15 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_assertReport(
 			StringBundler.concat(
-				PropsKeys.LIFERAY_HOME, StringPool.EQUAL,
-				PropsValues.LIFERAY_HOME, StringPool.NEW_LINE,
-				PropsKeys.LOCALES, StringPool.EQUAL,
+				"Upgrade properties liferay home: ", PropsValues.LIFERAY_HOME,
+				StringPool.NEW_LINE, "Upgrade properties locales: ",
 				Arrays.toString(PropsValues.LOCALES), StringPool.NEW_LINE,
-				PropsKeys.LOCALES_ENABLED, StringPool.EQUAL,
+				"Upgrade properties locales enabled: ",
 				Arrays.toString(PropsValues.LOCALES_ENABLED),
-				StringPool.NEW_LINE, PropsKeys.DL_STORE_IMPL, StringPool.EQUAL,
-				PropsValues.DL_STORE_IMPL));
+				StringPool.NEW_LINE, "Upgrade properties ",
+				StringUtil.replace(PropsKeys.DL_STORE_IMPL, '.', ' '),
+				StringPool.COLON, StringPool.SPACE, PropsValues.DL_STORE_IMPL,
+				StringPool.NEW_LINE));
 
 		_assertLogContextContains(
 			"upgrade.report.properties.liferay.home", PropsValues.LIFERAY_HOME);
@@ -382,30 +380,32 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_assertReport(
 			StringBundler.concat(
-				"Initial portal build number: 7100\n",
-				"Initial portal schema version: 1.0.0\n",
-				"Final portal build number: ", ReleaseInfo.getBuildNumber(),
-				StringPool.NEW_LINE, "Final portal schema version: ",
+				"Upgrade portal initial build number: 7100\n",
+				"Upgrade portal initial schema version: 1.0.0\n",
+				"Upgrade portal final build number: ",
+				ReleaseInfo.getBuildNumber(), StringPool.NEW_LINE,
+				"Upgrade portal final schema version: ",
 				latestSchemaVersion.toString(), StringPool.NEW_LINE,
-				"Expected portal build number: ", ReleaseInfo.getBuildNumber(),
-				StringPool.NEW_LINE, "Expected portal schema version: ",
+				"Upgrade portal expected build number: ",
+				ReleaseInfo.getBuildNumber(), StringPool.NEW_LINE,
+				"Upgrade portal expected schema version: ",
 				latestSchemaVersion.toString(), StringPool.NEW_LINE));
 
 		_assertLogContextContains(
-			"upgrade.report.initialPortalBuildNumber", "7100");
+			"upgrade.report.portal.initial.build.number", "7100");
 		_assertLogContextContains(
-			"upgrade.report.initialPortalSchemaVersion", "1.0.0");
+			"upgrade.report.portal.initial.schema.version", "1.0.0");
 		_assertLogContextContains(
-			"upgrade.report.finalPortalBuildNumber",
+			"upgrade.report.portal.final.build.number",
 			String.valueOf(ReleaseInfo.getBuildNumber()));
 		_assertLogContextContains(
-			"upgrade.report.finalPortalSchemaVersion",
+			"upgrade.report.portal.final.schema.version",
 			latestSchemaVersion.toString());
 		_assertLogContextContains(
-			"upgrade.report.expectedPortalBuildNumber",
+			"upgrade.report.portal.expected.build.number",
 			String.valueOf(ReleaseInfo.getBuildNumber()));
 		_assertLogContextContains(
-			"upgrade.report.expectedPortalSchemaVersion",
+			"upgrade.report.portal.expected.schema.version",
 			latestSchemaVersion.toString());
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/log/UpgradeLogContext.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/log/UpgradeLogContext.java
@@ -111,6 +111,7 @@ public class UpgradeLogContext implements LogContext {
 		VerifyProperties.class.getName(),
 		"com.liferay.portal.upgrade.internal.registry." +
 			"UpgradeStepRegistratorTracker",
-		"com.liferay.portal.upgrade.internal.release.ReleaseManagerImpl");
+		"com.liferay.portal.upgrade.internal.release.ReleaseManagerImpl",
+		"com.liferay.portal.upgrade.internal.report.UpgradeReport");
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
@@ -25,7 +25,7 @@ definition {
 		}
 
 		task ("Read the intial portal build number") {
-			if (!(contains(${fileContent}, "Initial portal build number: 7413"))) {
+			if (!(contains(${fileContent}, "Portal initial build number: 7413"))) {
 				echo(${fileContent});
 
 				fail("Inital portal build number is not present in upgrade report.");
@@ -35,7 +35,7 @@ definition {
 		task ("Read the final portal build number") {
 			var finalBuildVersion = Upgrade.getBuildNumber();
 
-			if (!(contains(${fileContent}, "Final portal build number: ${finalBuildVersion}"))) {
+			if (!(contains(${fileContent}, "Portal final build number: ${finalBuildVersion}"))) {
 				echo(${fileContent});
 
 				fail("Final portal build number is not present in upgrade report.");
@@ -45,7 +45,7 @@ definition {
 		task ("Read the expected portal build number") {
 			var expectedBuildVersion = Upgrade.getBuildNumber();
 
-			if (!(contains(${fileContent}, "Expected portal build number: ${expectedBuildVersion}"))) {
+			if (!(contains(${fileContent}, "Portal expected build number: ${expectedBuildVersion}"))) {
 				echo(${fileContent});
 
 				fail("Expected portal build number is not present in upgrade report.");
@@ -70,7 +70,7 @@ definition {
 
 			var databaseVersion = PropsUtil.get("database.${databaseType}.version");
 
-			if (!(contains(${fileContent}, "Using ${databaseType} version ${databaseVersion}"))) {
+			if (!(contains(${fileContent}, "Database version: ${databaseType} ${databaseVersion}"))) {
 				echo(${fileContent});
 
 				fail("Database type and version is not present in upgrade report.");
@@ -88,7 +88,7 @@ definition {
 		}
 
 		task ("Read which Document Library Store is being used") {
-			if (!(contains(${fileContent}, "dl.store.impl=com.liferay.portal.store.file.system.FileSystemStore"))) {
+			if (!(contains(${fileContent}, "Property dl.store.impl: com.liferay.portal.store.file.system.FileSystemStore"))) {
 				echo(${fileContent});
 
 				fail("Document library store is not present in upgrade report.");
@@ -96,7 +96,7 @@ definition {
 		}
 
 		task ("Read the size of document library storage") {
-			if (!(contains(${fileContent}, "The document library storage size is 750.03 KB"))) {
+			if (!(contains(${fileContent}, "Document library storage size: 750.03 KB"))) {
 				echo(${fileContent});
 
 				fail("Size of document library storage is not present in upgrade report.");
@@ -116,18 +116,22 @@ definition {
 			var fileContent = FileUtil.read("${liferayHome}/tools/portal-tools-db-upgrade-client/reports/upgrade_report.info");
 		}
 
-		task ("Read the content. Error expected") {
-			if (!(contains(${fileContent}, "Errors thrown during upgrade process"))) {
+		task ("Read the content. Check for error class name and message") {
+			if (!(contains(${fileContent}, "Errors"))) {
+				echo(${fileContent});
+
 				fail("Upgrade report does not contain expected errors.");
 			}
-		}
 
-		task ("Read the content. Check for class name and message") {
 			if (!(contains(${fileContent}, "Class name: com.liferay.portal.tools.DBUpgrader"))) {
+				echo(${fileContent});
+
 				fail("Upgrade report does not contain the error class name.");
 			}
 
-			if (!(contains(${fileContent}, "1 occurrences of the following errors: Unknown column 'servletContextName' in 'where clause'"))) {
+			if (!(contains(${fileContent}, "1 occurrences of the following event: Unknown column 'servletContextName' in 'where clause'"))) {
+				echo(${fileContent});
+
 				fail("Upgrade report does not contain the error message.");
 			}
 		}
@@ -143,7 +147,7 @@ definition {
 		}
 
 		task ("Read the processes list message") {
-			if (!(contains(${fileContent}, "Top 20 longest running upgrade processes"))) {
+			if (!(contains(${fileContent}, "Longest upgrade processes"))) {
 				echo(${fileContent});
 
 				fail("List with the 20 longest upgrade processes not found.");
@@ -192,7 +196,7 @@ definition {
 		}
 
 		task ("Check the total runtime is present") {
-			if (!(contains(${reportFileContent}, "Upgrade completed in"))) {
+			if (!(contains(${reportFileContent}, "Execution time: "))) {
 				echo(${reportFileContent});
 
 				fail("Total runtime is not present in upgrade report.");
@@ -200,7 +204,7 @@ definition {
 		}
 
 		task ("Check the intial portal build number") {
-			if (!(contains(${reportFileContent}, "Initial portal build number:"))) {
+			if (!(contains(${reportFileContent}, "Portal initial build number:"))) {
 				echo(${reportFileContent});
 
 				fail("Inital portal build number is not present in upgrade report.");
@@ -208,7 +212,7 @@ definition {
 		}
 
 		task ("Check the final portal build number") {
-			if (!(contains(${reportFileContent}, "Final portal build number:"))) {
+			if (!(contains(${reportFileContent}, "Portal final build number:"))) {
 				echo(${reportFileContent});
 
 				fail("Final portal build number is not present in upgrade report.");
@@ -216,7 +220,7 @@ definition {
 		}
 
 		task ("Check the expected portal build number") {
-			if (!(contains(${reportFileContent}, "Expected portal build number:"))) {
+			if (!(contains(${reportFileContent}, "Portal expected build number:"))) {
 				echo(${reportFileContent});
 
 				fail("Expected portal build number is not present in upgrade report.");
@@ -224,7 +228,7 @@ definition {
 		}
 
 		task ("Check the intial schema version") {
-			if (!(contains(${reportFileContent}, "Initial portal schema version:"))) {
+			if (!(contains(${reportFileContent}, "Portal initial schema version:"))) {
 				echo(${reportFileContent});
 
 				fail("Inital schema version is not present in upgrade report.");
@@ -232,7 +236,7 @@ definition {
 		}
 
 		task ("check the final schema version") {
-			if (!(contains(${reportFileContent}, "Final portal schema version:"))) {
+			if (!(contains(${reportFileContent}, "Portal final schema version:"))) {
 				echo(${reportFileContent});
 
 				fail("Final schema version is not present in upgrade report.");
@@ -240,7 +244,7 @@ definition {
 		}
 
 		task ("Check the expected schema version") {
-			if (!(contains(${reportFileContent}, "Expected portal schema version:"))) {
+			if (!(contains(${reportFileContent}, "Portal expected schema version:"))) {
 				echo(${reportFileContent});
 
 				fail("Expected schema version is not present in upgrade report.");
@@ -252,7 +256,7 @@ definition {
 
 			var databaseVersion = PropsUtil.get("database.${databaseType}.version");
 
-			if (!(contains(${reportFileContent}, "Using ${databaseType} version ${databaseVersion}"))) {
+			if (!(contains(${reportFileContent}, "Database version: ${databaseType} ${databaseVersion}"))) {
 				echo(${reportFileContent});
 
 				fail("Database type and version is not present in upgrade report.");
@@ -260,7 +264,7 @@ definition {
 		}
 
 		task ("Check the Document Library Store is present") {
-			if (!(contains(${reportFileContent}, "dl.store.impl=com.liferay.portal.store.file.system.FileSystemStore"))) {
+			if (!(contains(${reportFileContent}, "Property dl.store.impl: com.liferay.portal.store.file.system.FileSystemStore"))) {
 				echo(${reportFileContent});
 
 				fail("Document library store is not present in upgrade report.");
@@ -268,7 +272,7 @@ definition {
 		}
 
 		task ("Check the size of document library storage is present") {
-			if (!(contains(${reportFileContent}, "The document library storage size is"))) {
+			if (!(contains(${reportFileContent}, "Document library storage size:"))) {
 				echo(${reportFileContent});
 
 				fail("Size of document library storage is not present in upgrade report.");
@@ -276,13 +280,13 @@ definition {
 		}
 
 		task ("Check the row counts references") {
-			if (!(contains(${reportFileContent}, "Rows (initial)"))) {
+			if (!(contains(${reportFileContent}, "Initial rows"))) {
 				echo(${reportFileContent});
 
 				fail("Initial rows numbers column not present in upgrade report.");
 			}
 
-			if (!(contains(${reportFileContent}, "Rows (final)"))) {
+			if (!(contains(${reportFileContent}, "Final rows"))) {
 				echo(${reportFileContent});
 
 				fail("Final rows numbers column not present in upgrade report.");
@@ -290,7 +294,7 @@ definition {
 		}
 
 		task ("Check the longest processes list is present") {
-			if (!(contains(${reportFileContent}, "Top 20 longest running upgrade processes"))) {
+			if (!(contains(${reportFileContent}, "Longest upgrade processes"))) {
 				echo(${reportFileContent});
 
 				fail("List with the 20 longest upgrade processes not found.");
@@ -298,13 +302,13 @@ definition {
 		}
 
 		task ("Check no errors are thrown") {
-			if (!(contains(${reportFileContent}, "No errors thrown during upgrade"))) {
+			if (!(contains(${reportFileContent}, "Errors: Nothing registered"))) {
 				fail("Upgrade report contains unexpected errors.");
 			}
 		}
 
 		task ("Check no warnings are thrown") {
-			if (!(contains(${reportFileContent}, "No warnings thrown during upgrade"))) {
+			if (!(contains(${reportFileContent}, "Warnings: Nothing registered"))) {
 				fail("Upgrade report contains unexpected warnings.");
 			}
 		}
@@ -320,7 +324,7 @@ definition {
 		}
 
 		task ("Read the new report. No upgrade processes are expected") {
-			if (!(contains(${upgradeReportNew}, "No upgrade processes registered"))) {
+			if (!(contains(${upgradeReportNew}, "Osgi status: There are no pending upgrades"))) {
 				echo(${upgradeReportNew});
 
 				fail("New upgrade report contains unexpected upgrades.");
@@ -359,7 +363,7 @@ definition {
 		}
 
 		task ("Read the report. All upgrade processes are expected") {
-			if (!(contains(${upgradeReportOriginal}, "Top 20 longest running upgrade processes:"))) {
+			if (!(contains(${upgradeReportOriginal}, "Longest upgrade processes"))) {
 				echo(${upgradeReportOriginal});
 
 				fail("Upgrade report does not contains expected upgrades.");
@@ -379,7 +383,7 @@ definition {
 		}
 
 		task ("Read the new report. No upgrade processes are expected") {
-			if (!(contains(${upgradeReportNew}, "No upgrade processes registered"))) {
+			if (!(contains(${upgradeReportNew}, "Osgi status: There are no pending upgrades"))) {
 				echo(${upgradeReportNew});
 
 				fail("New upgrade report contains unexpected upgrades.");
@@ -421,13 +425,13 @@ definition {
 		}
 
 		task ("Read the row counts references") {
-			if (!(contains(${fileContent}, "Rows (initial)"))) {
+			if (!(contains(${fileContent}, "Initial rows"))) {
 				echo(${fileContent});
 
 				fail("Initial rows numbers column not present in upgrade report.");
 			}
 
-			if (!(contains(${fileContent}, "Rows (final)"))) {
+			if (!(contains(${fileContent}, "Final rows"))) {
 				echo(${fileContent});
 
 				fail("Final rows numbers column not present in upgrade report.");
@@ -447,7 +451,7 @@ definition {
 		}
 
 		task ("Read the intial schema version") {
-			if (!(contains(${fileContent}, "Initial portal schema version: 13.1.1"))) {
+			if (!(contains(${fileContent}, "Portal initial schema version: 13.1.1"))) {
 				echo(${fileContent});
 
 				fail("Inital schema version is not present in upgrade report.");
@@ -457,7 +461,7 @@ definition {
 		task ("Read the final schema version") {
 			var finalSchemaVersion = Upgrade.getSchemaVersion(mysqlStatement = "SELECT schemaVersion FROM Release_ WHERE servletContextName='portal';");
 
-			if (!(contains(${fileContent}, "Final portal schema version: ${finalSchemaVersion}"))) {
+			if (!(contains(${fileContent}, "Portal final schema version: ${finalSchemaVersion}"))) {
 				echo(${fileContent});
 
 				fail("Final schema version is not present in upgrade report.");
@@ -467,7 +471,7 @@ definition {
 		task ("Read the expected schema version") {
 			var expectedSchemaVersion = Upgrade.getSchemaVersion(mysqlStatement = "SELECT schemaVersion FROM Release_ WHERE servletContextName='portal';");
 
-			if (!(contains(${fileContent}, "Expected portal schema version: ${expectedSchemaVersion}"))) {
+			if (!(contains(${fileContent}, "Portal expected schema version: ${expectedSchemaVersion}"))) {
 				echo(${fileContent});
 
 				fail("Expected schema version is not present in upgrade report.");
@@ -497,13 +501,13 @@ definition {
 		}
 
 		task ("Capture the upgrade runtime in upgrade Report") {
-			var upgradeRunTimeReport = RegexUtil.replace(${fileContentReport}, "Upgrade completed i\"?n \"?(.*[0-9])", 1);
+			var upgradeRunTimeReport = RegexUtil.replace(${fileContentReport}, "Execution time: (.*[0-9])", 1);
 
 			echo("Upgrade runtime reported by upgrade_report.info is ${upgradeRunTimeReport}");
 		}
 
 		task ("Read the total runtime to see if it's present") {
-			if (!(contains(${fileContentReport}, "Upgrade completed in ${upgradeRunTimeReport}"))) {
+			if (!(contains(${fileContentReport}, "Execution time: ${upgradeRunTimeReport}"))) {
 				echo(${fileContentReport});
 
 				fail("Total runtime is not present in upgrade report.");
@@ -511,7 +515,7 @@ definition {
 		}
 
 		task ("Read the total runtime comparing with the one got in the logs") {
-			if (!(contains(${fileContentReport}, "Upgrade completed in ${upgradeRunTimeLog}"))) {
+			if (!(contains(${fileContentReport}, "Execution time: ${upgradeRunTimeLog}"))) {
 				echo(${fileContentReport});
 
 				fail("Total runtime in upgrade report does not match the runtime in upgrade.log file.");
@@ -551,22 +555,20 @@ definition {
 			var fileContent = FileUtil.read("${liferayHome}/tools/portal-tools-db-upgrade-client/reports/upgrade_report.info");
 		}
 
-		task ("Read the content. Warnings expected") {
-			if (!(contains(${fileContent}, "Warnings thrown during upgrade process"))) {
+		task ("Read the content. Check for warning class name and message") {
+			if (!(contains(${fileContent}, "Warnings"))) {
 				echo(${fileContent});
 
 				fail("Upgrade report does not contain expected warnings.");
 			}
-		}
 
-		task ("Read the content. Check for class name and message") {
 			if (!(contains(${fileContent}, "Class name:"))) {
 				echo(${fileContent});
 
 				fail("Upgrade report does not contain the warning class name.");
 			}
 
-			if (!(contains(${fileContent}, "occurrences of the following warnings: "))) {
+			if (!(contains(${fileContent}, "1 occurrences of the following event: null"))) {
 				echo(${fileContent});
 
 				fail("Upgrade report does not contain the warning message.");


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-158743
- LPS-158743 Marking the UpgradeReport class as an upgrade related class for the log context
- LPS-158743 Printing the upgrade report in the console as thread context information
- LPS-158743 Improving parseability of the upgrade report when printed as log context information
- LPS-158743 Adding filter to inject to make sure we are getting the right component
- LPS-158743 Adding integration tests to check the upgrade log context information
- LPS-158743 Fixing tests due to missing property setup
- LPS-158743 Improving the UpgradeReport code to make it much more easy to add new sections to it in the future and have less code
- LPS-158743 Changing tests to fit the new upgrade report format
- LPS-158743 Omit Upgrade as first word for every piece of info in the Upgrade Report
- LPS-158743 Simpler keys
- LPS-158743 Do not remove period for properties
- LPS-158743 Underline with the exact number of chars
- LPS-158743 Manual SF
- LPS-158743 Fixing tests due to changes in upgrade report format
- LPS-158743 Improving upgrade report readability
- LPS-158743 Update upgrade report tests to fit new format