### PR TITLE
[SF] LPS-154671 Check for company iteration via SQL queries in upgrade processes

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/CompanyIterationCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/CompanyIterationCheck.java
@@ -14,8 +14,14 @@
 
 package com.liferay.source.formatter.checkstyle.check;
 
+import com.liferay.petra.string.StringBundler;
+
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author Hugo Huijser
@@ -24,7 +30,7 @@ public class CompanyIterationCheck extends BaseCheck {
 
 	@Override
 	public int[] getDefaultTokens() {
-		return new int[] {TokenTypes.LITERAL_FOR};
+		return new int[] {TokenTypes.LITERAL_FOR, TokenTypes.METHOD_DEF};
 	}
 
 	@Override
@@ -33,6 +39,23 @@ public class CompanyIterationCheck extends BaseCheck {
 
 		if (absolutePath.contains("com/liferay/portal/") &&
 			absolutePath.contains("/upgrade/")) {
+
+			return;
+		}
+
+		if (detailAST.getType() == TokenTypes.METHOD_DEF) {
+			List<String> importNames = getImportNames(detailAST);
+
+			if (importNames.contains("java.sql.PreparedStatement")) {
+				System.out.println(getAbsolutePath());
+
+				_checkMethodCalls(
+					detailAST, "connection", "callStatement",
+					"prepareStatement");
+				_checkMethodCalls(
+					detailAST, "AutoBatchPreparedStatementUtil", "autoBatch",
+					"concurrentAutoBatch");
+			}
 
 			return;
 		}
@@ -57,19 +80,74 @@ public class CompanyIterationCheck extends BaseCheck {
 
 		if (typeName.equals("Company")) {
 			log(
-				detailAST, _MSG_USE_COMPANY_LOCAL_SERVICE, "forEachCompany",
+				detailAST, _MSG_USE_COMPANY_LOCAL_SERVICE_1, "forEachCompany",
 				typeName + " " + variableName);
 		}
 		else if ((typeName.equals("Long") || typeName.equals("long")) &&
 				 variableName.equals("companyId")) {
 
 			log(
-				detailAST, _MSG_USE_COMPANY_LOCAL_SERVICE, "forEachCompanyId",
+				detailAST, _MSG_USE_COMPANY_LOCAL_SERVICE_1, "forEachCompanyId",
 				typeName + " " + variableName);
 		}
 	}
 
-	private static final String _MSG_USE_COMPANY_LOCAL_SERVICE =
-		"company.local.service.use";
+	private void _checkMethodCalls(
+		DetailAST detailAST, String className, String... methodNames) {
+
+		for (DetailAST methodCallDetailAST :
+				getMethodCalls(detailAST, className, methodNames)) {
+
+			DetailAST elistDetailAST = methodCallDetailAST.findFirstToken(
+				TokenTypes.ELIST);
+
+			for (DetailAST exprDetailAST :
+					getAllChildTokens(elistDetailAST, false, TokenTypes.EXPR)) {
+
+				String sqlQuery = _extractSQLQuery(exprDetailAST);
+
+				if (sqlQuery != null) {
+					Matcher matcher = _selectSQLPattern.matcher(sqlQuery);
+
+					if (matcher.find()) {
+						log(
+							methodCallDetailAST,
+							_MSG_USE_COMPANY_LOCAL_SERVICE_2);
+
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	private String _extractSQLQuery(DetailAST detailAST) {
+		List<DetailAST> stringLiteralDetailASTs = getAllChildTokens(
+			detailAST, true, TokenTypes.STRING_LITERAL);
+
+		if (stringLiteralDetailASTs.isEmpty()) {
+			return null;
+		}
+
+		StringBundler sb = new StringBundler(
+			(2 * stringLiteralDetailASTs.size()) - 1);
+
+		for (DetailAST stringLiteralDetailAST : stringLiteralDetailASTs) {
+			String stringLiteral = stringLiteralDetailAST.getText();
+
+			sb.append(stringLiteral.substring(1, stringLiteral.length() - 1));
+		}
+
+		return sb.toString();
+	}
+
+	private static final String _MSG_USE_COMPANY_LOCAL_SERVICE_1 =
+		"company.local.service.use.1";
+
+	private static final String _MSG_USE_COMPANY_LOCAL_SERVICE_2 =
+		"company.local.service.use.2";
+
+	private static final Pattern _selectSQLPattern = Pattern.compile(
+		"select\\s+.+\\s+from\\s+Company", Pattern.CASE_INSENSITIVE);
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/CompanyIterationCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/CompanyIterationCheck.java
@@ -15,6 +15,7 @@
 package com.liferay.source.formatter.checkstyle.check;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -129,13 +130,12 @@ public class CompanyIterationCheck extends BaseCheck {
 			return null;
 		}
 
-		StringBundler sb = new StringBundler(
-			(2 * stringLiteralDetailASTs.size()) - 1);
+		StringBundler sb = new StringBundler(stringLiteralDetailASTs.size());
 
 		for (DetailAST stringLiteralDetailAST : stringLiteralDetailASTs) {
 			String stringLiteral = stringLiteralDetailAST.getText();
 
-			sb.append(stringLiteral.substring(1, stringLiteral.length() - 1));
+			sb.append(StringUtil.unquote(stringLiteral));
 		}
 
 		return sb.toString();

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -273,7 +273,8 @@
 			<property name="category" value="Bug Prevention" />
 			<property name="description" value="Checks that `CompanyLocalService.forEachCompany` or `CompanyLocalService.forEachCompanyId` is used when iterating over companies" />
 			<property name="enabled" value="false" />
-			<message key="company.local.service.use" value="Use ''CompanyLocalService.{0}'' when iterating over ''{1}''" />
+			<message key="company.local.service.use.1" value="Use ''CompanyLocalService.{0}'' when iterating over ''{1}''" />
+			<message key="company.local.service.use.2" value="Do not use SQL to iterate over companies. Use ''CompanyLocalService.forEachCompany'' instead" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ComponentAnnotationCheck">
 			<property name="category" value="Bug Prevention" />

--- a/modules/util/source-formatter/src/main/resources/documentation/check/company_iteration_check.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/check/company_iteration_check.markdown
@@ -22,9 +22,8 @@ We should do:
 ```java
 _companyLocalService.forEachCompanyId(
 	companyId ->
-		_commerceAccountGroupLocalService.
-			checkGuestCommerceAccountGroup(companyId));
-	}
+	    _commerceAccountGroupLocalService.
+	        checkGuestCommerceAccountGroup(companyId));
 ```
 #### Example 2
 
@@ -43,4 +42,28 @@ public void cleanUp(String... companyIds) {
 	_companyLocalService.forEachCompanyId(
 		companyId -> _cleanUp(companyId), companyIds);
 }
+```
+
+This rule also applies to SQL queries.
+
+#### Example 1
+
+Instead of:
+```java
+try (PreparedStatement preparedStatement = connection.prepareStatement(
+	    "select companyId, userId, userName from Company")) {
+
+	    preparedStatement.executeQuery();
+}
+```
+
+We should do:
+```java
+_companyLocalService.forEachCompany(
+	company -> {
+		long companyId = company.getCompanyId();
+		String userName = company.getUserName();
+
+        ...
+	});
 ```


### PR DESCRIPTION
__Ticket:__ [LPS-154671](https://issues.liferay.com/browse/LPS-154671)

This pull request improves the SF rule `CompanyIterationCheck`. Previously, it only look through for-loops that would iterate over companies. With this pull request, the check can now check SQL queries that run `select` over the `Company` table.

Let me know if I need to make any changes.