### PR TITLE
LPS-171283 Default language applied when creating new virtual instance via api

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -1819,9 +1819,23 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		defaultUser.setPassword("password");
 		defaultUser.setScreenName(String.valueOf(defaultUser.getUserId()));
 		defaultUser.setEmailAddress("default@" + company.getMx());
-		defaultUser.setLanguageId(
-			LocaleUtil.toLanguageId(
-				LocaleUtil.fromLanguageId(PropsValues.COMPANY_DEFAULT_LOCALE)));
+
+		Locale locale = null;
+
+		if (Validator.isNotNull(PropsValues.COMPANY_DEFAULT_LOCALE)) {
+			locale = LocaleUtil.fromLanguageId(
+				PropsValues.COMPANY_DEFAULT_LOCALE);
+		}
+		else {
+			User defaultCompanyUser = _userLocalService.fetchDefaultUser(
+				PortalUtil.getDefaultCompanyId());
+
+			if (defaultCompanyUser != null) {
+				locale = defaultCompanyUser.getLocale();
+			}
+		}
+
+		defaultUser.setLanguageId(LocaleUtil.toLanguageId(locale));
 
 		if (Validator.isNotNull(PropsValues.COMPANY_DEFAULT_TIME_ZONE)) {
 			defaultUser.setTimeZoneId(PropsValues.COMPANY_DEFAULT_TIME_ZONE);

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -17,11 +17,18 @@ package com.liferay.portal.kernel.security.auth;
 import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.TimeZoneThreadLocal;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 
 import java.util.Locale;
 import java.util.TimeZone;
@@ -111,6 +118,50 @@ public class CompanyThreadLocal {
 		};
 	}
 
+	private static User _fetchDefaultUser(long companyId) throws Exception {
+		User defaultUser = null;
+
+		try {
+			defaultUser = UserLocalServiceUtil.fetchDefaultUser(companyId);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+
+		if (defaultUser != null) {
+			return defaultUser;
+		}
+
+		try (Connection connection = DataAccess.getConnection()) {
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						"select userId, languageId, timeZoneId from User_ " +
+							"where companyId = ? and defaultUser = ?")) {
+
+				preparedStatement.setLong(1, companyId);
+				preparedStatement.setBoolean(2, true);
+
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					if (!resultSet.next()) {
+						return null;
+					}
+
+					defaultUser = UserLocalServiceUtil.createUser(
+						resultSet.getLong("userId"));
+
+					defaultUser.setLanguageId(
+						resultSet.getString("languageId"));
+					defaultUser.setTimeZoneId(
+						resultSet.getString("timeZoneId"));
+				}
+			}
+		}
+
+		return defaultUser;
+	}
+
 	private static boolean _setCompanyId(Long companyId) {
 		if (companyId.equals(_companyId.get())) {
 			return false;
@@ -127,13 +178,33 @@ public class CompanyThreadLocal {
 
 		if (companyId > 0) {
 			_companyId.set(companyId);
+
+			try {
+				User defaultUser = _fetchDefaultUser(companyId);
+
+				if (defaultUser == null) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							"No default user was found for company " +
+								companyId);
+					}
+				}
+				else {
+					LocaleThreadLocal.setDefaultLocale(defaultUser.getLocale());
+					TimeZoneThreadLocal.setDefaultTimeZone(
+						defaultUser.getTimeZone());
+				}
+			}
+			catch (Exception exception) {
+				_log.error(exception);
+			}
 		}
 		else {
 			_companyId.set(CompanyConstants.SYSTEM);
-		}
 
-		LocaleThreadLocal.setDefaultLocale(null);
-		TimeZoneThreadLocal.setDefaultTimeZone(null);
+			LocaleThreadLocal.setDefaultLocale(null);
+			TimeZoneThreadLocal.setDefaultTimeZone(null);
+		}
 
 		return true;
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/LocaleThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/LocaleThreadLocal.java
@@ -15,10 +15,6 @@
 package com.liferay.portal.kernel.util;
 
 import com.liferay.petra.lang.CentralizedThreadLocal;
-import com.liferay.portal.kernel.model.CompanyConstants;
-import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 
 import java.util.Locale;
 
@@ -28,17 +24,6 @@ import java.util.Locale;
 public class LocaleThreadLocal {
 
 	public static Locale getDefaultLocale() {
-		if ((_defaultLocale.get() == null) &&
-			(CompanyThreadLocal.getCompanyId() != CompanyConstants.SYSTEM)) {
-
-			User defaultUser = UserLocalServiceUtil.fetchDefaultUser(
-				CompanyThreadLocal.getCompanyId());
-
-			if (defaultUser != null) {
-				_defaultLocale.set(defaultUser.getLocale());
-			}
-		}
-
 		return _defaultLocale.get();
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/TimeZoneThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TimeZoneThreadLocal.java
@@ -15,10 +15,6 @@
 package com.liferay.portal.kernel.util;
 
 import com.liferay.petra.lang.CentralizedThreadLocal;
-import com.liferay.portal.kernel.model.CompanyConstants;
-import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 
 import java.util.TimeZone;
 
@@ -28,17 +24,6 @@ import java.util.TimeZone;
 public class TimeZoneThreadLocal {
 
 	public static TimeZone getDefaultTimeZone() {
-		if ((_defaultTimeZone.get() == null) &&
-			(CompanyThreadLocal.getCompanyId() != CompanyConstants.SYSTEM)) {
-
-			User defaultUser = UserLocalServiceUtil.fetchDefaultUser(
-				CompanyThreadLocal.getCompanyId());
-
-			if (defaultUser != null) {
-				_defaultTimeZone.set(defaultUser.getTimeZone());
-			}
-		}
-
 		return _defaultTimeZone.get();
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/locale/Locale.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/locale/Locale.testcase
@@ -735,7 +735,7 @@ definition {
 
 	@priority = 5
 	test ViewLocaleInNewVirtualInstance {
-		property portal.acceptance = "true";
+		property portal.acceptance = "LPS-171283";
 		property test.assert.warning.exceptions = "true";
 		property test.name.skip.portal.instance = "Locale#ViewLocaleInNewVirtualInstance";
 

--- a/test.properties
+++ b/test.properties
@@ -1162,7 +1162,7 @@
     test.batch.minimum.slave.ram[*redhat9*]=24
     test.batch.minimum.slave.ram[*rockylinux*]=24
 
-    test.batch.names=${test.batch.names[acceptance-dxp]}
+    test.batch.names=functional-tomcat90-mysql57-jdk8
 
     test.batch.names[subrepository-validation]=\
         central-requirements-jdk8,\
@@ -2133,7 +2133,7 @@
             (database.types == null) OR \
             (database.types ~ mysql)\
         ) AND \
-        (portal.acceptance == true)
+        (portal.acceptance == LPS-171283)
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8_redhat]=\
         (\


### PR DESCRIPTION
- LPS-171283 Default language applied when creating new virtual instance via api
- LPS-171283 DO NOT MERGE Only run failing test
- Revert "LPS-171011 Lazy approach to simplify the CompanyThreadLocal logic and avoid errors and warnings while creating a company and accessing to the CompanyThreadLocal from a different thread. This also improves the performance since CompanyThreadLocal is much more used than Locale and TimeZone ThreadLocal and getDefaultUser method uses a local(but cluster sync) map to retrive the defaultUser."
