### PR TITLE
[TS]LPS-174140 Upgrade process is never executed in WEB module if the portal was first started without upgrade.database.auto.run=true

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistratorTracker.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistratorTracker.java
@@ -35,6 +35,8 @@ import com.liferay.portal.util.PropsValues;
 
 import java.io.OutputStream;
 
+import java.sql.SQLException;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -177,8 +179,14 @@ public class UpgradeStepRegistratorTracker {
 					bundleSymbolicName, releaseUpgradeSteps);
 			}
 
-			List<UpgradeInfo> upgradeInfos =
-				upgradeStepRegistry.getUpgradeInfos();
+			List<UpgradeInfo> upgradeInfos = null;
+
+			try {
+				upgradeInfos = upgradeStepRegistry.getUpgradeInfos();
+			}
+			catch (SQLException sqlException) {
+				throw new RuntimeException(sqlException);
+			}
 
 			if (PropsValues.UPGRADE_DATABASE_AUTO_RUN ||
 				(_releaseLocalService.fetchRelease(bundleSymbolicName) ==

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistry.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistry.java
@@ -19,7 +19,11 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import java.sql.Connection;
+import java.sql.SQLException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,8 +45,10 @@ public class UpgradeStepRegistry implements UpgradeStepRegistrator.Registry {
 		return _releaseCreationUpgradeSteps;
 	}
 
-	public List<UpgradeInfo> getUpgradeInfos() {
-		if (_initialization) {
+	public List<UpgradeInfo> getUpgradeInfos() throws SQLException {
+		if (_initialization &&
+			PortalUpgradeProcess.isInLatestSchemaVersion(_connection)) {
+
 			if (_upgradeInfos.isEmpty()) {
 				return Arrays.asList(
 					new UpgradeInfo(
@@ -155,6 +161,8 @@ public class UpgradeStepRegistry implements UpgradeStepRegistrator.Registry {
 
 		return finalSchemaVersion.toString();
 	}
+
+	private static Connection _connection;
 
 	private final int _buildNumber;
 	private boolean _initialization;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistry.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistry.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.upgrade.internal.registry;
 
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
@@ -46,25 +47,24 @@ public class UpgradeStepRegistry implements UpgradeStepRegistrator.Registry {
 	}
 
 	public List<UpgradeInfo> getUpgradeInfos() throws SQLException {
-		if (_initialization &&
-			PortalUpgradeProcess.isInLatestSchemaVersion(_connection)) {
-
-			if (_upgradeInfos.isEmpty()) {
-				return Arrays.asList(
-					new UpgradeInfo(
-						"0.0.0", "1.0.0", _buildNumber,
-						new DummyUpgradeStep()));
+		try (Connection connection = DataAccess.getConnection()) {
+			if (_initialization &&
+				PortalUpgradeProcess.isInLatestSchemaVersion(connection)) {
+				if (_upgradeInfos.isEmpty()) {
+					return Arrays.asList(
+						new UpgradeInfo(
+							"0.0.0", "1.0.0", _buildNumber,
+							new DummyUpgradeStep()));
+				}
+				return ListUtil.concat(
+					Arrays.asList(
+						new UpgradeInfo(
+							"0.0.0", _getFinalSchemaVersion(_upgradeInfos),
+							_buildNumber, new DummyUpgradeStep())),
+					_upgradeInfos);
 			}
-
-			return ListUtil.concat(
-				Arrays.asList(
-					new UpgradeInfo(
-						"0.0.0", _getFinalSchemaVersion(_upgradeInfos),
-						_buildNumber, new DummyUpgradeStep())),
-				_upgradeInfos);
+			return _upgradeInfos;
 		}
-
-		return _upgradeInfos;
 	}
 
 	@Override
@@ -161,8 +161,6 @@ public class UpgradeStepRegistry implements UpgradeStepRegistrator.Registry {
 
 		return finalSchemaVersion.toString();
 	}
-
-	private static Connection _connection;
 
 	private final int _buildNumber;
 	private boolean _initialization;

--- a/modules/apps/portal/portal-upgrade-impl/src/test/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistryTest.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/test/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistryTest.java
@@ -20,6 +20,8 @@ import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import java.sql.SQLException;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -41,7 +43,7 @@ public class UpgradeStepRegistryTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	public void testCreateUpgradeInfos() {
+	public void testCreateUpgradeInfos() throws SQLException {
 		UpgradeStepRegistry upgradeStepRegistry = new UpgradeStepRegistry(0);
 
 		TestUpgradeStep testUpgradeStep = new TestUpgradeStep();
@@ -70,7 +72,7 @@ public class UpgradeStepRegistryTest {
 	}
 
 	@Test
-	public void testCreateUpgradeInfosWithNoSteps() {
+	public void testCreateUpgradeInfosWithNoSteps() throws SQLException {
 		UpgradeStepRegistry upgradeStepRegistry = new UpgradeStepRegistry(0);
 
 		upgradeStepRegistry.register("0.0.0", "1.0.0");
@@ -81,7 +83,7 @@ public class UpgradeStepRegistryTest {
 	}
 
 	@Test
-	public void testCreateUpgradeInfosWithOneStep() {
+	public void testCreateUpgradeInfosWithOneStep() throws SQLException {
 		UpgradeStepRegistry upgradeStepRegistry = new UpgradeStepRegistry(0);
 
 		TestUpgradeStep testUpgradeStep = new TestUpgradeStep();
@@ -97,28 +99,32 @@ public class UpgradeStepRegistryTest {
 	}
 
 	@Test
-	public void testCreateUpgradeInfosWithPostUpgradeSteps() {
+	public void testCreateUpgradeInfosWithPostUpgradeSteps()
+		throws SQLException {
 		_registerAndCheckPreAndPostUpgradeSteps(
 			new UpgradeStep[0],
 			new UpgradeStep[] {new TestUpgradeStep(), new TestUpgradeStep()});
 	}
 
 	@Test
-	public void testCreateUpgradeInfosWithPreAndPostUpgradeSteps() {
+	public void testCreateUpgradeInfosWithPreAndPostUpgradeSteps()
+		throws SQLException {
 		_registerAndCheckPreAndPostUpgradeSteps(
 			new UpgradeStep[] {new TestUpgradeStep()},
 			new UpgradeStep[] {new TestUpgradeStep()});
 	}
 
 	@Test
-	public void testCreateUpgradeInfosWithPreUpgradeSteps() {
+	public void testCreateUpgradeInfosWithPreUpgradeSteps()
+		throws SQLException {
 		_registerAndCheckPreAndPostUpgradeSteps(
 			new UpgradeStep[] {new TestUpgradeStep(), new TestUpgradeStep()},
 			new UpgradeStep[0]);
 	}
 
 	private void _registerAndCheckPreAndPostUpgradeSteps(
-		UpgradeStep[] preUpgradeSteps, UpgradeStep[] postUpgradeSteps) {
+			UpgradeStep[] preUpgradeSteps, UpgradeStep[] postUpgradeSteps)
+		throws SQLException {
 
 		UpgradeProcess upgradeProcess = new UpgradeProcess() {
 

--- a/modules/apps/portal/portal-upgrade-impl/src/test/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistryTest.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/test/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistryTest.java
@@ -101,6 +101,7 @@ public class UpgradeStepRegistryTest {
 	@Test
 	public void testCreateUpgradeInfosWithPostUpgradeSteps()
 		throws SQLException {
+
 		_registerAndCheckPreAndPostUpgradeSteps(
 			new UpgradeStep[0],
 			new UpgradeStep[] {new TestUpgradeStep(), new TestUpgradeStep()});
@@ -109,6 +110,7 @@ public class UpgradeStepRegistryTest {
 	@Test
 	public void testCreateUpgradeInfosWithPreAndPostUpgradeSteps()
 		throws SQLException {
+
 		_registerAndCheckPreAndPostUpgradeSteps(
 			new UpgradeStep[] {new TestUpgradeStep()},
 			new UpgradeStep[] {new TestUpgradeStep()});
@@ -117,6 +119,7 @@ public class UpgradeStepRegistryTest {
 	@Test
 	public void testCreateUpgradeInfosWithPreUpgradeSteps()
 		throws SQLException {
+
 		_registerAndCheckPreAndPostUpgradeSteps(
 			new UpgradeStep[] {new TestUpgradeStep(), new TestUpgradeStep()},
 			new UpgradeStep[0]);


### PR DESCRIPTION
Ticket:
[LPS-174140](https://issues.liferay.com/browse/LPS-174140)

Issue:
Upgrade process is never executed in WEB module if the portal was first started without upgrade.database.auto.run=true.  We have a schema version check during startup, but since we only check for major and minor versions, databases with the same major and minor will still startup causing entries to be created in the release_ tables which then prevents the module from being upgraded if a user decides to upgrade.  

Solution:
Check for the micro version when getting UpgradeInfos to prevent creating entries in the release_ table for modules that did not exist in the previous Update. 


