### PR TITLE
LPS-171387 Provide upgrade status and type during and after upgrade execution

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/build.gradle
+++ b/modules/apps/portal/portal-upgrade-impl/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:gogo-shell:gogo-shell-logging")
+	compileOnly project(":apps:portal-osgi-debug:portal-osgi-debug-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/DBUpgradeCheckerImpl.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/DBUpgradeCheckerImpl.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.internal;
+
+import com.liferay.portal.kernel.upgrade.util.DBUpgradeChecker;
+import com.liferay.portal.osgi.debug.SystemChecker;
+import com.liferay.portal.upgrade.internal.release.osgi.commands.ReleaseManagerOSGiCommands;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Luis Ortiz
+ */
+@Component(service = {DBUpgradeChecker.class, DBUpgradeCheckerImpl.class})
+public class DBUpgradeCheckerImpl implements DBUpgradeChecker {
+
+	@Override
+	public boolean check() {
+		String check = _releaseManagerOSGiCommands.check();
+
+		if (!check.isEmpty()) {
+			return false;
+		}
+
+		check = _systemChecker.check();
+
+		if (check.contains("UpgradeStepRegistrator")) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Reference
+	private volatile ReleaseManagerOSGiCommands _releaseManagerOSGiCommands;
+
+	@Reference(
+		target = "(component.name=com.liferay.portal.osgi.debug.declarative.service.internal.DeclarativeServiceUnsatisfiedComponentSystemChecker)"
+	)
+	private volatile SystemChecker _systemChecker;
+
+}

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeLogAppender.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeLogAppender.java
@@ -16,6 +16,7 @@ package com.liferay.portal.upgrade.internal.apache.logging.log4j.core;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.upgrade.util.DBUpgradeChecker;
 import com.liferay.portal.upgrade.internal.release.osgi.commands.ReleaseManagerOSGiCommands;
 import com.liferay.portal.upgrade.internal.report.UpgradeReport;
 import com.liferay.portal.upgrade.util.DBUpgradeStatus;
@@ -126,6 +127,8 @@ public class UpgradeLogAppender implements Appender {
 	public void start() {
 		_started = true;
 
+		DBUpgradeStatus.upgradeStarted();
+
 		if (PropsValues.UPGRADE_REPORT_ENABLED) {
 			_upgradeReport = new UpgradeReport();
 		}
@@ -136,7 +139,7 @@ public class UpgradeLogAppender implements Appender {
 	@Override
 	public void stop() {
 		if (_started) {
-			DBUpgradeStatus.upgradeFinished();
+			DBUpgradeStatus.upgradeFinished(_dbUpgradeChecker);
 
 			if (_upgradeReport != null) {
 				_upgradeReport.generateReport(
@@ -151,6 +154,9 @@ public class UpgradeLogAppender implements Appender {
 
 	private static final Logger _rootLogger =
 		(Logger)LogManager.getRootLogger();
+
+	@Reference(cardinality = ReferenceCardinality.OPTIONAL)
+	private volatile DBUpgradeChecker _dbUpgradeChecker;
 
 	@Reference
 	private PersistenceManager _persistenceManager;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeLogAppender.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeLogAppender.java
@@ -43,10 +43,10 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
  * @author Sam Ziemer
  */
 @Component(
-	immediate = true, property = "appender.name=UpgradeReportLogAppender",
+	immediate = true, property = "appender.name=UpgradeLogAppender",
 	service = Appender.class
 )
-public class UpgradeReportLogAppender implements Appender {
+public class UpgradeLogAppender implements Appender {
 
 	@Override
 	public void append(LogEvent logEvent) {
@@ -91,7 +91,7 @@ public class UpgradeReportLogAppender implements Appender {
 
 	@Override
 	public String getName() {
-		return "UpgradeReportLogAppender";
+		return "UpgradeLogAppender";
 	}
 
 	@Override

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeLogAppender.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeLogAppender.java
@@ -127,7 +127,7 @@ public class UpgradeLogAppender implements Appender {
 	public void start() {
 		_started = true;
 
-		DBUpgradeStatus.upgradeStarted();
+		DBUpgradeStatus.start();
 
 		if (PropsValues.UPGRADE_REPORT_ENABLED) {
 			_upgradeReport = new UpgradeReport();
@@ -139,7 +139,7 @@ public class UpgradeLogAppender implements Appender {
 	@Override
 	public void stop() {
 		if (_started) {
-			DBUpgradeStatus.upgradeFinished(_dbUpgradeChecker);
+			DBUpgradeStatus.finish(_dbUpgradeChecker);
 
 			if (_upgradeReport != null) {
 				_upgradeReport.generateReport(

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeReportLogAppender.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeReportLogAppender.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.upgrade.internal.release.osgi.commands.ReleaseManagerOSGiCommands;
 import com.liferay.portal.upgrade.internal.report.UpgradeReport;
 import com.liferay.portal.upgrade.util.DBUpgradeStatus;
+import com.liferay.portal.util.PropsValues;
 
 import java.io.Serializable;
 
@@ -125,7 +126,9 @@ public class UpgradeReportLogAppender implements Appender {
 	public void start() {
 		_started = true;
 
-		_upgradeReport = new UpgradeReport();
+		if (PropsValues.UPGRADE_REPORT_ENABLED) {
+			_upgradeReport = new UpgradeReport();
+		}
 
 		_rootLogger.addAppender(this);
 	}
@@ -135,10 +138,12 @@ public class UpgradeReportLogAppender implements Appender {
 		if (_started) {
 			DBUpgradeStatus.upgradeFinished();
 
-			_upgradeReport.generateReport(
-				_persistenceManager, _releaseManagerOSGiCommands);
+			if (_upgradeReport != null) {
+				_upgradeReport.generateReport(
+					_persistenceManager, _releaseManagerOSGiCommands);
 
-			_upgradeReport = null;
+				_upgradeReport = null;
+			}
 		}
 
 		_started = false;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeReportLogAppender.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeReportLogAppender.java
@@ -18,6 +18,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.upgrade.internal.release.osgi.commands.ReleaseManagerOSGiCommands;
 import com.liferay.portal.upgrade.internal.report.UpgradeReport;
+import com.liferay.portal.upgrade.util.DBUpgradeStatus;
 
 import java.io.Serializable;
 
@@ -59,7 +60,7 @@ public class UpgradeReportLogAppender implements Appender {
 		}
 
 		if (logEvent.getLevel() == Level.ERROR) {
-			_upgradeReport.addErrorMessage(
+			DBUpgradeStatus.addErrorMessage(
 				logEvent.getLoggerName(), formattedMessage);
 		}
 		else if (logEvent.getLevel() == Level.INFO) {
@@ -67,12 +68,12 @@ public class UpgradeReportLogAppender implements Appender {
 					logEvent.getLoggerName(), UpgradeProcess.class.getName()) &&
 				formattedMessage.startsWith("Completed upgrade process ")) {
 
-				_upgradeReport.addEventMessage(
+				DBUpgradeStatus.addUpgradeProcessMessage(
 					logEvent.getLoggerName(), formattedMessage);
 			}
 		}
 		else if (logEvent.getLevel() == Level.WARN) {
-			_upgradeReport.addWarningMessage(
+			DBUpgradeStatus.addWarningMessage(
 				logEvent.getLoggerName(), message.getFormattedMessage());
 		}
 	}
@@ -132,6 +133,8 @@ public class UpgradeReportLogAppender implements Appender {
 	@Override
 	public void stop() {
 		if (_started) {
+			DBUpgradeStatus.upgradeFinished();
+
 			_upgradeReport.generateReport(
 				_persistenceManager, _releaseManagerOSGiCommands);
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -432,7 +432,7 @@ public class UpgradeReport {
 		).put(
 			"database.version", _getDialectInfo()
 		).put(
-			"property", _getPropertiesInfo()
+			_PROPERTY_KEY, _getPropertiesInfo()
 		).put(
 			"document.library.storage.size", _getDLStorageInfoNew()
 		).put(
@@ -628,6 +628,11 @@ public class UpgradeReport {
 	}
 
 	private String _getUpgradeReportHeaderFromKey(String key) {
+		if (key.startsWith(_PROPERTY_KEY)) {
+			return StringUtil.replaceFirst(
+				StringUtil.upperCaseFirstLetter(key), '.', ' ');
+		}
+
 		return StringUtil.replace(
 			StringUtil.upperCaseFirstLetter(key), '.', ' ');
 	}
@@ -769,6 +774,8 @@ public class UpgradeReport {
 	};
 
 	private static final String _LOG_CONTEXT_PREFIX = "upgrade.report.";
+
+	private static final String _PROPERTY_KEY = "property";
 
 	private static final int _UPGRADE_PROCESSES_COUNT = 20;
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -393,13 +393,28 @@ public class UpgradeReport {
 
 	private Map<String, String> _getPortalVersionInfo() {
 		return LinkedHashMapBuilder.put(
-			"initial.build.number",
-			(_initialBuildNumber != 0) ? String.valueOf(_initialBuildNumber) :
-				"Unable to determine"
+			"expected.build.number",
+			() -> {
+				int expectedBuildNumber = ReleaseInfo.getBuildNumber();
+
+				if (expectedBuildNumber != 0) {
+					return String.valueOf(expectedBuildNumber);
+				}
+
+				return "Unable to determine";
+			}
 		).put(
-			"initial.schema.version",
-			(_initialSchemaVersion != null) ? _initialSchemaVersion :
-				"Unable to determine"
+			"expected.schema.version",
+			() -> {
+				String expectedSchemaVersion = String.valueOf(
+					PortalUpgradeProcess.getLatestSchemaVersion());
+
+				if (expectedSchemaVersion != null) {
+					return expectedSchemaVersion;
+				}
+
+				return "Unable to determine";
+			}
 		).put(
 			"final.build.number",
 			() -> {
@@ -423,28 +438,13 @@ public class UpgradeReport {
 				return "Unable to determine";
 			}
 		).put(
-			"expected.build.number",
-			() -> {
-				int expectedBuildNumber = ReleaseInfo.getBuildNumber();
-
-				if (expectedBuildNumber != 0) {
-					return String.valueOf(expectedBuildNumber);
-				}
-
-				return "Unable to determine";
-			}
+			"initial.build.number",
+			(_initialBuildNumber != 0) ? String.valueOf(_initialBuildNumber) :
+				"Unable to determine"
 		).put(
-			"expected.schema.version",
-			() -> {
-				String expectedSchemaVersion = String.valueOf(
-					PortalUpgradeProcess.getLatestSchemaVersion());
-
-				if (expectedSchemaVersion != null) {
-					return expectedSchemaVersion;
-				}
-
-				return "Unable to determine";
-			}
+			"initial.schema.version",
+			(_initialSchemaVersion != null) ? _initialSchemaVersion :
+				"Unable to determine"
 		).build();
 	}
 
@@ -452,13 +452,13 @@ public class UpgradeReport {
 		_setRootDir();
 
 		return LinkedHashMapBuilder.put(
+			PropsKeys.DL_STORE_IMPL, PropsValues.DL_STORE_IMPL
+		).put(
 			"liferay.home", PropsValues.LIFERAY_HOME
 		).put(
 			"locales", Arrays.toString(PropsValues.LOCALES)
 		).put(
 			"locales.enabled", Arrays.toString(PropsValues.LOCALES_ENABLED)
-		).put(
-			PropsKeys.DL_STORE_IMPL, PropsValues.DL_STORE_IMPL
 		).put(
 			"rootDir", (_rootDir != null) ? _rootDir : "Undefined"
 		).build();
@@ -468,26 +468,22 @@ public class UpgradeReport {
 		ReleaseManagerOSGiCommands releaseManagerOSGiCommands) {
 
 		return LinkedHashMapBuilder.<String, Object>put(
+			_PROPERTY_KEY, _getPropertiesInfo()
+		).put(
+			_TABLES_KEY + ".initial.final.rows", _getDatabaseTableCounts()
+		).put(
+			"database.version", _getDialectInfo()
+		).put(
+			"document.library.storage.size", _getDLStorageInfoNew()
+		).put(
+			"errors", _getSortedLogEvents("errors")
+		).put(
 			"execution.date", _getDate()
 		).put(
 			"execution.time", _getUpgradeExecutionTime()
 		).put(
-			"portal", _getPortalVersionInfo()
-		).put(
-			"database.version", _getDialectInfo()
-		).put(
-			_PROPERTY_KEY, _getPropertiesInfo()
-		).put(
-			"document.library.storage.size", _getDLStorageInfoNew()
-		).put(
-			_TABLES_KEY + ".initial.final.rows", _getDatabaseTableCounts()
-		).put(
 			"longest.upgrade.processes",
 			_getLongestRunningUpgradeProcessesList()
-		).put(
-			"errors", _getSortedLogEvents("errors")
-		).put(
-			"warnings", _getSortedLogEvents("warnings")
 		).put(
 			"osgi.status",
 			() -> {
@@ -503,6 +499,10 @@ public class UpgradeReport {
 
 				return check;
 			}
+		).put(
+			"portal", _getPortalVersionInfo()
+		).put(
+			"warnings", _getSortedLogEvents("warnings")
 		).build();
 	}
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -165,10 +165,7 @@ public class UpgradeReport {
 			String key = entry.getKey();
 			Object value = entry.getValue();
 
-			if (value instanceof Map<?, ?>) {
-				sb.append(_printContextMap(key, (Map<?, ?>)value));
-			}
-			else if (value instanceof List<?>) {
+			if (value instanceof List<?>) {
 				String header = _getReportHeaderFromKey(key);
 
 				sb.append(header);
@@ -193,6 +190,9 @@ public class UpgradeReport {
 						sb.append(StringPool.NEW_LINE);
 					}
 				}
+			}
+			else if (value instanceof Map<?, ?>) {
+				sb.append(_printContextMap(key, (Map<?, ?>)value));
 			}
 			else {
 				sb.append(_getReportSimpleValueLine(key, value));

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -73,7 +73,7 @@ public class UpgradeReport {
 	public UpgradeReport() {
 		_initialBuildNumber = _getBuildNumber();
 		_initialSchemaVersion = _getSchemaVersion();
-		_initialTableRowsMap = _getTableCounts();
+		_initialTableCountMap = _getTableCountMap();
 	}
 
 	public void addErrorMessage(String loggerName, String message) {
@@ -392,10 +392,10 @@ public class UpgradeReport {
 		).put(
 			"tables.initial.final.rows",
 			() -> {
-				Map<String, Integer> finalTableRowsMap = _getTableCounts();
+				Map<String, Integer> finalTableCountMap = _getTableCountMap();
 
-				if ((_initialTableRowsMap == null) ||
-					(finalTableRowsMap == null)) {
+				if ((_initialTableCountMap == null) ||
+					(finalTableCountMap == null)) {
 
 					return null;
 				}
@@ -404,15 +404,15 @@ public class UpgradeReport {
 
 				List<String> tableNamesList = new ArrayList<>();
 
-				tableNamesList.addAll(_initialTableRowsMap.keySet());
-				tableNamesList.addAll(finalTableRowsMap.keySet());
+				tableNamesList.addAll(_initialTableCountMap.keySet());
+				tableNamesList.addAll(finalTableCountMap.keySet());
 
 				ListUtil.distinct(
 					tableNamesList,
 					(tableNameA, tableNameB) -> {
-						int countA = _initialTableRowsMap.getOrDefault(
+						int countA = _initialTableCountMap.getOrDefault(
 							tableNameA, 0);
-						int countB = _initialTableRowsMap.getOrDefault(
+						int countB = _initialTableCountMap.getOrDefault(
 							tableNameB, 0);
 
 						if (countA != countB) {
@@ -423,9 +423,9 @@ public class UpgradeReport {
 					});
 
 				for (String tableName : tableNamesList) {
-					int initialCount = _initialTableRowsMap.getOrDefault(
+					int initialCount = _initialTableCountMap.getOrDefault(
 						tableName, -1);
-					int finalCount = finalTableRowsMap.getOrDefault(
+					int finalCount = finalTableCountMap.getOrDefault(
 						tableName, -1);
 
 					if ((initialCount <= 0) && (finalCount <= 0)) {
@@ -664,7 +664,7 @@ public class UpgradeReport {
 		return eventMessages;
 	}
 
-	private Map<String, Integer> _getTableCounts() {
+	private Map<String, Integer> _getTableCountMap() {
 		try (Connection connection = DataAccess.getConnection()) {
 			DatabaseMetaData databaseMetaData = connection.getMetaData();
 
@@ -791,7 +791,7 @@ public class UpgradeReport {
 		new ConcurrentHashMap<>();
 	private final int _initialBuildNumber;
 	private final String _initialSchemaVersion;
-	private final Map<String, Integer> _initialTableRowsMap;
+	private final Map<String, Integer> _initialTableCountMap;
 	private PersistenceManager _persistenceManager;
 	private String _rootDir;
 	private final Map<String, Map<String, Integer>> _warningMessages =

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -430,22 +430,22 @@ public class UpgradeReport {
 		).put(
 			"portal", _getPortalVersionInfo()
 		).put(
-			"using.database", _getDialectInfo()
+			"database.version", _getDialectInfo()
 		).put(
-			"properties", _getPropertiesInfo()
+			"property", _getPropertiesInfo()
 		).put(
 			"document.library.storage.size", _getDLStorageInfoNew()
 		).put(
 			"tables.initial.final.rows", _getDatabaseTableCounts()
 		).put(
-			"longest.running.upgrade.processes",
+			"longest.upgrade.processes",
 			_getLongestRunningUpgradeProcessesList()
 		).put(
 			"errors", _getSortedLogEvents("errors")
 		).put(
 			"warnings", _getSortedLogEvents("warnings")
 		).put(
-			"release.osgi.info",
+			"osgi.status",
 			() -> {
 				if (releaseManagerOSGiCommands == null) {
 					return "Not possible to check upgrades status";

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -544,7 +544,7 @@ public class UpgradeReport {
 
 		if (key.startsWith(_TABLES_KEY)) {
 			return String.format(
-				TableCounts.FORMAT, "Table name", "Initial rows", "Final rows");
+				TableCounts.FORMAT, "Table Name", "Initial Rows", "Final Rows");
 		}
 
 		return StringUtil.replace(

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -852,8 +852,8 @@ public class UpgradeReport {
 					_message);
 			}
 
-			private final int _occurrences;
 			private final String _message;
+			private final int _occurrences;
 
 		}
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -628,7 +628,8 @@ public class UpgradeReport {
 	}
 
 	private String _getUpgradeReportHeaderFromKey(String key) {
-		return "Upgrade " + StringUtil.replace(key, '.', ' ');
+		return StringUtil.replace(
+			StringUtil.upperCaseFirstLetter(key), '.', ' ');
 	}
 
 	private String _getUpgradeReportSimpleValueLine(String key, Object value) {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -672,7 +672,9 @@ public class UpgradeReport {
 				sb.append(_printContextMap(key, (Map<?, ?>)value));
 			}
 			else if (value instanceof List<?>) {
-				sb.append(_getUpgradeReportHeaderFromKey(key));
+				String header = _getUpgradeReportHeaderFromKey(key);
+
+				sb.append(header);
 
 				List<Object> elements = (List<Object>)value;
 
@@ -683,7 +685,10 @@ public class UpgradeReport {
 				else {
 					sb.append(StringPool.NEW_LINE);
 					sb.append(
-						"-------------------------------------------------");
+						ListUtil.toString(
+							Collections.nCopies(
+								header.length(), StringPool.MINUS),
+							StringPool.NULL, StringPool.BLANK));
 					sb.append(StringPool.NEW_LINE);
 
 					for (Object object : (List<Object>)value) {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -483,7 +483,7 @@ public class UpgradeReport {
 		).put(
 			"document.library.storage.size", _getDLStorageInfoNew()
 		).put(
-			"tables.initial.final.rows", _getDatabaseTableCounts()
+			_TABLES_KEY + ".initial.final.rows", _getDatabaseTableCounts()
 		).put(
 			"longest.upgrade.processes",
 			_getLongestRunningUpgradeProcessesList()
@@ -543,6 +543,11 @@ public class UpgradeReport {
 		if (key.startsWith(_PROPERTY_KEY)) {
 			return StringUtil.replaceFirst(
 				StringUtil.upperCaseFirstLetter(key), '.', ' ');
+		}
+
+		if (key.startsWith(_TABLES_KEY)) {
+			return String.format(
+				TableCounts.FORMAT, "Table name", "Initial rows", "Final rows");
 		}
 
 		return StringUtil.replace(
@@ -784,6 +789,8 @@ public class UpgradeReport {
 
 	private static final String _PROPERTY_KEY = "property";
 
+	private static final String _TABLES_KEY = "tables";
+
 	private static final int _UPGRADE_PROCESSES_COUNT = 20;
 
 	private static final Log _log = LogFactoryUtil.getLog(UpgradeReport.class);
@@ -886,6 +893,8 @@ public class UpgradeReport {
 
 	private class TableCounts {
 
+		public static final String FORMAT = "%-30s %20s %20s";
+
 		public TableCounts(
 			String tableName, String initialCount, String finalCount) {
 
@@ -902,10 +911,8 @@ public class UpgradeReport {
 					StringPool.COLON, _finalCount);
 			}
 
-			String format = "%-30s %20s %20s";
-
 			return String.format(
-				format, _tableName, _initialCount, _finalCount);
+				FORMAT, _tableName, _initialCount, _finalCount);
 		}
 
 		private final String _finalCount;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -514,7 +514,7 @@ public class UpgradeReport {
 			"osgi.status",
 			() -> {
 				if (releaseManagerOSGiCommands == null) {
-					return "Not possible to check upgrades status";
+					return "Unable to determine. Upgrade check not available";
 				}
 
 				String check = releaseManagerOSGiCommands.check();

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -790,7 +790,7 @@ public class UpgradeReport {
 		}
 
 		public void addEvent(String message, int occurrences) {
-			_counts.add(new Counts(message, occurrences));
+			_counts.add(new Count(message, occurrences));
 		}
 
 		@Override
@@ -805,9 +805,9 @@ public class UpgradeReport {
 			sb.append(_clazz);
 			sb.append(StringPool.NEW_LINE);
 
-			for (Counts counter : _counts) {
+			for (Count count : _counts) {
 				sb.append(StringPool.TAB);
-				sb.append(counter.toString());
+				sb.append(count.toString());
 				sb.append(StringPool.NEW_LINE);
 			}
 
@@ -815,11 +815,11 @@ public class UpgradeReport {
 		}
 
 		private final String _clazz;
-		private final List<Counts> _counts = new ArrayList<>();
+		private final List<Count> _counts = new ArrayList<>();
 
-		private class Counts {
+		private class Count {
 
-			public Counts(String message, int occurrences) {
+			public Count(String message, int occurrences) {
 				_message = message;
 				_occurrences = occurrences;
 			}

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -360,7 +360,8 @@ public class UpgradeReport {
 				}
 
 				if (_rootDir == null) {
-					return "Unable to determine. \"rootDir\" was not set";
+					return "Unable to determine. Document library " +
+						"\"rootDir\" was not set";
 				}
 
 				double bytes = 0;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -812,8 +812,8 @@ public class UpgradeReport {
 			_clazz = clazz;
 		}
 
-		public void addEvent(String message, int coincidences) {
-			_counts.add(new Counts(message, coincidences));
+		public void addEvent(String message, int occurrences) {
+			_counts.add(new Counts(message, occurrences));
 		}
 
 		@Override
@@ -842,23 +842,23 @@ public class UpgradeReport {
 
 		private class Counts {
 
-			public Counts(String message, int coincidences) {
+			public Counts(String message, int occurrences) {
 				_message = message;
-				_coincidences = coincidences;
+				_occurrences = occurrences;
 			}
 
 			@Override
 			public String toString() {
 				if (_logContext) {
-					return _coincidences + StringPool.COLON + _message;
+					return _occurrences + StringPool.COLON + _message;
 				}
 
 				return StringBundler.concat(
-					_coincidences, " occurrences of the following event: ",
+					_occurrences, " occurrences of the following event: ",
 					_message);
 			}
 
-			private final int _coincidences;
+			private final int _occurrences;
 			private final String _message;
 
 		}

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -233,12 +233,12 @@ public class UpgradeReport {
 			return null;
 		}
 
+		List<TableCounts> tableCounts = new ArrayList<>();
+
 		List<String> tableNames = new ArrayList<>();
 
 		tableNames.addAll(_initialTableCounts.keySet());
 		tableNames.addAll(finalTableCounts.keySet());
-
-		List<TableCounts> tableCounts = new ArrayList<>();
 
 		ListUtil.distinct(
 			tableNames,
@@ -291,12 +291,9 @@ public class UpgradeReport {
 	private String _getDialectInfo() {
 		DB db = DBManagerUtil.getDB();
 
-		String dbType = String.valueOf(db.getDBType());
-
-		String dbVersion =
-			db.getMajorVersion() + StringPool.PERIOD + db.getMinorVersion();
-
-		return dbType + StringPool.SPACE + dbVersion;
+		return StringBundler.concat(
+			db.getDBType(), StringPool.SPACE, db.getMajorVersion(),
+			StringPool.PERIOD, db.getMinorVersion());
 	}
 
 	private String _getDLStorageInfoNew() {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -338,7 +338,7 @@ public class UpgradeReport {
 	}
 
 	private String _getLogContextSectionKey(String section) {
-		return _LOG_CONTEXT_PREFIX + section;
+		return "upgrade.report." + section;
 	}
 
 	private List<RunningProcess> _getLongestRunningUpgradeProcessesList() {
@@ -468,9 +468,9 @@ public class UpgradeReport {
 		ReleaseManagerOSGiCommands releaseManagerOSGiCommands) {
 
 		return LinkedHashMapBuilder.<String, Object>put(
-			_PROPERTY_KEY, _getPropertiesInfo()
+			"property", _getPropertiesInfo()
 		).put(
-			_TABLES_KEY + ".initial.final.rows", _getDatabaseTableCounts()
+			"tables.initial.final.rows", _getDatabaseTableCounts()
 		).put(
 			"database.version", _getDialectInfo()
 		).put(
@@ -537,12 +537,12 @@ public class UpgradeReport {
 	}
 
 	private String _getReportHeaderFromKey(String key) {
-		if (key.startsWith(_PROPERTY_KEY)) {
+		if (key.startsWith("property.")) {
 			return StringUtil.replaceFirst(
 				StringUtil.upperCaseFirstLetter(key), '.', ' ');
 		}
 
-		if (key.startsWith(_TABLES_KEY)) {
+		if (key.startsWith("tables.")) {
 			return String.format(
 				TableCounts.FORMAT, "Table Name", "Initial Rows", "Final Rows");
 		}
@@ -781,12 +781,6 @@ public class UpgradeReport {
 		"com.liferay.portal.search.elasticsearch7.internal.sidecar." +
 			"SidecarManager"
 	};
-
-	private static final String _LOG_CONTEXT_PREFIX = "upgrade.report.";
-
-	private static final String _PROPERTY_KEY = "property";
-
-	private static final String _TABLES_KEY = "tables";
 
 	private static final int _UPGRADE_PROCESSES_COUNT = 20;
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -61,6 +61,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.felix.cm.PersistenceManager;
+import org.apache.logging.log4j.ThreadContext;
 
 /**
  * @author Sam Ziemer
@@ -117,6 +118,18 @@ public class UpgradeReport {
 
 		_persistenceManager = persistenceManager;
 
+		String dateInfo = _getDateInfo();
+		String timeInfo = _getUpgradeTimeInfo();
+		String portalVersionsInfo = _getPortalVersionsInfo();
+		String dialectInfo = _getDialectInfo();
+		String propertiesInfo = _getPropertiesInfo();
+		String dlStorageInfo = _getDLStorageInfo();
+		String databaseTablesInfo = _getDatabaseTablesInfo();
+		String upgradeProcessesInfo = _getUpgradeProcessesInfo();
+		String errorLogEventsInfo = _getLogEventsInfo("errors");
+		String warningLogEventsInfo = _getLogEventsInfo("warnings");
+		String releaseManagerOSGiInfo = (releaseManagerOSGiCommands == null) ? StringPool.BLANK : releaseManagerOSGiCommands.check();
+
 		try {
 			File reportFile = _getReportFile();
 
@@ -124,15 +137,10 @@ public class UpgradeReport {
 				reportFile,
 				StringUtil.merge(
 					new String[] {
-						_getDateInfo(), _getUpgradeTimeInfo(),
-						_getPortalVersionsInfo(), _getDialectInfo(),
-						_getPropertiesInfo(), _getDLStorageInfo(),
-						_getDatabaseTablesInfo(), _getUpgradeProcessesInfo(),
-						_getLogEventsInfo("errors"),
-						_getLogEventsInfo("warnings"),
-						(releaseManagerOSGiCommands == null) ?
-							StringPool.BLANK :
-								releaseManagerOSGiCommands.check()
+						dateInfo, timeInfo, portalVersionsInfo, dialectInfo,
+						propertiesInfo, dlStorageInfo, databaseTablesInfo,
+						upgradeProcessesInfo, errorLogEventsInfo,
+						warningLogEventsInfo, releaseManagerOSGiInfo
 					},
 					StringPool.NEW_LINE + StringPool.NEW_LINE));
 
@@ -144,6 +152,26 @@ public class UpgradeReport {
 		}
 		catch (IOException ioException) {
 			_log.error("Unable to generate the upgrade report", ioException);
+		}
+
+		if (PropsValues.UPGRADE_LOG_CONTEXT_ENABLED) {
+			ThreadContext.put("upgrade.report.date", dateInfo);
+			ThreadContext.put("upgrade.report.time", timeInfo);
+			ThreadContext.put("upgrade.report.portalVersion", portalVersionsInfo);
+			ThreadContext.put("upgrade.report.dialect", dialectInfo);
+			ThreadContext.put("upgrade.report.properties", propertiesInfo);
+			ThreadContext.put("upgrade.report.dlstorage", dlStorageInfo);
+			ThreadContext.put("upgrade.report.databasetables", databaseTablesInfo);
+			ThreadContext.put("upgrade.report.upgradeprocesses", upgradeProcessesInfo);
+			ThreadContext.put("upgrade.report.errorlogevents", errorLogEventsInfo);
+			ThreadContext.put("upgrade.report.warninglogevents", warningLogEventsInfo);
+			ThreadContext.put("upgrade.report.releasemanagerOSGi", releaseManagerOSGiInfo);
+
+			if (_log.isInfoEnabled()) {
+				_log.info("Upgrade report generated");
+			}
+
+			ThreadContext.clearMap();
 		}
 	}
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -53,7 +53,6 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -275,19 +274,6 @@ public class UpgradeReport {
 		return tableCounts;
 	}
 
-	private String _getDate() {
-		Calendar calendar = Calendar.getInstance();
-
-		Date date = calendar.getTime();
-
-		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(
-			"EEE, MMM dd, yyyy hh:mm:ss z");
-
-		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-
-		return simpleDateFormat.format(date);
-	}
-
 	private String _getDialectInfo() {
 		DB db = DBManagerUtil.getDB();
 
@@ -478,9 +464,20 @@ public class UpgradeReport {
 		).put(
 			"errors", _getSortedLogEvents("errors")
 		).put(
-			"execution.date", _getDate()
+			"execution.date",
+			() -> {
+				SimpleDateFormat simpleDateFormat = new SimpleDateFormat(
+					"EEE, MMM dd, yyyy hh:mm:ss z");
+
+				simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+				Calendar calendar = Calendar.getInstance();
+
+				return simpleDateFormat.format(calendar.getTime());
+			}
 		).put(
-			"execution.time", _getUpgradeExecutionTime()
+			"execution.time",
+			(DBUpgrader.getUpgradeTime() / Time.SECOND) + " seconds"
 		).put(
 			"longest.upgrade.processes",
 			_getLongestRunningUpgradeProcessesList()
@@ -685,11 +682,6 @@ public class UpgradeReport {
 
 			return null;
 		}
-	}
-
-	private String _getUpgradeExecutionTime() {
-		return String.format(
-			"%s seconds", DBUpgrader.getUpgradeTime() / Time.SECOND);
 	}
 
 	private String _printContextMap(String key, Map<?, ?> map) {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -400,8 +400,6 @@ public class UpgradeReport {
 					return null;
 				}
 
-				List<TableCounts> tableCountsList = new ArrayList<>();
-
 				List<String> tableNamesList = new ArrayList<>();
 
 				tableNamesList.addAll(_initialTableCountMap.keySet());
@@ -421,6 +419,8 @@ public class UpgradeReport {
 
 						return tableNameA.compareTo(tableNameB);
 					});
+
+				List<TableCounts> tableCountsList = new ArrayList<>();
 
 				for (String tableName : tableNamesList) {
 					int initialCount = _initialTableCountMap.getOrDefault(

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -529,7 +529,7 @@ public class UpgradeReport {
 	}
 
 	private File _getReportFile() {
-		File reportsDir = null;
+		File reportsDir;
 
 		if (DBUpgrader.isUpgradeClient()) {
 			reportsDir = new File(".", "reports");

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -278,6 +278,8 @@ public class UpgradeReport {
 		).put(
 			"type", DBUpgradeStatus.getUpgradeType()
 		).put(
+			"result", DBUpgradeStatus.getUpgradeStatus()
+		).put(
 			"database.version",
 			() -> {
 				DB db = DBManagerUtil.getDB();

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -221,7 +221,9 @@ public class UpgradeReport {
 						DBUpgradeStatus.getInitialSchemaVersion(
 							ReleaseConstants.DEFAULT_SERVLET_CONTEXT_NAME);
 
-					if (initialSchemaVersion != null) {
+					if ((initialSchemaVersion != null) &&
+						!initialSchemaVersion.equals("0.0.0")) {
+
 						return initialSchemaVersion;
 					}
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -278,9 +278,9 @@ public class UpgradeReport {
 				}
 			).build()
 		).put(
-			"type", DBUpgradeStatus.getUpgradeType()
+			"type", DBUpgradeStatus.getType()
 		).put(
-			"result", DBUpgradeStatus.getUpgradeStatus()
+			"result", DBUpgradeStatus.getStatus()
 		).put(
 			"database.version",
 			() -> {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.internal.release.osgi.commands.ReleaseManagerOSGiCommands;
+import com.liferay.portal.upgrade.util.DBUpgradeStatus;
 import com.liferay.portal.util.PropsValues;
 
 import java.io.File;
@@ -59,7 +60,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.felix.cm.PersistenceManager;
@@ -72,51 +72,12 @@ public class UpgradeReport {
 
 	public UpgradeReport() {
 		_initialBuildNumber = _getBuildNumber();
-		_initialSchemaVersion = _getSchemaVersion();
 		_initialTableCountMap = _getTableCountMap();
-	}
-
-	public void addErrorMessage(String loggerName, String message) {
-		Map<String, Integer> errorMessages = _errorMessages.computeIfAbsent(
-			loggerName, key -> new ConcurrentHashMap<>());
-
-		int occurrences = errorMessages.computeIfAbsent(message, key -> 0);
-
-		occurrences++;
-
-		errorMessages.put(message, occurrences);
-	}
-
-	public void addEventMessage(String loggerName, String message) {
-		List<String> eventMessages = _eventMessages.computeIfAbsent(
-			loggerName, key -> new ArrayList<>());
-
-		eventMessages.add(message);
-	}
-
-	public void addWarningMessage(String loggerName, String message) {
-		Map<String, Integer> warningMessages = _warningMessages.computeIfAbsent(
-			loggerName, key -> new ConcurrentHashMap<>());
-
-		int count = warningMessages.computeIfAbsent(message, key -> 0);
-
-		count++;
-
-		warningMessages.put(message, count);
-	}
-
-	public void filterMessages() {
-		for (String filteredClassName : _FILTERED_CLASS_NAMES) {
-			_errorMessages.remove(filteredClassName);
-			_warningMessages.remove(filteredClassName);
-		}
 	}
 
 	public void generateReport(
 		PersistenceManager persistenceManager,
 		ReleaseManagerOSGiCommands releaseManagerOSGiCommands) {
-
-		filterMessages();
 
 		_persistenceManager = persistenceManager;
 
@@ -255,8 +216,17 @@ public class UpgradeReport {
 					String.valueOf(_initialBuildNumber) : "Unable to determine"
 			).put(
 				"initial.schema.version",
-				(_initialSchemaVersion != null) ? _initialSchemaVersion :
-					"Unable to determine"
+				() -> {
+					String initialSchemaVersion =
+						DBUpgradeStatus.getInitialSchemaVersion(
+							ReleaseConstants.DEFAULT_SERVLET_CONTEXT_NAME);
+
+					if (initialSchemaVersion != null) {
+						return initialSchemaVersion;
+					}
+
+					return "Unable to determine";
+				}
 			).put(
 				"final.build.number",
 				() -> {
@@ -271,7 +241,9 @@ public class UpgradeReport {
 			).put(
 				"final.schema.version",
 				() -> {
-					String finalSchemaVersion = _getSchemaVersion();
+					String finalSchemaVersion =
+						DBUpgradeStatus.getFinalSchemaVersion(
+							ReleaseConstants.DEFAULT_SERVLET_CONTEXT_NAME);
 
 					if (finalSchemaVersion != null) {
 						return finalSchemaVersion;
@@ -449,7 +421,10 @@ public class UpgradeReport {
 		).put(
 			"longest.upgrade.processes",
 			() -> {
-				List<String> messages = _eventMessages.get(
+				Map<String, ArrayList<String>> eventMessages =
+					DBUpgradeStatus.getUpgradeProcessMessages();
+
+				List<String> messages = eventMessages.get(
 					UpgradeProcess.class.getName());
 
 				if (ListUtil.isEmpty(messages)) {
@@ -599,37 +574,20 @@ public class UpgradeReport {
 		return null;
 	}
 
-	private String _getSchemaVersion() {
-		try (Connection connection = DataAccess.getConnection();
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				"select schemaVersion from Release_ where releaseId = " +
-					ReleaseConstants.DEFAULT_ID)) {
-
-			ResultSet resultSet = preparedStatement.executeQuery();
-
-			if (resultSet.next()) {
-				return resultSet.getString("schemaVersion");
-			}
-		}
-		catch (SQLException sqlException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn("Unable to get schema version", sqlException);
-			}
-		}
-
-		return null;
-	}
-
 	private List<EventMessage> _getSortedLogEvents(String type) {
 		List<Map.Entry<String, Map<String, Integer>>> events =
 			new ArrayList<>();
 
+		Map<String, Map<String, Integer>> map = null;
+
 		if (type.equals("errors")) {
-			events.addAll(_errorMessages.entrySet());
+			map = DBUpgradeStatus.getErrorMessages();
 		}
 		else {
-			events.addAll(_warningMessages.entrySet());
+			map = DBUpgradeStatus.getWarningMessages();
 		}
+
+		events.addAll(map.entrySet());
 
 		ListUtil.sort(
 			events,
@@ -774,28 +732,16 @@ public class UpgradeReport {
 		"com.liferay.portal.store.file.system.configuration." +
 			"FileSystemStoreConfiguration";
 
-	private static final String[] _FILTERED_CLASS_NAMES = {
-		"com.liferay.portal.search.elasticsearch7.internal.sidecar." +
-			"SidecarManager"
-	};
-
 	private static final int _UPGRADE_PROCESSES_COUNT = 20;
 
 	private static final Log _log = LogFactoryUtil.getLog(UpgradeReport.class);
 
 	private static boolean _logContext;
 
-	private final Map<String, Map<String, Integer>> _errorMessages =
-		new ConcurrentHashMap<>();
-	private final Map<String, ArrayList<String>> _eventMessages =
-		new ConcurrentHashMap<>();
 	private final int _initialBuildNumber;
-	private final String _initialSchemaVersion;
 	private final Map<String, Integer> _initialTableCountMap;
 	private PersistenceManager _persistenceManager;
 	private String _rootDir;
-	private final Map<String, Map<String, Integer>> _warningMessages =
-		new ConcurrentHashMap<>();
 
 	private static class EventMessage {
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -276,6 +276,8 @@ public class UpgradeReport {
 				}
 			).build()
 		).put(
+			"type", DBUpgradeStatus.getUpgradeType()
+		).put(
 			"database.version",
 			() -> {
 				DB db = DBManagerUtil.getDB();

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -63,7 +63,7 @@ import org.junit.Test;
 /**
  * @author Sam Ziemer
  */
-public abstract class BaseUpgradeReportLogAppenderTestCase {
+public abstract class BaseUpgradeLogAppenderTestCase {
 
 	@ClassRule
 	@Rule
@@ -240,8 +240,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	public void testLogEvents() throws Exception {
 		_appender.start();
 
-		Log log = LogFactoryUtil.getLog(
-			BaseUpgradeReportLogAppenderTestCase.class);
+		Log log = LogFactoryUtil.getLog(BaseUpgradeLogAppenderTestCase.class);
 
 		log.warn("Warning");
 		log.warn("Warning");
@@ -529,7 +528,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 		"(\\w+_?)\\s+(\\d+|-)\\s+(\\d+|-)\n");
 	private static Logger _upgradeReportLogger;
 
-	@Inject(filter = "appender.name=UpgradeReportLogAppender")
+	@Inject(filter = "appender.name=UpgradeLogAppender")
 	private Appender _appender;
 
 	@Inject

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -110,8 +110,8 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 		_originalFiltered = false;
 		_originalModuleSchemaVersionsMap.clear();
 		_originalUpgradeProcessMessages.clear();
-		_originalUpgradeStatus = "Pending";
-		_originalUpgradeType = "Not calculated";
+		_originalStatus = "Pending";
+		_originalType = "Not calculated";
 		_originalWarningMessages.clear();
 	}
 
@@ -445,13 +445,13 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 		_originalFiltered = ReflectionTestUtil.getFieldValue(
 			DBUpgradeStatus.class, "_filtered");
 		_originalModuleSchemaVersionsMap = ReflectionTestUtil.getFieldValue(
-			DBUpgradeStatus.class, "_moduleSchemaVersionsMap");
+			DBUpgradeStatus.class, "_servletSchemaVersionsMap");
 		_originalUpgradeProcessMessages = ReflectionTestUtil.getFieldValue(
 			DBUpgradeStatus.class, "_upgradeProcessMessages");
-		_originalUpgradeStatus = ReflectionTestUtil.getFieldValue(
-			DBUpgradeStatus.class, "_upgradeStatus");
-		_originalUpgradeType = ReflectionTestUtil.getFieldValue(
-			DBUpgradeStatus.class, "_upgradeType");
+		_originalStatus = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_status");
+		_originalType = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_type");
 		_originalWarningMessages = ReflectionTestUtil.getFieldValue(
 			DBUpgradeStatus.class, "_warningMessages");
 	}
@@ -560,13 +560,13 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 	private static Map<String, Map<String, Integer>> _originalErrorMessages;
 	private static boolean _originalFiltered;
 	private static Map<String, Object> _originalModuleSchemaVersionsMap;
+	private static String _originalStatus;
+	private static String _originalType;
 	private static boolean _originalUpgradeClient;
 	private static boolean _originalUpgradeLogContextEnabled;
 	private static Map<String, ArrayList<String>>
 		_originalUpgradeProcessMessages;
 	private static boolean _originalUpgradeReportEnabled;
-	private static String _originalUpgradeStatus;
-	private static String _originalUpgradeType;
 	private static Map<String, Map<String, Integer>> _originalWarningMessages;
 	private static final Pattern _pattern = Pattern.compile(
 		"(\\w+_?)\\s+(\\d+|-)\\s+(\\d+|-)\n");

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -36,10 +36,12 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
+import com.liferay.portal.upgrade.util.DBUpgradeStatus;
 import com.liferay.portal.util.PropsValues;
 
 import java.io.File;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -81,6 +83,10 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 		ReflectionTestUtil.setFieldValue(
 			PropsValues.class, "UPGRADE_LOG_CONTEXT_ENABLED",
 			_originalUpgradeLogContextEnabled);
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_REPORT_ENABLED",
+			_originalUpgradeReportEnabled);
 	}
 
 	@Before
@@ -99,6 +105,14 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			"com.liferay.portal.upgrade.internal.report.UpgradeReport");
 
 		_upgradeReportLogger.addAppender(_logContextAppender);
+
+		_originalErrorMessages.clear();
+		_originalFiltered = false;
+		_originalModuleSchemaVersionsMap.clear();
+		_originalUpgradeProcessMessages.clear();
+		_originalUpgradeStatus = "Pending";
+		_originalUpgradeType = "Not calculated";
+		_originalWarningMessages.clear();
 	}
 
 	@After
@@ -419,6 +433,27 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 
 		ReflectionTestUtil.setFieldValue(
 			PropsValues.class, "UPGRADE_LOG_CONTEXT_ENABLED", true);
+
+		_originalUpgradeReportEnabled = ReflectionTestUtil.getFieldValue(
+			PropsValues.class, "UPGRADE_REPORT_ENABLED");
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_REPORT_ENABLED", true);
+
+		_originalErrorMessages = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_errorMessages");
+		_originalFiltered = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_filtered");
+		_originalModuleSchemaVersionsMap = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_moduleSchemaVersionsMap");
+		_originalUpgradeProcessMessages = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_upgradeProcessMessages");
+		_originalUpgradeStatus = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_upgradeStatus");
+		_originalUpgradeType = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_upgradeType");
+		_originalWarningMessages = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_warningMessages");
 	}
 
 	protected abstract String getFilePath();
@@ -522,8 +557,17 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 	private static Appender _logContextAppender;
 	private static final Pattern _logContextDatabaseTablePattern =
 		Pattern.compile("(\\w+_?):(\\d+|-):(\\d+|-)");
+	private static Map<String, Map<String, Integer>> _originalErrorMessages;
+	private static boolean _originalFiltered;
+	private static Map<String, Object> _originalModuleSchemaVersionsMap;
 	private static boolean _originalUpgradeClient;
 	private static boolean _originalUpgradeLogContextEnabled;
+	private static Map<String, ArrayList<String>>
+		_originalUpgradeProcessMessages;
+	private static boolean _originalUpgradeReportEnabled;
+	private static String _originalUpgradeStatus;
+	private static String _originalUpgradeType;
+	private static Map<String, Map<String, Integer>> _originalWarningMessages;
 	private static final Pattern _pattern = Pattern.compile(
 		"(\\w+_?)\\s+(\\d+|-)\\s+(\\d+|-)\n");
 	private static Logger _upgradeReportLogger;

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -89,8 +89,6 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		builder.withPattern("%level - %m%n %X");
 
-		_unsyncStringWriter = new UnsyncStringWriter();
-
 		_logContextAppender = WriterAppender.createAppender(
 			builder.build(), null, _unsyncStringWriter,
 			"logContextWriterAppender", false, false);
@@ -107,8 +105,6 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	public void tearDown() {
 		_appender.stop();
 
-		_reportContent = null;
-
 		File reportsDir = new File(getFilePath(), "reports");
 
 		if ((reportsDir != null) && reportsDir.exists()) {
@@ -124,8 +120,6 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 		_upgradeReportLogger.removeAppender(_logContextAppender);
 
 		_logContextAppender.stop();
-
-		_logContextAppender = null;
 	}
 
 	@Test
@@ -533,7 +527,8 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	private static boolean _originalUpgradeLogContextEnabled;
 	private static final Pattern _pattern = Pattern.compile(
 		"(\\w+_?)\\s+(\\d+|-)\\s+(\\d+|-)\n");
-	private static UnsyncStringWriter _unsyncStringWriter;
+	private static UnsyncStringWriter _unsyncStringWriter =
+		new UnsyncStringWriter();
 	private static Logger _upgradeReportLogger;
 
 	@Inject(filter = "appender.name=UpgradeReportLogAppender")

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -363,7 +363,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	private static final Pattern _pattern = Pattern.compile(
 		"(\\w+_?)\\s+(\\d+|-)\\s+(\\d+|-)\n");
 
-	@Inject
+	@Inject (filter = "appender.name=UpgradeReportLogAppender")
 	private Appender _appender;
 
 	@Inject

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -77,6 +77,10 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		ReflectionTestUtil.setFieldValue(
 			DBUpgrader.class, "_upgradeClient", _originalUpgradeClient);
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_LOG_CONTEXT_ENABLED",
+			_originalUpgradeLogContextEnabled);
 	}
 
 	@Before
@@ -418,6 +422,12 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		ReflectionTestUtil.setFieldValue(
 			DBUpgrader.class, "_upgradeClient", upgradeClient);
+
+		_originalUpgradeLogContextEnabled = ReflectionTestUtil.getFieldValue(
+			PropsValues.class, "UPGRADE_LOG_CONTEXT_ENABLED");
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_LOG_CONTEXT_ENABLED", true);
 	}
 
 	protected abstract String getFilePath();
@@ -520,6 +530,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	private static final Pattern _logContextDatabaseTablePattern =
 		Pattern.compile("(\\w+_?):(\\d+|-):(\\d+|-)");
 	private static boolean _originalUpgradeClient;
+	private static boolean _originalUpgradeLogContextEnabled;
 	private static final Pattern _pattern = Pattern.compile(
 		"(\\w+_?)\\s+(\\d+|-)\\s+(\\d+|-)\n");
 	private static UnsyncStringWriter _unsyncStringWriter;

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -196,6 +196,8 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 			}
 		}
 
+		Assert.assertTrue(table1Exists && table2Exists);
+
 		_assertLogContextContains(
 			"upgrade.report.tables.initial.final.rows",
 			"UpgradeReportTable1:0:1");
@@ -452,7 +454,9 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	private void _assertLogContextContains(String key, String testString) {
 		String values = _getLogContextKey(key);
 
-		Assert.assertTrue(values.contains(testString));
+		Assert.assertTrue(
+			StringUtil.containsIgnoreCase(
+				values, testString, StringPool.BLANK));
 	}
 
 	private void _assertReport(String testString) throws Exception {

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -527,8 +527,6 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	private static boolean _originalUpgradeLogContextEnabled;
 	private static final Pattern _pattern = Pattern.compile(
 		"(\\w+_?)\\s+(\\d+|-)\\s+(\\d+|-)\n");
-	private static final UnsyncStringWriter _unsyncStringWriter =
-		new UnsyncStringWriter();
 	private static Logger _upgradeReportLogger;
 
 	@Inject(filter = "appender.name=UpgradeReportLogAppender")
@@ -538,5 +536,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	private ReleaseLocalService _releaseLocalService;
 
 	private String _reportContent;
+	private final UnsyncStringWriter _unsyncStringWriter =
+		new UnsyncStringWriter();
 
 }

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -527,7 +527,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	private static boolean _originalUpgradeLogContextEnabled;
 	private static final Pattern _pattern = Pattern.compile(
 		"(\\w+_?)\\s+(\\d+|-)\\s+(\\d+|-)\n");
-	private static UnsyncStringWriter _unsyncStringWriter =
+	private static final UnsyncStringWriter _unsyncStringWriter =
 		new UnsyncStringWriter();
 	private static Logger _upgradeReportLogger;
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -233,7 +233,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				reportContent.indexOf(fasterUpgradeProcessName));
 
 		String upgradeProcesses = _getLogContextKey(
-			"upgrade.report.longest.running.upgrade.processes");
+			"upgrade.report.longest.upgrade.processes");
 
 		Assert.assertTrue(
 			upgradeProcesses.indexOf(slowerUpgradeProcessName) <
@@ -264,7 +264,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_assertLogContextContains("upgrade.report.warnings", "2:Warning");
 		_assertLogContextContains(
-			"upgrade.report.longest.running.upgrade.processes",
+			"upgrade.report.longest.upgrade.processes",
 			"com.liferay.portal.UpgradeTest:20401 ms");
 	}
 
@@ -296,7 +296,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				bundleSymbolicName, " from 0.0.1 to ", currentSchemaVersion));
 
 		_assertLogContextContains(
-			"upgrade.report.release.osgi.info",
+			"upgrade.report.osgi.status",
 			StringBundler.concat(
 				"There are upgrade processes available for ",
 				bundleSymbolicName, " from 0.0.1 to ", currentSchemaVersion));
@@ -308,15 +308,14 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_appender.stop();
 
-		_assertReport("Upgrade errors: Nothing registered");
-		_assertReport(
-			"Upgrade longest running upgrade processes: Nothing registered");
-		_assertReport("Upgrade warnings: Nothing registered");
+		_assertReport("Errors: Nothing registered");
+		_assertReport("Longest upgrade processes: Nothing registered");
+		_assertReport("Warnings: Nothing registered");
 
 		_assertLogContextContains("upgrade.report.warnings", "[]");
 		_assertLogContextContains("upgrade.report.errors", "[]");
 		_assertLogContextContains(
-			"upgrade.report.longest.running.upgrade.processes", "[]");
+			"upgrade.report.longest.upgrade.processes", "[]");
 	}
 
 	@Test
@@ -327,26 +326,25 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_assertReport(
 			StringBundler.concat(
-				"Upgrade properties liferay home: ", PropsValues.LIFERAY_HOME,
-				StringPool.NEW_LINE, "Upgrade properties locales: ",
+				"Property liferay.home: ", PropsValues.LIFERAY_HOME,
+				StringPool.NEW_LINE, "Property locales: ",
 				Arrays.toString(PropsValues.LOCALES), StringPool.NEW_LINE,
-				"Upgrade properties locales enabled: ",
+				"Property locales.enabled: ",
 				Arrays.toString(PropsValues.LOCALES_ENABLED),
-				StringPool.NEW_LINE, "Upgrade properties ",
-				StringUtil.replace(PropsKeys.DL_STORE_IMPL, '.', ' '),
+				StringPool.NEW_LINE, "Property ", PropsKeys.DL_STORE_IMPL,
 				StringPool.COLON, StringPool.SPACE, PropsValues.DL_STORE_IMPL,
 				StringPool.NEW_LINE));
 
 		_assertLogContextContains(
-			"upgrade.report.properties.liferay.home", PropsValues.LIFERAY_HOME);
+			"upgrade.report.property.liferay.home", PropsValues.LIFERAY_HOME);
 		_assertLogContextContains(
-			"upgrade.report.properties.locales",
+			"upgrade.report.property.locales",
 			Arrays.toString(PropsValues.LOCALES));
 		_assertLogContextContains(
-			"upgrade.report.properties.locales.enabled",
+			"upgrade.report.property.locales.enabled",
 			Arrays.toString(PropsValues.LOCALES_ENABLED));
 		_assertLogContextContains(
-			"upgrade.report.properties." + PropsKeys.DL_STORE_IMPL,
+			"upgrade.report.property." + PropsKeys.DL_STORE_IMPL,
 			PropsValues.DL_STORE_IMPL);
 	}
 
@@ -380,15 +378,13 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_assertReport(
 			StringBundler.concat(
-				"Upgrade portal initial build number: 7100\n",
-				"Upgrade portal initial schema version: 1.0.0\n",
-				"Upgrade portal final build number: ",
-				ReleaseInfo.getBuildNumber(), StringPool.NEW_LINE,
-				"Upgrade portal final schema version: ",
+				"Portal initial build number: 7100\n",
+				"Portal initial schema version: 1.0.0\n",
+				"Portal final build number: ", ReleaseInfo.getBuildNumber(),
+				StringPool.NEW_LINE, "Portal final schema version: ",
 				latestSchemaVersion.toString(), StringPool.NEW_LINE,
-				"Upgrade portal expected build number: ",
-				ReleaseInfo.getBuildNumber(), StringPool.NEW_LINE,
-				"Upgrade portal expected schema version: ",
+				"Portal expected build number: ", ReleaseInfo.getBuildNumber(),
+				StringPool.NEW_LINE, "Portal expected schema version: ",
 				latestSchemaVersion.toString(), StringPool.NEW_LINE));
 
 		_assertLogContextContains(

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -143,7 +143,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 		_assertDatabaseTablesAreSorted(matcher);
 
 		String databaseTables = _getLogContextKey(
-			"upgrade.report.databaseTables");
+			"upgrade.report.tables.initial.final.rows");
 
 		matcher = _logContextDatabaseTablePattern.matcher(databaseTables);
 
@@ -197,9 +197,11 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 		}
 
 		_assertLogContextContains(
-			"upgrade.report.databaseTables", "UpgradeReportTable1:0:1");
+			"upgrade.report.tables.initial.final.rows",
+			"UpgradeReportTable1:0:1");
 		_assertLogContextContains(
-			"upgrade.report.databaseTables", "UpgradeReportTable2:1:0");
+			"upgrade.report.tables.initial.final.rows",
+			"UpgradeReportTable2:1:0");
 	}
 
 	@Test
@@ -231,7 +233,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				reportContent.indexOf(fasterUpgradeProcessName));
 
 		String upgradeProcesses = _getLogContextKey(
-			"upgrade.report.longestUpgradeProcesses");
+			"upgrade.report.longest.running.upgrade.processes");
 
 		Assert.assertTrue(
 			upgradeProcesses.indexOf(slowerUpgradeProcessName) <
@@ -256,14 +258,13 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_appender.stop();
 
-		_assertReport("2 occurrences of the following warnings: Warning");
+		_assertReport("2 occurrences of the following event: Warning");
 		_assertReport(
 			"com.liferay.portal.UpgradeTest took 20401 ms to complete");
 
+		_assertLogContextContains("upgrade.report.warnings", "2:Warning");
 		_assertLogContextContains(
-			"upgrade.report.warningsLogEvents", "2:Warning");
-		_assertLogContextContains(
-			"upgrade.report.longestUpgradeProcesses",
+			"upgrade.report.longest.running.upgrade.processes",
 			"com.liferay.portal.UpgradeTest:20401 ms");
 	}
 
@@ -295,7 +296,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				bundleSymbolicName, " from 0.0.1 to ", currentSchemaVersion));
 
 		_assertLogContextContains(
-			"upgrade.report.releasemanagerOSGi",
+			"upgrade.report.release.osgi.info",
 			StringBundler.concat(
 				"There are upgrade processes available for ",
 				bundleSymbolicName, " from 0.0.1 to ", currentSchemaVersion));
@@ -307,19 +308,15 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_appender.stop();
 
-		_assertReport("No errors thrown during upgrade");
-		_assertReport("No upgrade processes registered");
-		_assertReport("No warnings thrown during upgrade");
+		_assertReport("Upgrade errors: Nothing registered");
+		_assertReport(
+			"Upgrade longest running upgrade processes: Nothing registered");
+		_assertReport("Upgrade warnings: Nothing registered");
 
+		_assertLogContextContains("upgrade.report.warnings", "[]");
+		_assertLogContextContains("upgrade.report.errors", "[]");
 		_assertLogContextContains(
-			"upgrade.report.warningsLogEvents",
-			"No warnings thrown during upgrade");
-		_assertLogContextContains(
-			"upgrade.report.errorsLogEvents",
-			"No errors thrown during upgrade");
-		_assertLogContextContains(
-			"upgrade.report.longestUpgradeProcesses",
-			"No upgrade processes registered");
+			"upgrade.report.longest.running.upgrade.processes", "[]");
 	}
 
 	@Test
@@ -330,14 +327,15 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_assertReport(
 			StringBundler.concat(
-				PropsKeys.LIFERAY_HOME, StringPool.EQUAL,
-				PropsValues.LIFERAY_HOME, StringPool.NEW_LINE,
-				PropsKeys.LOCALES, StringPool.EQUAL,
+				"Upgrade properties liferay home: ", PropsValues.LIFERAY_HOME,
+				StringPool.NEW_LINE, "Upgrade properties locales: ",
 				Arrays.toString(PropsValues.LOCALES), StringPool.NEW_LINE,
-				PropsKeys.LOCALES_ENABLED, StringPool.EQUAL,
+				"Upgrade properties locales enabled: ",
 				Arrays.toString(PropsValues.LOCALES_ENABLED),
-				StringPool.NEW_LINE, PropsKeys.DL_STORE_IMPL, StringPool.EQUAL,
-				PropsValues.DL_STORE_IMPL));
+				StringPool.NEW_LINE, "Upgrade properties ",
+				StringUtil.replace(PropsKeys.DL_STORE_IMPL, '.', ' '),
+				StringPool.COLON, StringPool.SPACE, PropsValues.DL_STORE_IMPL,
+				StringPool.NEW_LINE));
 
 		_assertLogContextContains(
 			"upgrade.report.properties.liferay.home", PropsValues.LIFERAY_HOME);
@@ -382,30 +380,32 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_assertReport(
 			StringBundler.concat(
-				"Initial portal build number: 7100\n",
-				"Initial portal schema version: 1.0.0\n",
-				"Final portal build number: ", ReleaseInfo.getBuildNumber(),
-				StringPool.NEW_LINE, "Final portal schema version: ",
+				"Upgrade portal initial build number: 7100\n",
+				"Upgrade portal initial schema version: 1.0.0\n",
+				"Upgrade portal final build number: ",
+				ReleaseInfo.getBuildNumber(), StringPool.NEW_LINE,
+				"Upgrade portal final schema version: ",
 				latestSchemaVersion.toString(), StringPool.NEW_LINE,
-				"Expected portal build number: ", ReleaseInfo.getBuildNumber(),
-				StringPool.NEW_LINE, "Expected portal schema version: ",
+				"Upgrade portal expected build number: ",
+				ReleaseInfo.getBuildNumber(), StringPool.NEW_LINE,
+				"Upgrade portal expected schema version: ",
 				latestSchemaVersion.toString(), StringPool.NEW_LINE));
 
 		_assertLogContextContains(
-			"upgrade.report.initialPortalBuildNumber", "7100");
+			"upgrade.report.portal.initial.build.number", "7100");
 		_assertLogContextContains(
-			"upgrade.report.initialPortalSchemaVersion", "1.0.0");
+			"upgrade.report.portal.initial.schema.version", "1.0.0");
 		_assertLogContextContains(
-			"upgrade.report.finalPortalBuildNumber",
+			"upgrade.report.portal.final.build.number",
 			String.valueOf(ReleaseInfo.getBuildNumber()));
 		_assertLogContextContains(
-			"upgrade.report.finalPortalSchemaVersion",
+			"upgrade.report.portal.final.schema.version",
 			latestSchemaVersion.toString());
 		_assertLogContextContains(
-			"upgrade.report.expectedPortalBuildNumber",
+			"upgrade.report.portal.expected.build.number",
 			String.valueOf(ReleaseInfo.getBuildNumber()));
 		_assertLogContextContains(
-			"upgrade.report.expectedPortalSchemaVersion",
+			"upgrade.report.portal.expected.schema.version",
 			latestSchemaVersion.toString());
 	}
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgradeCheckerImplTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgradeCheckerImplTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Release;
+import com.liferay.portal.kernel.service.ReleaseLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.upgrade.util.DBUpgradeChecker;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luis Ortiz
+ */
+@RunWith(Arquillian.class)
+public class DBUpgradeCheckerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testCheckOK() {
+		Assert.assertTrue(_dbUpgradeChecker.check());
+	}
+
+	@Test
+	public void testMissingUpgrades() {
+		String bundleSymbolicName = "com.liferay.asset.service";
+
+		Release release = _releaseLocalService.fetchRelease(bundleSymbolicName);
+
+		String currentSchemaVersion = release.getSchemaVersion();
+
+		try {
+			release.setSchemaVersion("1.0.0");
+
+			_releaseLocalService.updateRelease(release);
+
+			Assert.assertFalse(_dbUpgradeChecker.check());
+		}
+		finally {
+			release = _releaseLocalService.fetchRelease(bundleSymbolicName);
+
+			release.setSchemaVersion(currentSchemaVersion);
+
+			_releaseLocalService.updateRelease(release);
+		}
+	}
+
+	@Inject
+	private volatile DBUpgradeChecker _dbUpgradeChecker;
+
+	@Inject
+	private ReleaseLocalService _releaseLocalService;
+
+}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgradeStatusTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgradeStatusTest.java
@@ -62,14 +62,14 @@ public class DBUpgradeStatusTest {
 			DBUpgradeStatus.class, "_errorMessages");
 		_originalFiltered = ReflectionTestUtil.getFieldValue(
 			DBUpgradeStatus.class, "_filtered");
-		_originalModuleSchemaVersionsMap = ReflectionTestUtil.getFieldValue(
-			DBUpgradeStatus.class, "_moduleSchemaVersionsMap");
+		_originalServletSchemaVersionsMap = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_servletSchemaVersionsMap");
 		_originalUpgradeProcessMessages = ReflectionTestUtil.getFieldValue(
 			DBUpgradeStatus.class, "_upgradeProcessMessages");
-		_originalUpgradeStatus = ReflectionTestUtil.getFieldValue(
-			DBUpgradeStatus.class, "_upgradeStatus");
-		_originalUpgradeType = ReflectionTestUtil.getFieldValue(
-			DBUpgradeStatus.class, "_upgradeType");
+		_originalStatus = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_status");
+		_originalType = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_type");
 		_originalWarningMessages = ReflectionTestUtil.getFieldValue(
 			DBUpgradeStatus.class, "_warningMessages");
 
@@ -87,10 +87,10 @@ public class DBUpgradeStatusTest {
 	public void setUp() {
 		_originalErrorMessages.clear();
 		_originalFiltered = false;
-		_originalModuleSchemaVersionsMap.clear();
+		_originalServletSchemaVersionsMap.clear();
 		_originalUpgradeProcessMessages.clear();
-		_originalUpgradeStatus = "Pending";
-		_originalUpgradeType = "Not calculated";
+		_originalStatus = "Pending";
+		_originalType = "Not calculated";
 		_originalWarningMessages.clear();
 
 		ReflectionTestUtil.setFieldValue(DBUpgrader.class, "_stopWatch", null);
@@ -106,9 +106,9 @@ public class DBUpgradeStatusTest {
 
 		StartupHelperUtil.setUpgrading(false);
 
-		Assert.assertEquals("Failure", DBUpgradeStatus.getUpgradeStatus());
+		Assert.assertEquals("Failure", DBUpgradeStatus.getStatus());
 
-		Assert.assertEquals("No upgrade", DBUpgradeStatus.getUpgradeType());
+		Assert.assertEquals("No upgrade", DBUpgradeStatus.getType());
 	}
 
 	@Test
@@ -127,9 +127,9 @@ public class DBUpgradeStatusTest {
 		_setReleaseSchemaVersion(
 			bundleSymbolicName, currentSchemaVersion.toString());
 
-		Assert.assertEquals("Failure", DBUpgradeStatus.getUpgradeStatus());
+		Assert.assertEquals("Failure", DBUpgradeStatus.getStatus());
 
-		Assert.assertEquals("No upgrade", DBUpgradeStatus.getUpgradeType());
+		Assert.assertEquals("No upgrade", DBUpgradeStatus.getType());
 	}
 
 	@Test
@@ -153,9 +153,9 @@ public class DBUpgradeStatusTest {
 
 		StartupHelperUtil.setUpgrading(false);
 
-		Assert.assertEquals("Success", DBUpgradeStatus.getUpgradeStatus());
+		Assert.assertEquals("Success", DBUpgradeStatus.getStatus());
 
-		Assert.assertEquals("No upgrade", DBUpgradeStatus.getUpgradeType());
+		Assert.assertEquals("No upgrade", DBUpgradeStatus.getType());
 	}
 
 	@Test
@@ -173,9 +173,9 @@ public class DBUpgradeStatusTest {
 
 		StartupHelperUtil.setUpgrading(false);
 
-		Assert.assertEquals("Warning", DBUpgradeStatus.getUpgradeStatus());
+		Assert.assertEquals("Warning", DBUpgradeStatus.getStatus());
 
-		Assert.assertEquals("No upgrade", DBUpgradeStatus.getUpgradeType());
+		Assert.assertEquals("No upgrade", DBUpgradeStatus.getType());
 	}
 
 	private Version _getReleaseSchemaVersion(String bundleSymbolicName) {
@@ -262,24 +262,24 @@ public class DBUpgradeStatusTest {
 		_setReleaseSchemaVersion(
 			microBundleSymbolicName, currentMicroSchemaVersion.toString());
 
-		Assert.assertEquals("Success", DBUpgradeStatus.getUpgradeStatus());
+		Assert.assertEquals("Success", DBUpgradeStatus.getStatus());
 
 		if (!type.equals("Qualifier")) {
-			Assert.assertEquals(type, DBUpgradeStatus.getUpgradeType());
+			Assert.assertEquals(type, DBUpgradeStatus.getType());
 		}
 		else {
-			Assert.assertEquals("Micro", DBUpgradeStatus.getUpgradeType());
+			Assert.assertEquals("Micro", DBUpgradeStatus.getType());
 		}
 	}
 
 	private static Map<String, Map<String, Integer>> _originalErrorMessages;
 	private static boolean _originalFiltered;
-	private static Map<String, Object> _originalModuleSchemaVersionsMap;
+	private static Map<String, Object> _originalServletSchemaVersionsMap;
+	private static String _originalStatus;
 	private static StopWatch _originalStopWatch;
+	private static String _originalType;
 	private static Map<String, ArrayList<String>>
 		_originalUpgradeProcessMessages;
-	private static String _originalUpgradeStatus;
-	private static String _originalUpgradeType;
 	private static Map<String, Map<String, Integer>> _originalWarningMessages;
 
 	@Inject

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgradeStatusTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgradeStatusTest.java
@@ -1,0 +1,314 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.events.StartupHelperUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Release;
+import com.liferay.portal.kernel.service.ReleaseLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.version.Version;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.tools.DBUpgrader;
+import com.liferay.portal.upgrade.util.DBUpgradeStatus;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import org.apache.commons.lang.time.StopWatch;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luis Ortiz
+ */
+@RunWith(Arquillian.class)
+public class DBUpgradeStatusTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() {
+		_originalErrorMessages = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_errorMessages");
+		_originalFiltered = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_filtered");
+		_originalModuleSchemaVersionsMap = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_moduleSchemaVersionsMap");
+		_originalUpgradeProcessMessages = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_upgradeProcessMessages");
+		_originalUpgradeStatus = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_upgradeStatus");
+		_originalUpgradeType = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_upgradeType");
+		_originalWarningMessages = ReflectionTestUtil.getFieldValue(
+			DBUpgradeStatus.class, "_warningMessages");
+
+		_originalStopWatch = ReflectionTestUtil.getFieldValue(
+			DBUpgrader.class, "_stopWatch");
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		ReflectionTestUtil.setFieldValue(
+			DBUpgrader.class, "_stopWatch", _originalStopWatch);
+	}
+
+	@Before
+	public void setUp() {
+		_originalErrorMessages.clear();
+		_originalFiltered = false;
+		_originalModuleSchemaVersionsMap.clear();
+		_originalUpgradeProcessMessages.clear();
+		_originalUpgradeStatus = "Pending";
+		_originalUpgradeType = "Not calculated";
+		_originalWarningMessages.clear();
+
+		ReflectionTestUtil.setFieldValue(DBUpgrader.class, "_stopWatch", null);
+	}
+
+	@Test
+	public void testErrorUpgrade() throws Exception {
+		StartupHelperUtil.setUpgrading(true);
+
+		ErrorUpgradeProcess upgradeProcess = new ErrorUpgradeProcess();
+
+		upgradeProcess.doUpgrade();
+
+		StartupHelperUtil.setUpgrading(false);
+
+		Assert.assertEquals("Failure", DBUpgradeStatus.getUpgradeStatus());
+
+		Assert.assertEquals("No upgrade", DBUpgradeStatus.getUpgradeType());
+	}
+
+	@Test
+	public void testFailureUpgradesPending() {
+		String bundleSymbolicName = "com.liferay.asset.service";
+
+		Version currentSchemaVersion = _getReleaseSchemaVersion(
+			bundleSymbolicName);
+
+		_setReleaseSchemaVersion(bundleSymbolicName, "1.0.0");
+
+		StartupHelperUtil.setUpgrading(true);
+
+		StartupHelperUtil.setUpgrading(false);
+
+		_setReleaseSchemaVersion(
+			bundleSymbolicName, currentSchemaVersion.toString());
+
+		Assert.assertEquals("Failure", DBUpgradeStatus.getUpgradeStatus());
+
+		Assert.assertEquals("No upgrade", DBUpgradeStatus.getUpgradeType());
+	}
+
+	@Test
+	public void testMajorUpgrade() {
+		_testUpgradeType("Major");
+	}
+
+	@Test
+	public void testMicroUpgrade() {
+		_testUpgradeType("Micro");
+	}
+
+	@Test
+	public void testMinorUpgrade() {
+		_testUpgradeType("Minor");
+	}
+
+	@Test
+	public void testNoUpgrades() {
+		StartupHelperUtil.setUpgrading(true);
+
+		StartupHelperUtil.setUpgrading(false);
+
+		Assert.assertEquals("Success", DBUpgradeStatus.getUpgradeStatus());
+
+		Assert.assertEquals("No upgrade", DBUpgradeStatus.getUpgradeType());
+	}
+
+	@Test
+	public void testQualifierUpgrade() {
+		_testUpgradeType("Qualifier");
+	}
+
+	@Test
+	public void testWarningUpgrade() throws Exception {
+		StartupHelperUtil.setUpgrading(true);
+
+		WarningUpgradeProcess upgradeProcess = new WarningUpgradeProcess();
+
+		upgradeProcess.doUpgrade();
+
+		StartupHelperUtil.setUpgrading(false);
+
+		Assert.assertEquals("Warning", DBUpgradeStatus.getUpgradeStatus());
+
+		Assert.assertEquals("No upgrade", DBUpgradeStatus.getUpgradeType());
+	}
+
+	private Version _getReleaseSchemaVersion(String bundleSymbolicName) {
+		Release release = _releaseLocalService.fetchRelease(bundleSymbolicName);
+
+		return Version.parseVersion(release.getSchemaVersion());
+	}
+
+	private void _setReleaseSchemaVersion(
+		String bundleSymbolicName, String schemaVersion) {
+
+		Release release = _releaseLocalService.fetchRelease(bundleSymbolicName);
+
+		release.setSchemaVersion(schemaVersion);
+
+		_releaseLocalService.updateRelease(release);
+	}
+
+	private void _testUpgradeType(String type) {
+		String majorBundleSymbolicName = "com.liferay.asset.service";
+		String minorBundleSymbolicName = "com.liferay.journal.service";
+		String microBundleSymbolicName = "com.liferay.object.service";
+		String qualifierBundleSymbolicName = "com.liferay.calendar.service";
+
+		Version currentMajorSchemaVersion = _getReleaseSchemaVersion(
+			majorBundleSymbolicName);
+		Version currentMinorSchemaVersion = _getReleaseSchemaVersion(
+			minorBundleSymbolicName);
+		Version currentMicroSchemaVersion = _getReleaseSchemaVersion(
+			microBundleSymbolicName);
+
+		Version currentQualifierSchemaVersion = _getReleaseSchemaVersion(
+			qualifierBundleSymbolicName);
+
+		_setReleaseSchemaVersion(
+			qualifierBundleSymbolicName,
+			currentQualifierSchemaVersion.toString() + ".step-2");
+
+		StartupHelperUtil.setUpgrading(true);
+
+		if (type.equals("Major")) {
+			_setReleaseSchemaVersion(
+				majorBundleSymbolicName,
+				StringBundler.concat(
+					String.valueOf(currentMajorSchemaVersion.getMajor() + 1),
+					StringPool.PERIOD,
+					String.valueOf(currentMajorSchemaVersion.getMinor()),
+					StringPool.PERIOD,
+					String.valueOf(currentMajorSchemaVersion.getMicro())));
+		}
+
+		if (type.equals("Minor")) {
+			_setReleaseSchemaVersion(
+				minorBundleSymbolicName,
+				StringBundler.concat(
+					String.valueOf(currentMinorSchemaVersion.getMajor()),
+					StringPool.PERIOD,
+					String.valueOf(currentMinorSchemaVersion.getMinor() + 1),
+					StringPool.PERIOD,
+					String.valueOf(currentMinorSchemaVersion.getMicro())));
+		}
+
+		if (type.equals("Micro")) {
+			_setReleaseSchemaVersion(
+				microBundleSymbolicName,
+				StringBundler.concat(
+					String.valueOf(currentMicroSchemaVersion.getMajor()),
+					StringPool.PERIOD,
+					String.valueOf(currentMicroSchemaVersion.getMinor()),
+					StringPool.PERIOD,
+					String.valueOf(currentMicroSchemaVersion.getMicro() + 1)));
+		}
+
+		_setReleaseSchemaVersion(
+			qualifierBundleSymbolicName,
+			currentQualifierSchemaVersion.toString());
+
+		StartupHelperUtil.setUpgrading(false);
+
+		_setReleaseSchemaVersion(
+			majorBundleSymbolicName, currentMajorSchemaVersion.toString());
+		_setReleaseSchemaVersion(
+			minorBundleSymbolicName, currentMinorSchemaVersion.toString());
+		_setReleaseSchemaVersion(
+			microBundleSymbolicName, currentMicroSchemaVersion.toString());
+
+		Assert.assertEquals("Success", DBUpgradeStatus.getUpgradeStatus());
+
+		if (!type.equals("Qualifier")) {
+			Assert.assertEquals(type, DBUpgradeStatus.getUpgradeType());
+		}
+		else {
+			Assert.assertEquals("Micro", DBUpgradeStatus.getUpgradeType());
+		}
+	}
+
+	private static Map<String, Map<String, Integer>> _originalErrorMessages;
+	private static boolean _originalFiltered;
+	private static Map<String, Object> _originalModuleSchemaVersionsMap;
+	private static StopWatch _originalStopWatch;
+	private static Map<String, ArrayList<String>>
+		_originalUpgradeProcessMessages;
+	private static String _originalUpgradeStatus;
+	private static String _originalUpgradeType;
+	private static Map<String, Map<String, Integer>> _originalWarningMessages;
+
+	@Inject
+	private ReleaseLocalService _releaseLocalService;
+
+	private class ErrorUpgradeProcess extends UpgradeProcess {
+
+		@Override
+		protected void doUpgrade() throws Exception {
+			_log.error("Error on upgrade");
+		}
+
+		private final Log _log = LogFactoryUtil.getLog(
+			ErrorUpgradeProcess.class);
+
+	}
+
+	private class WarningUpgradeProcess extends UpgradeProcess {
+
+		@Override
+		protected void doUpgrade() throws Exception {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Warn on upgrade");
+			}
+		}
+
+		private final Log _log = LogFactoryUtil.getLog(
+			WarningUpgradeProcess.class);
+
+	}
+
+}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
@@ -28,8 +28,12 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
+import org.apache.commons.lang.time.StopWatch;
+
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -51,6 +55,19 @@ public class DBUpgraderTest {
 	public static void setUpClass() throws SQLException {
 		_currentBuildNumber = _getReleaseColumnValue("buildNumber");
 		_currentState = _getReleaseColumnValue("state_");
+		_originalStopWatch = ReflectionTestUtil.getFieldValue(
+			DBUpgrader.class, "_stopWatch");
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		ReflectionTestUtil.setFieldValue(
+			DBUpgrader.class, "_stopWatch", _originalStopWatch);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		ReflectionTestUtil.setFieldValue(DBUpgrader.class, "_stopWatch", null);
 	}
 
 	@After
@@ -132,5 +149,6 @@ public class DBUpgraderTest {
 
 	private static int _currentBuildNumber;
 	private static int _currentState;
+	private static StopWatch _originalStopWatch;
 
 }

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeLogAppenderUpgradeClientTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeLogAppenderUpgradeClientTest.java
@@ -23,8 +23,8 @@ import org.junit.runner.RunWith;
  * @author Luis Ortiz
  */
 @RunWith(Arquillian.class)
-public class UpgradeReportLogAppenderUpgradeClientTest
-	extends BaseUpgradeReportLogAppenderTestCase {
+public class UpgradeLogAppenderUpgradeClientTest
+	extends BaseUpgradeLogAppenderTestCase {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeLogAppenderUpgradeOnStartupTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeLogAppenderUpgradeOnStartupTest.java
@@ -24,8 +24,8 @@ import org.junit.runner.RunWith;
  * @author Luis Ortiz
  */
 @RunWith(Arquillian.class)
-public class UpgradeReportLogAppenderUpgradeOnStartupTest
-	extends BaseUpgradeReportLogAppenderTestCase {
+public class UpgradeLogAppenderUpgradeOnStartupTest
+	extends BaseUpgradeLogAppenderTestCase {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaVerifyUpgradeConnectionCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaVerifyUpgradeConnectionCheck.java
@@ -32,6 +32,7 @@ public class JavaVerifyUpgradeConnectionCheck extends BaseFileCheck {
 
 		if (absolutePath.contains("/test/") ||
 			fileName.endsWith("DBUpgrader.java") ||
+			fileName.endsWith("DBUpgradeStatus.java") ||
 			fileName.endsWith("Test.java") ||
 			fileName.endsWith("UpgradeTableListener.java") ||
 			content.contains("Callable<Void>")) {

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 70.1.0
+Bundle-Version: 71.0.0
 Export-Package:\
 	com.liferay.portal.bean,\
 	com.liferay.portal.dao.orm.hibernate,\

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 70.0.2
+Bundle-Version: 70.1.0
 Export-Package:\
 	com.liferay.portal.bean,\
 	com.liferay.portal.dao.orm.hibernate,\

--- a/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
+++ b/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
@@ -36,7 +36,6 @@ import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.log.UpgradeLogContext;
-import com.liferay.portal.upgrade.util.DBUpgradeStatus;
 import com.liferay.portal.util.PropsValues;
 
 import java.sql.Connection;
@@ -108,8 +107,6 @@ public class StartupHelperUtil {
 				LogContextRegistryUtil.registerLogContext(
 					UpgradeLogContext.getInstance());
 			}
-
-			DBUpgradeStatus.setInitialSchemaVersion();
 
 			DBUpgrader.startUpgradeLogAppender();
 		}

--- a/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
+++ b/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.log.UpgradeLogContext;
+import com.liferay.portal.upgrade.util.DBUpgradeStatus;
 import com.liferay.portal.util.PropsValues;
 
 import java.sql.Connection;
@@ -107,6 +108,8 @@ public class StartupHelperUtil {
 				LogContextRegistryUtil.registerLogContext(
 					UpgradeLogContext.getInstance());
 			}
+
+			DBUpgradeStatus.setInitialSchemaVersion();
 
 			DBUpgrader.startUpgradeLogAppender();
 		}

--- a/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
+++ b/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
@@ -108,10 +108,10 @@ public class StartupHelperUtil {
 					UpgradeLogContext.getInstance());
 			}
 
-			DBUpgrader.startUpgradeReportLogAppender();
+			DBUpgrader.startUpgradeLogAppender();
 		}
 		else {
-			DBUpgrader.stopUpgradeReportLogAppender();
+			DBUpgrader.stopUpgradeLogAppender();
 
 			LogContextRegistryUtil.unregisterLogContext(
 				UpgradeLogContext.getInstance());

--- a/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
+++ b/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
@@ -108,9 +108,7 @@ public class StartupHelperUtil {
 					UpgradeLogContext.getInstance());
 			}
 
-			if (PropsValues.UPGRADE_REPORT_ENABLED) {
-				DBUpgrader.startUpgradeReportLogAppender();
-			}
+			DBUpgrader.startUpgradeReportLogAppender();
 		}
 		else {
 			DBUpgrader.stopUpgradeReportLogAppender();

--- a/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
+++ b/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
@@ -54,6 +54,7 @@ import com.liferay.portal.spring.aop.DynamicProxyCreator;
 import com.liferay.portal.spring.configurator.ConfigurableApplicationContextConfigurator;
 import com.liferay.portal.spring.override.OverrideBeanDefinitionRegistryPostProcessor;
 import com.liferay.portal.tools.DBUpgrader;
+import com.liferay.portal.upgrade.util.DBUpgradeStatus;
 import com.liferay.portal.util.InitUtil;
 import com.liferay.portal.util.PortalClassPathUtil;
 import com.liferay.portal.util.PropsUtil;
@@ -343,6 +344,7 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 			}
 		}
 		else {
+			DBUpgradeStatus.setNoUpgradesEnabled();
 
 			// Check class names
 

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -180,7 +180,7 @@ public class DBUpgrader {
 		System.out.println("Exiting DBUpgrader#main(String[]).");
 	}
 
-	public static void startUpgradeReportLogAppender() {
+	public static void startUpgradeLogAppender() {
 		if (_stopWatch == null) {
 			_initUpgradeStopwatch();
 		}
@@ -189,7 +189,7 @@ public class DBUpgrader {
 
 		serviceLatch.<Appender>waitFor(
 			StringBundler.concat(
-				"(&(appender.name=UpgradeReportLogAppender)(objectClass=",
+				"(&(appender.name=UpgradeLogAppender)(objectClass=",
 				Appender.class.getName(), "))"),
 			appender -> {
 				_appender = appender;
@@ -201,7 +201,7 @@ public class DBUpgrader {
 			});
 	}
 
-	public static void stopUpgradeReportLogAppender() {
+	public static void stopUpgradeLogAppender() {
 		if (_appender != null) {
 			_stopWatch.stop();
 

--- a/portal-impl/src/com/liferay/portal/tools/packageinfo
+++ b/portal-impl/src/com/liferay/portal/tools/packageinfo
@@ -1,1 +1,1 @@
-version 11.2.0
+version 12.0.0

--- a/portal-impl/src/com/liferay/portal/upgrade/log/UpgradeLogContext.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/log/UpgradeLogContext.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.tools.DBUpgrader;
+import com.liferay.portal.upgrade.util.DBUpgradeStatus;
 import com.liferay.portal.verify.VerifyProperties;
 
 import java.util.Collections;
@@ -107,8 +108,8 @@ public class UpgradeLogContext implements LogContext {
 	private final Map<String, String> _defaultContext =
 		Collections.singletonMap("component", "framework");
 	private final Set<String> _upgradeClassNames = SetUtil.fromArray(
-		DBUpgrader.class.getName(), LoggingTimer.class.getName(),
-		VerifyProperties.class.getName(),
+		DBUpgrader.class.getName(), DBUpgradeStatus.class.getName(),
+		LoggingTimer.class.getName(), VerifyProperties.class.getName(),
 		"com.liferay.portal.upgrade.internal.registry." +
 			"UpgradeStepRegistratorTracker",
 		"com.liferay.portal.upgrade.internal.release.ReleaseManagerImpl",

--- a/portal-impl/src/com/liferay/portal/upgrade/log/UpgradeLogContext.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/log/UpgradeLogContext.java
@@ -111,6 +111,7 @@ public class UpgradeLogContext implements LogContext {
 		VerifyProperties.class.getName(),
 		"com.liferay.portal.upgrade.internal.registry." +
 			"UpgradeStepRegistratorTracker",
-		"com.liferay.portal.upgrade.internal.release.ReleaseManagerImpl");
+		"com.liferay.portal.upgrade.internal.release.ReleaseManagerImpl",
+		"com.liferay.portal.upgrade.internal.report.UpgradeReport");
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/util/DBUpgradeStatus.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/DBUpgradeStatus.java
@@ -19,7 +19,9 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.util.DBUpgradeChecker;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.version.Version;
+import com.liferay.portal.util.PropsValues;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -33,6 +35,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.sql.DataSource;
+
+import org.apache.logging.log4j.ThreadContext;
 
 /**
  * @author Luis Ortiz
@@ -123,6 +127,22 @@ public class DBUpgradeStatus {
 		_setFinalSchemaVersion();
 		_calculateUpgradeStatus(dbUpgradeChecker);
 		_calculateTypeOfUpgrade();
+
+		if (PropsValues.UPGRADE_LOG_CONTEXT_ENABLED) {
+			ThreadContext.put("upgrade.type", _upgradeType);
+			ThreadContext.put("upgrade.result", _upgradeStatus);
+		}
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Upgrade of type ", _upgradeType, " finished with ",
+					_upgradeStatus, " result."));
+		}
+
+		if (PropsValues.UPGRADE_LOG_CONTEXT_ENABLED) {
+			ThreadContext.clearMap();
+		}
 	}
 
 	public static void upgradeStarted() {

--- a/portal-impl/src/com/liferay/portal/upgrade/util/DBUpgradeStatus.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/DBUpgradeStatus.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.util;
+
+import com.liferay.petra.function.UnsafeBiConsumer;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.InfrastructureUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.sql.DataSource;
+
+/**
+ * @author Luis Ortiz
+ */
+public class DBUpgradeStatus {
+
+	public static void addErrorMessage(String loggerName, String message) {
+		Map<String, Integer> errorMessages = _errorMessages.computeIfAbsent(
+			loggerName, key -> new ConcurrentHashMap<>());
+
+		int occurrences = errorMessages.computeIfAbsent(message, key -> 0);
+
+		occurrences++;
+
+		errorMessages.put(message, occurrences);
+	}
+
+	public static void addUpgradeProcessMessage(
+		String loggerName, String message) {
+
+		List<String> eventMessages = _upgradeProcessMessages.computeIfAbsent(
+			loggerName, key -> new ArrayList<>());
+
+		eventMessages.add(message);
+	}
+
+	public static void addWarningMessage(String loggerName, String message) {
+		Map<String, Integer> warningMessages = _warningMessages.computeIfAbsent(
+			loggerName, key -> new ConcurrentHashMap<>());
+
+		int count = warningMessages.computeIfAbsent(message, key -> 0);
+
+		count++;
+
+		warningMessages.put(message, count);
+	}
+
+	public static Map<String, Map<String, Integer>> getErrorMessages() {
+		_filterMessages();
+
+		return _errorMessages;
+	}
+
+	public static String getFinalSchemaVersion(String bundleSymbolicName) {
+		ModuleSchemaVersions moduleSchemaVersions =
+			_moduleSchemaVersionsMap.get(bundleSymbolicName);
+
+		return moduleSchemaVersions.getFinalSchemaVersion();
+	}
+
+	public static String getInitialSchemaVersion(String bundleSymbolicName) {
+		ModuleSchemaVersions moduleSchemaVersions =
+			_moduleSchemaVersionsMap.get(bundleSymbolicName);
+
+		return moduleSchemaVersions.getInitialSchemaVersion();
+	}
+
+	public static Map<String, ArrayList<String>> getUpgradeProcessMessages() {
+		return _upgradeProcessMessages;
+	}
+
+	public static Map<String, Map<String, Integer>> getWarningMessages() {
+		_filterMessages();
+
+		return _warningMessages;
+	}
+
+	public static void upgradeFinished() {
+		_setFinalSchemaVersion();
+	}
+
+	private static void _browseReleaseTable(
+		UnsafeBiConsumer<ModuleSchemaVersions, String, Exception>
+			unsafeBiConsumer) {
+
+		DataSource dataSource = InfrastructureUtil.getDataSource();
+
+		if (dataSource == null) {
+			return;
+		}
+
+		try (Connection connection = dataSource.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select servletContextName, schemaVersion from Release_")) {
+
+			ResultSet resultSet = preparedStatement.executeQuery();
+
+			while (resultSet.next()) {
+				String servletContextName = resultSet.getString(
+					"servletContextName");
+				String schemaVersion = resultSet.getString("schemaVersion");
+
+				ModuleSchemaVersions moduleSchemaVersions =
+					_moduleSchemaVersionsMap.get(servletContextName);
+
+				if (moduleSchemaVersions == null) {
+					moduleSchemaVersions = new ModuleSchemaVersions(null);
+
+					_moduleSchemaVersionsMap.put(
+						servletContextName, moduleSchemaVersions);
+				}
+
+				unsafeBiConsumer.accept(moduleSchemaVersions, schemaVersion);
+			}
+		}
+		catch (SQLException sqlException) {
+			_log.error("Unable to get schema version", sqlException);
+		}
+		catch (Exception exception) {
+			_log.error("Unable to process Release_ table", exception);
+		}
+	}
+
+	private static void _filterMessages() {
+		if (!_filtered) {
+			for (String filteredClassName : _FILTERED_CLASS_NAMES) {
+				_errorMessages.remove(filteredClassName);
+				_warningMessages.remove(filteredClassName);
+			}
+
+			_filtered = true;
+		}
+	}
+
+	private static void _setFinalSchemaVersion() {
+		_browseReleaseTable(
+			(moduleSchemaVersions, schemaVersion) ->
+				moduleSchemaVersions.setFinalSchemaVersion(schemaVersion));
+	}
+
+	private static void _setInitialSchemaVersion() {
+		_browseReleaseTable(
+			(moduleSchemaVersions, schemaVersion) ->
+				moduleSchemaVersions.setInitialSchemaVersion(schemaVersion));
+	}
+
+	private static final String[] _FILTERED_CLASS_NAMES = {
+		"com.liferay.portal.search.elasticsearch7.internal.sidecar." +
+			"SidecarManager"
+	};
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DBUpgradeStatus.class);
+
+	private static final Map<String, Map<String, Integer>> _errorMessages =
+		new ConcurrentHashMap<>();
+	private static boolean _filtered;
+	private static final Map<String, ModuleSchemaVersions>
+		_moduleSchemaVersionsMap = new HashMap<>();
+	private static final Map<String, ArrayList<String>>
+		_upgradeProcessMessages = new ConcurrentHashMap<>();
+	private static final Map<String, Map<String, Integer>> _warningMessages =
+		new ConcurrentHashMap<>();
+
+	static {
+		_setInitialSchemaVersion();
+	}
+
+	private static class ModuleSchemaVersions {
+
+		public ModuleSchemaVersions(String initialSchemaVersion) {
+			_initialSchemaVersion = initialSchemaVersion;
+		}
+
+		public String getFinalSchemaVersion() {
+			return _finalSchemaVersion;
+		}
+
+		public String getInitialSchemaVersion() {
+			return _initialSchemaVersion;
+		}
+
+		public void setFinalSchemaVersion(String finalSchemaVersion) {
+			_finalSchemaVersion = finalSchemaVersion;
+		}
+
+		public void setInitialSchemaVersion(String expectedSchemaVersion) {
+			_initialSchemaVersion = expectedSchemaVersion;
+		}
+
+		private String _finalSchemaVersion;
+		private String _initialSchemaVersion;
+
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/util/DBUpgradeStatus.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/DBUpgradeStatus.java
@@ -103,6 +103,12 @@ public class DBUpgradeStatus {
 		return _warningMessages;
 	}
 
+	public static void setInitialSchemaVersion() {
+		_browseReleaseTable(
+			(moduleSchemaVersions, schemaVersion) ->
+				moduleSchemaVersions.setInitialSchemaVersion(schemaVersion));
+	}
+	
 	public static void setNoUpgradesEnabled() {
 		_upgradeType = "Not enabled";
 	}
@@ -221,12 +227,6 @@ public class DBUpgradeStatus {
 				moduleSchemaVersions.setFinalSchemaVersion(schemaVersion));
 	}
 
-	private static void _setInitialSchemaVersion() {
-		_browseReleaseTable(
-			(moduleSchemaVersions, schemaVersion) ->
-				moduleSchemaVersions.setInitialSchemaVersion(schemaVersion));
-	}
-
 	private static final String[] _FILTERED_CLASS_NAMES = {
 		"com.liferay.portal.search.elasticsearch7.internal.sidecar." +
 			"SidecarManager"
@@ -246,10 +246,6 @@ public class DBUpgradeStatus {
 	private static final Map<String, Map<String, Integer>> _warningMessages =
 		new ConcurrentHashMap<>();
 
-	static {
-		_setInitialSchemaVersion();
-	}
-
 	private static class ModuleSchemaVersions {
 
 		public ModuleSchemaVersions(String initialSchemaVersion) {
@@ -268,8 +264,14 @@ public class DBUpgradeStatus {
 			_finalSchemaVersion = finalSchemaVersion;
 		}
 
-		public void setInitialSchemaVersion(String expectedSchemaVersion) {
-			_initialSchemaVersion = expectedSchemaVersion;
+		public void setInitialSchemaVersion(String initialSchemaVersion) {
+			if (initialSchemaVersion == null) {
+				_initialSchemaVersion = "0.0.0";
+
+				return;
+			}
+
+			_initialSchemaVersion = initialSchemaVersion;
 		}
 
 		private String _finalSchemaVersion;

--- a/portal-impl/src/com/liferay/portal/upgrade/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.0
+version 6.2.0

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 100.1.1
+Bundle-Version: 100.2.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/DBUpgradeChecker.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/DBUpgradeChecker.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.upgrade.util;
+
+/**
+ * @author Luis Ortiz
+ */
+public interface DBUpgradeChecker {
+
+	public boolean check();
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/packageinfo
@@ -1,1 +1,1 @@
-version 10.3.0
+version 10.4.0

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
@@ -25,7 +25,7 @@ definition {
 		}
 
 		task ("Read the intial portal build number") {
-			if (!(contains(${fileContent}, "Initial portal build number: 7413"))) {
+			if (!(contains(${fileContent}, "Portal initial build number: 7413"))) {
 				echo(${fileContent});
 
 				fail("Inital portal build number is not present in upgrade report.");
@@ -35,7 +35,7 @@ definition {
 		task ("Read the final portal build number") {
 			var finalBuildVersion = Upgrade.getBuildNumber();
 
-			if (!(contains(${fileContent}, "Final portal build number: ${finalBuildVersion}"))) {
+			if (!(contains(${fileContent}, "Portal final build number: ${finalBuildVersion}"))) {
 				echo(${fileContent});
 
 				fail("Final portal build number is not present in upgrade report.");
@@ -45,7 +45,7 @@ definition {
 		task ("Read the expected portal build number") {
 			var expectedBuildVersion = Upgrade.getBuildNumber();
 
-			if (!(contains(${fileContent}, "Expected portal build number: ${expectedBuildVersion}"))) {
+			if (!(contains(${fileContent}, "Portal expected build number: ${expectedBuildVersion}"))) {
 				echo(${fileContent});
 
 				fail("Expected portal build number is not present in upgrade report.");
@@ -70,7 +70,7 @@ definition {
 
 			var databaseVersion = PropsUtil.get("database.${databaseType}.version");
 
-			if (!(contains(${fileContent}, "Using ${databaseType} version ${databaseVersion}"))) {
+			if (!(contains(${fileContent}, "Database version: ${databaseType} ${databaseVersion}"))) {
 				echo(${fileContent});
 
 				fail("Database type and version is not present in upgrade report.");
@@ -88,7 +88,7 @@ definition {
 		}
 
 		task ("Read which Document Library Store is being used") {
-			if (!(contains(${fileContent}, "dl.store.impl=com.liferay.portal.store.file.system.FileSystemStore"))) {
+			if (!(contains(${fileContent}, "Property dl.store.impl: com.liferay.portal.store.file.system.FileSystemStore"))) {
 				echo(${fileContent});
 
 				fail("Document library store is not present in upgrade report.");
@@ -96,7 +96,7 @@ definition {
 		}
 
 		task ("Read the size of document library storage") {
-			if (!(contains(${fileContent}, "The document library storage size is 750.03 KB"))) {
+			if (!(contains(${fileContent}, "Document library storage size: 750.03 KB"))) {
 				echo(${fileContent});
 
 				fail("Size of document library storage is not present in upgrade report.");
@@ -116,18 +116,22 @@ definition {
 			var fileContent = FileUtil.read("${liferayHome}/tools/portal-tools-db-upgrade-client/reports/upgrade_report.info");
 		}
 
-		task ("Read the content. Error expected") {
-			if (!(contains(${fileContent}, "Errors thrown during upgrade process"))) {
+		task ("Read the content. Check for error class name and message") {
+			if (!(contains(${fileContent}, "Errors"))) {
+				echo(${fileContent});
+
 				fail("Upgrade report does not contain expected errors.");
 			}
-		}
 
-		task ("Read the content. Check for class name and message") {
 			if (!(contains(${fileContent}, "Class name: com.liferay.portal.tools.DBUpgrader"))) {
+				echo(${fileContent});
+
 				fail("Upgrade report does not contain the error class name.");
 			}
 
-			if (!(contains(${fileContent}, "1 occurrences of the following errors: Unknown column 'servletContextName' in 'where clause'"))) {
+			if (!(contains(${fileContent}, "1 occurrences of the following event: Unknown column 'servletContextName' in 'where clause'"))) {
+				echo(${fileContent});
+
 				fail("Upgrade report does not contain the error message.");
 			}
 		}
@@ -143,7 +147,7 @@ definition {
 		}
 
 		task ("Read the processes list message") {
-			if (!(contains(${fileContent}, "Top 20 longest running upgrade processes"))) {
+			if (!(contains(${fileContent}, "Longest upgrade processes"))) {
 				echo(${fileContent});
 
 				fail("List with the 20 longest upgrade processes not found.");
@@ -192,7 +196,7 @@ definition {
 		}
 
 		task ("Check the total runtime is present") {
-			if (!(contains(${reportFileContent}, "Upgrade completed in"))) {
+			if (!(contains(${reportFileContent}, "Execution time: "))) {
 				echo(${reportFileContent});
 
 				fail("Total runtime is not present in upgrade report.");
@@ -200,7 +204,7 @@ definition {
 		}
 
 		task ("Check the intial portal build number") {
-			if (!(contains(${reportFileContent}, "Initial portal build number:"))) {
+			if (!(contains(${reportFileContent}, "Portal initial build number:"))) {
 				echo(${reportFileContent});
 
 				fail("Inital portal build number is not present in upgrade report.");
@@ -208,7 +212,7 @@ definition {
 		}
 
 		task ("Check the final portal build number") {
-			if (!(contains(${reportFileContent}, "Final portal build number:"))) {
+			if (!(contains(${reportFileContent}, "Portal final build number:"))) {
 				echo(${reportFileContent});
 
 				fail("Final portal build number is not present in upgrade report.");
@@ -216,7 +220,7 @@ definition {
 		}
 
 		task ("Check the expected portal build number") {
-			if (!(contains(${reportFileContent}, "Expected portal build number:"))) {
+			if (!(contains(${reportFileContent}, "Portal expected build number:"))) {
 				echo(${reportFileContent});
 
 				fail("Expected portal build number is not present in upgrade report.");
@@ -224,7 +228,7 @@ definition {
 		}
 
 		task ("Check the intial schema version") {
-			if (!(contains(${reportFileContent}, "Initial portal schema version:"))) {
+			if (!(contains(${reportFileContent}, "Portal initial schema version:"))) {
 				echo(${reportFileContent});
 
 				fail("Inital schema version is not present in upgrade report.");
@@ -232,7 +236,7 @@ definition {
 		}
 
 		task ("check the final schema version") {
-			if (!(contains(${reportFileContent}, "Final portal schema version:"))) {
+			if (!(contains(${reportFileContent}, "Portal final schema version:"))) {
 				echo(${reportFileContent});
 
 				fail("Final schema version is not present in upgrade report.");
@@ -240,7 +244,7 @@ definition {
 		}
 
 		task ("Check the expected schema version") {
-			if (!(contains(${reportFileContent}, "Expected portal schema version:"))) {
+			if (!(contains(${reportFileContent}, "Portal expected schema version:"))) {
 				echo(${reportFileContent});
 
 				fail("Expected schema version is not present in upgrade report.");
@@ -252,7 +256,7 @@ definition {
 
 			var databaseVersion = PropsUtil.get("database.${databaseType}.version");
 
-			if (!(contains(${reportFileContent}, "Using ${databaseType} version ${databaseVersion}"))) {
+			if (!(contains(${reportFileContent}, "Database version: ${databaseType} ${databaseVersion}"))) {
 				echo(${reportFileContent});
 
 				fail("Database type and version is not present in upgrade report.");
@@ -260,7 +264,7 @@ definition {
 		}
 
 		task ("Check the Document Library Store is present") {
-			if (!(contains(${reportFileContent}, "dl.store.impl=com.liferay.portal.store.file.system.FileSystemStore"))) {
+			if (!(contains(${reportFileContent}, "Property dl.store.impl: com.liferay.portal.store.file.system.FileSystemStore"))) {
 				echo(${reportFileContent});
 
 				fail("Document library store is not present in upgrade report.");
@@ -268,7 +272,7 @@ definition {
 		}
 
 		task ("Check the size of document library storage is present") {
-			if (!(contains(${reportFileContent}, "The document library storage size is"))) {
+			if (!(contains(${reportFileContent}, "Document library storage size:"))) {
 				echo(${reportFileContent});
 
 				fail("Size of document library storage is not present in upgrade report.");
@@ -276,13 +280,13 @@ definition {
 		}
 
 		task ("Check the row counts references") {
-			if (!(contains(${reportFileContent}, "Rows (initial)"))) {
+			if (!(contains(${reportFileContent}, "Initial rows"))) {
 				echo(${reportFileContent});
 
 				fail("Initial rows numbers column not present in upgrade report.");
 			}
 
-			if (!(contains(${reportFileContent}, "Rows (final)"))) {
+			if (!(contains(${reportFileContent}, "Final rows"))) {
 				echo(${reportFileContent});
 
 				fail("Final rows numbers column not present in upgrade report.");
@@ -290,7 +294,7 @@ definition {
 		}
 
 		task ("Check the longest processes list is present") {
-			if (!(contains(${reportFileContent}, "Top 20 longest running upgrade processes"))) {
+			if (!(contains(${reportFileContent}, "Longest upgrade processes"))) {
 				echo(${reportFileContent});
 
 				fail("List with the 20 longest upgrade processes not found.");
@@ -298,13 +302,13 @@ definition {
 		}
 
 		task ("Check no errors are thrown") {
-			if (!(contains(${reportFileContent}, "No errors thrown during upgrade"))) {
+			if (!(contains(${reportFileContent}, "Errors: Nothing registered"))) {
 				fail("Upgrade report contains unexpected errors.");
 			}
 		}
 
 		task ("Check no warnings are thrown") {
-			if (!(contains(${reportFileContent}, "No warnings thrown during upgrade"))) {
+			if (!(contains(${reportFileContent}, "Warnings: Nothing registered"))) {
 				fail("Upgrade report contains unexpected warnings.");
 			}
 		}
@@ -320,7 +324,7 @@ definition {
 		}
 
 		task ("Read the new report. No upgrade processes are expected") {
-			if (!(contains(${upgradeReportNew}, "No upgrade processes registered"))) {
+			if (!(contains(${upgradeReportNew}, "Osgi status: There are no pending upgrades"))) {
 				echo(${upgradeReportNew});
 
 				fail("New upgrade report contains unexpected upgrades.");
@@ -359,7 +363,7 @@ definition {
 		}
 
 		task ("Read the report. All upgrade processes are expected") {
-			if (!(contains(${upgradeReportOriginal}, "Top 20 longest running upgrade processes:"))) {
+			if (!(contains(${upgradeReportOriginal}, "Longest upgrade processes"))) {
 				echo(${upgradeReportOriginal});
 
 				fail("Upgrade report does not contains expected upgrades.");
@@ -379,7 +383,7 @@ definition {
 		}
 
 		task ("Read the new report. No upgrade processes are expected") {
-			if (!(contains(${upgradeReportNew}, "No upgrade processes registered"))) {
+			if (!(contains(${upgradeReportNew}, "Osgi status: There are no pending upgrades"))) {
 				echo(${upgradeReportNew});
 
 				fail("New upgrade report contains unexpected upgrades.");
@@ -421,13 +425,13 @@ definition {
 		}
 
 		task ("Read the row counts references") {
-			if (!(contains(${fileContent}, "Rows (initial)"))) {
+			if (!(contains(${fileContent}, "Initial rows"))) {
 				echo(${fileContent});
 
 				fail("Initial rows numbers column not present in upgrade report.");
 			}
 
-			if (!(contains(${fileContent}, "Rows (final)"))) {
+			if (!(contains(${fileContent}, "Final rows"))) {
 				echo(${fileContent});
 
 				fail("Final rows numbers column not present in upgrade report.");
@@ -447,7 +451,7 @@ definition {
 		}
 
 		task ("Read the intial schema version") {
-			if (!(contains(${fileContent}, "Initial portal schema version: 13.1.1"))) {
+			if (!(contains(${fileContent}, "Portal initial schema version: 13.1.1"))) {
 				echo(${fileContent});
 
 				fail("Inital schema version is not present in upgrade report.");
@@ -457,7 +461,7 @@ definition {
 		task ("Read the final schema version") {
 			var finalSchemaVersion = Upgrade.getSchemaVersion(mysqlStatement = "SELECT schemaVersion FROM Release_ WHERE servletContextName='portal';");
 
-			if (!(contains(${fileContent}, "Final portal schema version: ${finalSchemaVersion}"))) {
+			if (!(contains(${fileContent}, "Portal final schema version: ${finalSchemaVersion}"))) {
 				echo(${fileContent});
 
 				fail("Final schema version is not present in upgrade report.");
@@ -467,7 +471,7 @@ definition {
 		task ("Read the expected schema version") {
 			var expectedSchemaVersion = Upgrade.getSchemaVersion(mysqlStatement = "SELECT schemaVersion FROM Release_ WHERE servletContextName='portal';");
 
-			if (!(contains(${fileContent}, "Expected portal schema version: ${expectedSchemaVersion}"))) {
+			if (!(contains(${fileContent}, "Portal expected schema version: ${expectedSchemaVersion}"))) {
 				echo(${fileContent});
 
 				fail("Expected schema version is not present in upgrade report.");
@@ -497,13 +501,13 @@ definition {
 		}
 
 		task ("Capture the upgrade runtime in upgrade Report") {
-			var upgradeRunTimeReport = RegexUtil.replace(${fileContentReport}, "Upgrade completed i\"?n \"?(.*[0-9])", 1);
+			var upgradeRunTimeReport = RegexUtil.replace(${fileContentReport}, "Execution time: (.*[0-9])", 1);
 
 			echo("Upgrade runtime reported by upgrade_report.info is ${upgradeRunTimeReport}");
 		}
 
 		task ("Read the total runtime to see if it's present") {
-			if (!(contains(${fileContentReport}, "Upgrade completed in ${upgradeRunTimeReport}"))) {
+			if (!(contains(${fileContentReport}, "Execution time: ${upgradeRunTimeReport}"))) {
 				echo(${fileContentReport});
 
 				fail("Total runtime is not present in upgrade report.");
@@ -511,7 +515,7 @@ definition {
 		}
 
 		task ("Read the total runtime comparing with the one got in the logs") {
-			if (!(contains(${fileContentReport}, "Upgrade completed in ${upgradeRunTimeLog}"))) {
+			if (!(contains(${fileContentReport}, "Execution time: ${upgradeRunTimeLog}"))) {
 				echo(${fileContentReport});
 
 				fail("Total runtime in upgrade report does not match the runtime in upgrade.log file.");
@@ -551,22 +555,20 @@ definition {
 			var fileContent = FileUtil.read("${liferayHome}/tools/portal-tools-db-upgrade-client/reports/upgrade_report.info");
 		}
 
-		task ("Read the content. Warnings expected") {
-			if (!(contains(${fileContent}, "Warnings thrown during upgrade process"))) {
+		task ("Read the content. Check for warning class name and message") {
+			if (!(contains(${fileContent}, "Warnings"))) {
 				echo(${fileContent});
 
 				fail("Upgrade report does not contain expected warnings.");
 			}
-		}
 
-		task ("Read the content. Check for class name and message") {
 			if (!(contains(${fileContent}, "Class name:"))) {
 				echo(${fileContent});
 
 				fail("Upgrade report does not contain the warning class name.");
 			}
 
-			if (!(contains(${fileContent}, "occurrences of the following warnings: "))) {
+			if (!(contains(${fileContent}, "1 occurrences of the following event: null"))) {
 				echo(${fileContent});
 
 				fail("Upgrade report does not contain the warning message.");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
@@ -280,13 +280,13 @@ definition {
 		}
 
 		task ("Check the row counts references") {
-			if (!(contains(${reportFileContent}, "Initial rows"))) {
+			if (!(contains(${reportFileContent}, "Initial Rows"))) {
 				echo(${reportFileContent});
 
 				fail("Initial rows numbers column not present in upgrade report.");
 			}
 
-			if (!(contains(${reportFileContent}, "Final rows"))) {
+			if (!(contains(${reportFileContent}, "Final Rows"))) {
 				echo(${reportFileContent});
 
 				fail("Final rows numbers column not present in upgrade report.");
@@ -425,13 +425,13 @@ definition {
 		}
 
 		task ("Read the row counts references") {
-			if (!(contains(${fileContent}, "Initial rows"))) {
+			if (!(contains(${fileContent}, "Initial Rows"))) {
 				echo(${fileContent});
 
 				fail("Initial rows numbers column not present in upgrade report.");
 			}
 
-			if (!(contains(${fileContent}, "Final rows"))) {
+			if (!(contains(${fileContent}, "Final Rows"))) {
 				echo(${fileContent});
 
 				fail("Final rows numbers column not present in upgrade report.");


### PR DESCRIPTION
- LPS-158743 Marking the UpgradeReport class as an upgrade related class for the log context
- LPS-158743 Printing the upgrade report in the console as thread context information
- LPS-158743 Improving parseability of the upgrade report when printed as log context information
- LPS-158743 Adding filter to inject to make sure we are getting the right component
- LPS-158743 Adding integration tests to check the upgrade log context information
- LPS-158743 Fixing tests due to missing property setup
- LPS-158743 Improving the UpgradeReport code to make it much more easy to add new sections to it in the future and have less code
- LPS-158743 Changing tests to fit the new upgrade report format
- LPS-158743 Omit Upgrade as first word for every piece of info in the Upgrade Report
- LPS-158743 Simpler keys
- LPS-158743 Do not remove period for properties
- LPS-158743 Underline with the exact number of chars
- LPS-158743 Manual SF
- LPS-158743 Fixing tests due to changes in upgrade report format
- LPS-158743 Improving upgrade report readability
- LPS-158743 Fixing integration tests by adding one missing check and ignoring case in comparisons due to case insensitive databases
- LPS-158743 Update upgrade report tests to fit new format
- LPS-158743 This is done already. Every test method has a new instance of the test class
- LPS-158743 Sort
- LPS-158743 Use SB
- LPS-158743 Sort? #sfme We need to update SF to check LinkedHashMapBuilder too
- LPS-158743 Wordsmith
- LPS-158743 Wordsmith
- LPS-158743 Better this way. Note that I added a . in the check
- LPS-158743 auto SF
- LPS-158743 Simplify
- LPS-158743 Inline
- LPS-158743 Proper name?
- LPS-158743 Better naming
- LPS-158743 Inline
- LPS-158743 We cannot order alphabetically the keys on the LinkedHashMaps because we need the upgrade report to be printed in a specific order to improve readability
- LPS-158743 More clear message
- LPS-158743 Auto SF
- LPS-158743 UnsyncStringWriter should not be static, so every test has its own writer
- LPS-158743 We do not use TableCounts class for this. Let's clarify by using map and a singular compound name. We are storing a map of table counts (all tables and one count per table)
- LPS-158743 When needed
- LPS-158743 Unify message
- LPS-158743 Not needed
- LPS-158743 Capitalize column names
- LPS-171387 New class to control the status of the upgrade process. It takes some logic from the UpgradeReport to get the events information
- LPS-171387 Baseline
- LPS-171387 Adding new exception to SF rule to avoid check on file that does not require check
- LPS-171387 Upgrade report should only be generated when the upgrade.report.enabled property is true, but the UpgradeReportLogAppender needs to be created always to collect data needed for the DBUpgradeStatus class
- LPS-171387 Renaming class as now it is not related exclusively to the upgrade report but the upgrades in general
- LPS-171387 Baseline
- LPS-171387 Calculating the type of upgrade at the end, based on the initial an final schema versions
- LPS-171387 Optimization to avoid reading Release_ table when not needed
- LPS-171387 New component to check if there are pending pending upgrades to be run and unresolved UpgradeStepRegistrator components
- LPS-171387 Applying new DBUpgradeChecker component at the end of upgrades
- LPS-171387 Baseline
- LPS-171387 Printing the upgrade type and result in the log when the upgrade is finished
- LPS-171387 Improving naming
- LPS-171387 For portal, schemaVersion 0.0.0 means that it has not been possible to obtain the value
- LPS-171387 Fixing BDUpgradeTest class by initializing variables properly before test executions
- LPS-171387 Fixing integration tests by resetting the DBUpgradeStatus variables on every test run
- LPS-171387 Adding integration tests for DBUpgradeStatus class
- LPS-171387 Adding integration tests for DBUpgradeCheckerImpl class
- LPS-171387 Baseline
- LPS-171387 Better naming
