### PR TITLE
LPS-176185 Stop calculating DL size when it takes longer than 10 seconds

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -71,7 +71,6 @@ public class UpgradeReport {
 		_initialBuildNumber = _getBuildNumber();
 		_initialSchemaVersion = _getSchemaVersion();
 		_initialTableCounts = _getTableCounts();
-		_DLSizeThread = new DLSizeThread();
 	}
 
 	public void addErrorMessage(String loggerName, String message) {
@@ -264,21 +263,21 @@ public class UpgradeReport {
 				"because the property \"rootDir\" was not set\n";
 		}
 
-		_DLSize = 0;
+		_documentLibrarySize = 0;
 
 		try {
-			_DLSizeThread.start();
+			_documentLibrarySizeThread.start();
 
-			_DLSizeThread.join(PropsValues.DL_STORAGE_INFO_TIMEOUT);
+			_documentLibrarySizeThread.join(
+				PropsValues.DL_STORAGE_INFO_TIMEOUT);
 		}
 		catch (Exception exception) {
 			return exception.getMessage();
 		}
 
-		if (_DLSizeThread.isAlive()) {
-			return
-				"Unable to determine the document library storage size" +
-				" because it is too large. You can check it manually";
+		if (_documentLibrarySizeThread.isAlive()) {
+			return "Unable to determine the document library storage size " +
+				"because it is too large. You can check it manually";
 		}
 
 		String[] dictionary = {"bytes", "KB", "MB", "GB", "TB", "PB"};
@@ -286,14 +285,16 @@ public class UpgradeReport {
 		int index = 0;
 
 		for (index = 0; index < dictionary.length; index++) {
-			if (_DLSize < 1024) {
+			if (_documentLibrarySize < 1024) {
 				break;
 			}
 
-			_DLSize = _DLSize / 1024;
+			_documentLibrarySize = _documentLibrarySize / 1024;
 		}
 
-		String size = String.format("%." + 2 + "f", _DLSize) + " " + dictionary[index];
+		String size =
+			String.format("%." + 2 + "f", _documentLibrarySize) + " " +
+				dictionary[index];
 
 		return "The document library storage size is " + size;
 	}
@@ -626,14 +627,6 @@ public class UpgradeReport {
 				Map.Entry.comparingByValue(Integer::compare)));
 	}
 
-	private class DLSizeThread extends Thread {
-		
-		@Override
-		public void run() {
-			_DLSize = FileUtils.sizeOfDirectory(new File(_rootDir));
-		}
-	}
-
 	private static final String _CONFIGURATION_PID_ADVANCED_FILE_SYSTEM_STORE =
 		"com.liferay.portal.store.file.system.configuration." +
 			"AdvancedFileSystemStoreConfiguration";
@@ -653,6 +646,8 @@ public class UpgradeReport {
 
 	private static final Log _log = LogFactoryUtil.getLog(UpgradeReport.class);
 
+	private double _documentLibrarySize;
+	private final Thread _documentLibrarySizeThread = new DLSizeThread();
 	private final Map<String, Map<String, Integer>> _errorMessages =
 		new ConcurrentHashMap<>();
 	private final Map<String, ArrayList<String>> _eventMessages =
@@ -660,11 +655,19 @@ public class UpgradeReport {
 	private final int _initialBuildNumber;
 	private final String _initialSchemaVersion;
 	private final Map<String, Integer> _initialTableCounts;
-	private Thread _DLSizeThread;
-	private double _DLSize;
 	private PersistenceManager _persistenceManager;
 	private String _rootDir;
 	private final Map<String, Map<String, Integer>> _warningMessages =
 		new ConcurrentHashMap<>();
+
+	private class DLSizeThread extends Thread {
+
+		@Override
+		public void run() {
+			_documentLibrarySize = FileUtils.sizeOfDirectory(
+				new File(_rootDir));
+		}
+
+	}
 
 }

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -258,13 +258,23 @@ public class UpgradeReport {
 				"because the property \"rootDir\" was not set\n";
 		}
 
-		double bytes = 0;
+		_DLSize = 0;
+
+		Thread DLSizeThread = new DLSizeThread();
+
+		DLSizeThread.start();
 
 		try {
-			bytes = FileUtils.sizeOfDirectory(new File(_rootDir));
+			DLSizeThread.join(10000);
 		}
 		catch (Exception exception) {
 			return exception.getMessage();
+		}
+
+		if (DLSizeThread.isAlive()) {
+			return
+				"Unable to determine the document library storage size" +
+				" because it is too large. You can check it manually";
 		}
 
 		String[] dictionary = {"bytes", "KB", "MB", "GB", "TB", "PB"};
@@ -272,16 +282,14 @@ public class UpgradeReport {
 		int index = 0;
 
 		for (index = 0; index < dictionary.length; index++) {
-			if (bytes < 1024) {
+			if (_DLSize < 1024) {
 				break;
 			}
 
-			bytes = bytes / 1024;
+			_DLSize = _DLSize / 1024;
 		}
 
-		String size = StringBundler.concat(
-			String.format("%." + 2 + "f", bytes), StringPool.SPACE,
-			dictionary[index]);
+		String size = String.format("%." + 2 + "f", _DLSize) + " " + dictionary[index];
 
 		return "The document library storage size is " + size;
 	}
@@ -614,6 +622,14 @@ public class UpgradeReport {
 				Map.Entry.comparingByValue(Integer::compare)));
 	}
 
+	public class DLSizeThread extends Thread {
+		
+		@Override
+		public void run() {
+			_DLSize = FileUtils.sizeOfDirectory(new File(_rootDir));
+		}
+	}
+
 	private static final String _CONFIGURATION_PID_ADVANCED_FILE_SYSTEM_STORE =
 		"com.liferay.portal.store.file.system.configuration." +
 			"AdvancedFileSystemStoreConfiguration";
@@ -640,6 +656,8 @@ public class UpgradeReport {
 	private final int _initialBuildNumber;
 	private final String _initialSchemaVersion;
 	private final Map<String, Integer> _initialTableCounts;
+
+	private double _DLSize;
 	private PersistenceManager _persistenceManager;
 	private String _rootDir;
 	private final Map<String, Map<String, Integer>> _warningMessages =

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -71,6 +71,7 @@ public class UpgradeReport {
 		_initialBuildNumber = _getBuildNumber();
 		_initialSchemaVersion = _getSchemaVersion();
 		_initialTableCounts = _getTableCounts();
+		_DLSizeThread = new DLSizeThread();
 	}
 
 	public void addErrorMessage(String loggerName, String message) {
@@ -265,18 +266,16 @@ public class UpgradeReport {
 
 		_DLSize = 0;
 
-		Thread DLSizeThread = new DLSizeThread();
-
-		DLSizeThread.start();
-
 		try {
-			DLSizeThread.join(10000);
+			_DLSizeThread.start();
+
+			_DLSizeThread.join(10000);
 		}
 		catch (Exception exception) {
 			return exception.getMessage();
 		}
 
-		if (DLSizeThread.isAlive()) {
+		if (_DLSizeThread.isAlive()) {
 			return
 				"Unable to determine the document library storage size" +
 				" because it is too large. You can check it manually";
@@ -627,7 +626,7 @@ public class UpgradeReport {
 				Map.Entry.comparingByValue(Integer::compare)));
 	}
 
-	public class DLSizeThread extends Thread {
+	private class DLSizeThread extends Thread {
 		
 		@Override
 		public void run() {
@@ -661,7 +660,7 @@ public class UpgradeReport {
 	private final int _initialBuildNumber;
 	private final String _initialSchemaVersion;
 	private final Map<String, Integer> _initialTableCounts;
-
+	private Thread _DLSizeThread;
 	private double _DLSize;
 	private PersistenceManager _persistenceManager;
 	private String _rootDir;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -120,6 +120,10 @@ public class UpgradeReport {
 		try {
 			File reportFile = _getReportFile();
 
+			if (_log.isInfoEnabled()) {
+				_log.info("Starting Upgrade Report generation");
+			}
+
 			FileUtil.write(
 				reportFile,
 				StringUtil.merge(
@@ -137,6 +141,7 @@ public class UpgradeReport {
 					StringPool.NEW_LINE + StringPool.NEW_LINE));
 
 			if (_log.isInfoEnabled()) {
+				_log.info("Upgrade Report generation completed");
 				_log.info(
 					"Upgrade report generated in " +
 						reportFile.getAbsolutePath());

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -269,7 +269,7 @@ public class UpgradeReport {
 		try {
 			_DLSizeThread.start();
 
-			_DLSizeThread.join(10000);
+			_DLSizeThread.join(PropsValues.DL_STORAGE_INFO_TIMEOUT);
 		}
 		catch (Exception exception) {
 			return exception.getMessage();

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -16,7 +16,6 @@ package com.liferay.portal.upgrade.test;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.bean.BeanPropertiesImpl;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -72,7 +71,8 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 			DBUpgrader.class, "_upgradeClient", _originalUpgradeClient);
 
 		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "DL_STORAGE_INFO_TIMEOUT", _originalDLStorageTimeout);
+			PropsValues.class, "DL_STORAGE_INFO_TIMEOUT",
+			_originalDLStorageTimeout);
 	}
 
 	@After
@@ -173,6 +173,95 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 			previousInitialCount = initialCount;
 			previousTableName = tableName;
 		}
+	}
+
+	@Test
+	public void testGetDLStorageInfoAfterTimeout() throws Exception {
+		_appender.start();
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "DL_STORAGE_INFO_TIMEOUT", 1);
+
+		Object upgradeReport = ReflectionTestUtil.getFieldValue(
+			_appender, "_upgradeReport");
+		
+		ReflectionTestUtil.setFieldValue(
+			upgradeReport, "_DLSizeThread",
+			new Thread() {
+
+				@Override
+				public void run() {
+					try {
+						long timeout = ReflectionTestUtil.getFieldValue(
+							PropsValues.class, "DL_STORAGE_INFO_TIMEOUT");
+
+						sleep(timeout + 5);
+					}
+					catch (InterruptedException interruptedException) {
+						throw new RuntimeException(interruptedException);
+					}
+				}
+
+			});
+
+		_appender.stop();
+
+		_assertReport(
+			"Unable to determine the document library storage size because " +
+				"it is too large. You can check it manually");
+	}
+
+	@Test
+	public void testGetDLStorageInfoBeforeTimeout() throws Exception {
+		_appender.start();
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "DL_STORAGE_INFO_TIMEOUT", 5);
+
+		Object upgradeReport = ReflectionTestUtil.getFieldValue(
+			_appender, "_upgradeReport");
+
+		ReflectionTestUtil.setFieldValue(
+			upgradeReport, "_DLSizeThread",
+			new Thread() {
+
+				@Override
+				public void run() {
+					try {
+						long timeout = ReflectionTestUtil.getFieldValue(
+							PropsValues.class, "DL_STORAGE_INFO_TIMEOUT");
+
+						sleep(timeout / 5);
+					}
+					catch (InterruptedException interruptedException) {
+						throw new RuntimeException(interruptedException);
+					}
+				}
+
+			});
+
+		_appender.stop();
+
+		double documentLibrarySize = ReflectionTestUtil.getFieldValue(
+			upgradeReport, "_DLSize");
+
+		String[] dictionary = {"bytes", "KB", "MB", "GB", "TB", "PB"};
+
+		int index = 0;
+
+		for (index = 0; index < dictionary.length; index++) {
+			if (documentLibrarySize < 1024) {
+				break;
+			}
+
+			documentLibrarySize = documentLibrarySize / 1024;
+		}
+
+		String size =
+			String.format("%." + 2 + "f", documentLibrarySize) + " " +
+				dictionary[index];
+
+		_assertReport("The document library storage size is " + size);
 	}
 
 	@Test
@@ -285,93 +374,6 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	}
 
 	@Test
-	public void testGetDLStorageInfoAfterTimeout() throws Exception {
-
-		_appender.start();
-
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "DL_STORAGE_INFO_TIMEOUT", 1);
-
-		Object upgradeReport = ReflectionTestUtil.getFieldValue(
-			_appender,"_upgradeReport");
-
-		//getset
-		ReflectionTestUtil.setFieldValue(upgradeReport, "_DLSizeThread",
-			new Thread() {
-			@Override
-			public void run() {
-				try {
-					sleep((long) ReflectionTestUtil.getFieldValue(
-						PropsValues.class, "DL_STORAGE_INFO_TIMEOUT")
-						  + 5);
-				}
-				catch (InterruptedException e) {
-					throw new RuntimeException(e);
-				}
-			}
-		});
-
-		_appender.stop();
-
-		_assertReport("Unable to determine the document library " +
-					  "storage size because it is too large. You can check " +
-					  "it manually");
-	}
-
-
-
-	@Test
-	public void testGetDLStorageInfoBeforeTimeout() throws Exception {
-
-		_appender.start();
-
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "DL_STORAGE_INFO_TIMEOUT", 5);
-
-		Object upgradeReport = ReflectionTestUtil.getFieldValue(_appender,"_upgradeReport");
-
-		ReflectionTestUtil.setFieldValue(upgradeReport, "_DLSizeThread", new Thread() {
-			@Override
-			public void run() {
-				try {
-					sleep((long) ReflectionTestUtil.getFieldValue(
-						PropsValues.class, "DL_STORAGE_INFO_TIMEOUT")
-						  / 5);
-				}
-				catch (InterruptedException e) {
-					throw new RuntimeException(e);
-				}
-			}
-		});
-
-		_appender.stop();
-
-		double documentLibrarySize = ReflectionTestUtil.getFieldValue(upgradeReport,
-			"_DLSize");
-
-		String[] dictionary = {"bytes", "KB", "MB", "GB", "TB", "PB"};
-
-		int index = 0;
-
-		for (index = 0; index < dictionary.length; index++) {
-			if (documentLibrarySize < 1024) {
-				break;
-			}
-
-			documentLibrarySize = documentLibrarySize / 1024;
-		}
-
-		String size = String.format("%." + 2 + "f", documentLibrarySize) + " " + dictionary[index];
-
-
-		_assertReport(
-			StringBundler.concat(
-				"The document library storage size is ",
-				size));
-
-	}
-
-	@Test
 	public void testSchemaVersion() throws Exception {
 		Release release = _releaseLocalService.getRelease(1);
 
@@ -427,7 +429,6 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_originalDLStorageTimeout = ReflectionTestUtil.getFieldValue(
 			PropsValues.class, "DL_STORAGE_INFO_TIMEOUT");
-
 	}
 
 	protected abstract String getFilePath();
@@ -454,8 +455,8 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	}
 
 	private static DB _db;
-	private static boolean _originalUpgradeClient;
 	private static long _originalDLStorageTimeout;
+	private static boolean _originalUpgradeClient;
 	private static final Pattern _pattern = Pattern.compile(
 		"(\\w+_?)\\s+(\\d+|-)\\s+(\\d+|-)\n");
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -16,6 +16,7 @@ package com.liferay.portal.upgrade.test;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.bean.BeanPropertiesImpl;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -69,6 +70,9 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		ReflectionTestUtil.setFieldValue(
 			DBUpgrader.class, "_upgradeClient", _originalUpgradeClient);
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "DL_STORAGE_INFO_TIMEOUT", _originalDLStorageTimeout);
 	}
 
 	@After
@@ -281,6 +285,93 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	}
 
 	@Test
+	public void testGetDLStorageInfoAfterTimeout() throws Exception {
+
+		_appender.start();
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "DL_STORAGE_INFO_TIMEOUT", 1);
+
+		Object upgradeReport = ReflectionTestUtil.getFieldValue(
+			_appender,"_upgradeReport");
+
+		//getset
+		ReflectionTestUtil.setFieldValue(upgradeReport, "_DLSizeThread",
+			new Thread() {
+			@Override
+			public void run() {
+				try {
+					sleep((long) ReflectionTestUtil.getFieldValue(
+						PropsValues.class, "DL_STORAGE_INFO_TIMEOUT")
+						  + 5);
+				}
+				catch (InterruptedException e) {
+					throw new RuntimeException(e);
+				}
+			}
+		});
+
+		_appender.stop();
+
+		_assertReport("Unable to determine the document library " +
+					  "storage size because it is too large. You can check " +
+					  "it manually");
+	}
+
+
+
+	@Test
+	public void testGetDLStorageInfoBeforeTimeout() throws Exception {
+
+		_appender.start();
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "DL_STORAGE_INFO_TIMEOUT", 5);
+
+		Object upgradeReport = ReflectionTestUtil.getFieldValue(_appender,"_upgradeReport");
+
+		ReflectionTestUtil.setFieldValue(upgradeReport, "_DLSizeThread", new Thread() {
+			@Override
+			public void run() {
+				try {
+					sleep((long) ReflectionTestUtil.getFieldValue(
+						PropsValues.class, "DL_STORAGE_INFO_TIMEOUT")
+						  / 5);
+				}
+				catch (InterruptedException e) {
+					throw new RuntimeException(e);
+				}
+			}
+		});
+
+		_appender.stop();
+
+		double documentLibrarySize = ReflectionTestUtil.getFieldValue(upgradeReport,
+			"_DLSize");
+
+		String[] dictionary = {"bytes", "KB", "MB", "GB", "TB", "PB"};
+
+		int index = 0;
+
+		for (index = 0; index < dictionary.length; index++) {
+			if (documentLibrarySize < 1024) {
+				break;
+			}
+
+			documentLibrarySize = documentLibrarySize / 1024;
+		}
+
+		String size = String.format("%." + 2 + "f", documentLibrarySize) + " " + dictionary[index];
+
+
+		_assertReport(
+			StringBundler.concat(
+				"The document library storage size is ",
+				size));
+
+	}
+
+	@Test
 	public void testSchemaVersion() throws Exception {
 		Release release = _releaseLocalService.getRelease(1);
 
@@ -333,6 +424,10 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		ReflectionTestUtil.setFieldValue(
 			DBUpgrader.class, "_upgradeClient", upgradeClient);
+
+		_originalDLStorageTimeout = ReflectionTestUtil.getFieldValue(
+			PropsValues.class, "DL_STORAGE_INFO_TIMEOUT");
+
 	}
 
 	protected abstract String getFilePath();
@@ -360,6 +455,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 	private static DB _db;
 	private static boolean _originalUpgradeClient;
+	private static long _originalDLStorageTimeout;
 	private static final Pattern _pattern = Pattern.compile(
 		"(\\w+_?)\\s+(\\d+|-)\\s+(\\d+|-)\n");
 

--- a/modules/util/portal-tools-db-upgrade-client/src/main/resources/portal-upgrade.properties
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/resources/portal-upgrade.properties
@@ -7,15 +7,15 @@ schema.run.enabled=false
 
 upgrade.database.auto.run=true
 
+dl.storage.info.timeout=10000
+
 hibernate.jdbc.batch_size=250
 
 index.on.startup=false
 
-dependency.manager.thread.pool.enabled=false
-
 module.framework.properties.blacklist.portal.profile.names=com.liferay.portal.properties.swapper
 module.framework.properties.osgi.console=localhost:11311
 
-scheduler.enabled=false
+dependency.manager.thread.pool.enabled=false
 
-dl.storage.info.timeout=10000
+scheduler.enabled=false

--- a/modules/util/portal-tools-db-upgrade-client/src/main/resources/portal-upgrade.properties
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/resources/portal-upgrade.properties
@@ -17,3 +17,5 @@ module.framework.properties.blacklist.portal.profile.names=com.liferay.portal.pr
 module.framework.properties.osgi.console=localhost:11311
 
 scheduler.enabled=false
+
+dl.storage.info.timeout=10000

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -756,6 +756,11 @@ public class PropsValues {
 	public static final String[] DL_REPOSITORY_IMPL = PropsUtil.getArray(
 		PropsKeys.DL_REPOSITORY_IMPL);
 
+	public static final long DL_STORAGE_INFO_TIMEOUT =
+		GetterUtil.getLong(
+			PropsUtil.get(
+				PropsKeys.DL_STORAGE_INFO_TIMEOUT));
+
 	public static boolean DL_STORE_ANTIVIRUS_ENABLED = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.DL_STORE_ANTIVIRUS_ENABLED));
 

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -756,10 +756,8 @@ public class PropsValues {
 	public static final String[] DL_REPOSITORY_IMPL = PropsUtil.getArray(
 		PropsKeys.DL_REPOSITORY_IMPL);
 
-	public static final long DL_STORAGE_INFO_TIMEOUT =
-		GetterUtil.getLong(
-			PropsUtil.get(
-				PropsKeys.DL_STORAGE_INFO_TIMEOUT));
+	public static final long DL_STORAGE_INFO_TIMEOUT = GetterUtil.getLong(
+		PropsUtil.get(PropsKeys.DL_STORAGE_INFO_TIMEOUT));
 
 	public static boolean DL_STORE_ANTIVIRUS_ENABLED = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.DL_STORE_ANTIVIRUS_ENABLED));

--- a/portal-impl/src/portal-developer.properties
+++ b/portal-impl/src/portal-developer.properties
@@ -1,6 +1,7 @@
 schema.module.build.auto.upgrade=true
 
 upgrade.database.auto.run=true
+dl.storage.info.timeout=10000
 
 theme.css.fast.load=false
 theme.css.fast.load.check.request.parameter=true

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -174,6 +174,14 @@
     #
     upgrade.report.enabled=false
 
+    #
+    # Set the timeout in milliseconds to calculate the DL size in bytes
+    # while the upgrade report is being generated.
+    #
+    # Env: DL_STORAGE_INFO_TIMEOUT
+    #
+    dl.storage.info.timeout=10000
+
 ##
 ## Auto Deploy
 ##

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -175,10 +175,10 @@
     upgrade.report.enabled=false
 
     #
-    # Set the timeout in milliseconds to calculate the DL size in bytes
-    # while the upgrade report is being generated.
+    # Set the timeout in milliseconds to calculate the DL size in bytes while
+    # the upgrade report is being generated.
     #
-    # Env: DL_STORAGE_INFO_TIMEOUT
+    # Env: LIFERAY_DL_PERIOD_STORAGE_PERIOD_INFO_PERIOD_TIMEOUT
     #
     dl.storage.info.timeout=10000
 
@@ -6573,6 +6573,11 @@
     # Env: LIFERAY_FEATURE_PERIOD_FLAG_PERIOD__UPPERCASEL__UPPERCASEP__UPPERCASES__MINUS__NUMBER1__NUMBER7__NUMBER3__NUMBER8__NUMBER9__NUMBER4_
     #
     feature.flag.LPS-173894=false
+
+    #
+    # Env: LIFERAY_FEATURE_PERIOD_FLAG_PERIOD__UPPERCASEL__UPPERCASEP__UPPERCASES__MINUS__NUMBER1__NUMBER7__NUMBER5__NUMBER8__NUMBER5__NUMBER0_
+    #
+    feature.flag.LPS-175850=false
 
     #
     # Env: LIFERAY_FEATURE_PERIOD_FLAG_PERIOD__UPPERCASEL__UPPERCASEP__UPPERCASES__MINUS__NUMBER1__NUMBER7__NUMBER6__NUMBER0__NUMBER8__NUMBER3_

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -918,6 +918,9 @@ public interface PropsKeys {
 	public static final String DL_SHOW_HIDDEN_MOUNT_FOLDERS =
 		"dl.show.hidden.mount.folders";
 
+	public static final String DL_STORAGE_INFO_TIMEOUT =
+		"dl.storage.info.timeout";
+
 	public static final String DL_STORE_ANTIVIRUS_ENABLED =
 		"dl.store.antivirus.enabled";
 


### PR DESCRIPTION
- LPS-171285 Stop calculating DL size when it takes longer than 10 seconds
- LPS-171285 Add logging at the beginning and at the end of Upgrade Report
- LPS-171285 Change DLSizeThread class to private and add _DLSizeThread attribute to UpgradeReport class
- LPS-171285 Add DL_STORAGE_INFO_TIMEOUT property
- LPS-171285 Add tests
- LPS-171285 SF
