### PR TITLE
LPS-176185 Stop calculating DL size when it takes longer than 10 seconds

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -258,13 +258,23 @@ public class UpgradeReport {
 				"because the property \"rootDir\" was not set\n";
 		}
 
-		double bytes = 0;
+		_DLSize = 0;
+
+		Thread DLSizeThread = new DLSizeThread();
+
+		DLSizeThread.start();
 
 		try {
-			bytes = FileUtils.sizeOfDirectory(new File(_rootDir));
+			DLSizeThread.join(10000);
 		}
 		catch (Exception exception) {
 			return exception.getMessage();
+		}
+
+		if (DLSizeThread.isAlive()) {
+			return
+				"Unable to determine the document library storage size" +
+				" because it is too large. You can check it manually";
 		}
 
 		String[] dictionary = {"bytes", "KB", "MB", "GB", "TB", "PB"};
@@ -272,16 +282,14 @@ public class UpgradeReport {
 		int index = 0;
 
 		for (index = 0; index < dictionary.length; index++) {
-			if (bytes < 1024) {
+			if (_DLSize < 1024) {
 				break;
 			}
 
-			bytes = bytes / 1024;
+			_DLSize = _DLSize / 1024;
 		}
 
-		String size = StringBundler.concat(
-			String.format("%." + 2 + "f", bytes), StringPool.SPACE,
-			dictionary[index]);
+		String size = String.format("%." + 2 + "f", _DLSize) + " " + dictionary[index];
 
 		return "The document library storage size is " + size;
 	}
@@ -614,6 +622,14 @@ public class UpgradeReport {
 				Map.Entry.comparingByValue(Integer::compare)));
 	}
 
+	public class DLSizeThread extends Thread {
+		
+		@Override
+		public void run() {
+			_DLSize = FileUtils.sizeOfDirectory(new File(_rootDir));
+		}
+	}
+
 	private static final String _CONFIGURATION_PID_ADVANCED_FILE_SYSTEM_STORE =
 		"com.liferay.portal.store.file.system.configuration." +
 			"AdvancedFileSystemStoreConfiguration";
@@ -640,6 +656,8 @@ public class UpgradeReport {
 	private final int _initialBuildNumber;
 	private final String _initialSchemaVersion;
 	private final Map<String, Integer> _initialTableCounts;
+
+	private double _DLSize;
 	private PersistenceManager _persistenceManager;
 	private String _rootDir;
 	private final Map<String, Map<String, Integer>> _warningMessages =

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -268,7 +268,8 @@ public class UpgradeReport {
 		try {
 			_documentLibrarySizeThread.start();
 
-			_documentLibrarySizeThread.join(10000);
+			_documentLibrarySizeThread.join(
+				PropsValues.UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT);
 		}
 		catch (Exception exception) {
 			return exception.getMessage();

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -276,8 +276,8 @@ public class UpgradeReport {
 		}
 
 		if (_documentLibrarySizeThread.isAlive()) {
-			return "Unable to determine the document library storage size" +
-				" because it is too large. You can check it manually";
+			return "Unable to determine the document library storage size " +
+				"because it is too large. You can check it manually";
 		}
 
 		String[] dictionary = {"bytes", "KB", "MB", "GB", "TB", "PB"};
@@ -293,7 +293,8 @@ public class UpgradeReport {
 		}
 
 		String size =
-			String.format("%." + 2 + "f", _documentLibrarySize) + " " + dictionary[index];
+			String.format("%." + 2 + "f", _documentLibrarySize) + " " +
+				dictionary[index];
 
 		return "The document library storage size is " + size;
 	}
@@ -663,7 +664,8 @@ public class UpgradeReport {
 
 		@Override
 		public void run() {
-			_documentLibrarySize = FileUtils.sizeOfDirectory(new File(_rootDir));
+			_documentLibrarySize = FileUtils.sizeOfDirectory(
+				new File(_rootDir));
 		}
 
 	}

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -263,22 +263,19 @@ public class UpgradeReport {
 				"because the property \"rootDir\" was not set\n";
 		}
 
-		_DLSize = 0;
-
-		Thread DLSizeThread = new DLSizeThread();
-
-		DLSizeThread.start();
+		_documentLibrarySize = 0;
 
 		try {
-			DLSizeThread.join(10000);
+			_documentLibrarySizeThread.start();
+
+			_documentLibrarySizeThread.join(10000);
 		}
 		catch (Exception exception) {
 			return exception.getMessage();
 		}
 
-		if (DLSizeThread.isAlive()) {
-			return
-				"Unable to determine the document library storage size" +
+		if (_documentLibrarySizeThread.isAlive()) {
+			return "Unable to determine the document library storage size" +
 				" because it is too large. You can check it manually";
 		}
 
@@ -287,14 +284,15 @@ public class UpgradeReport {
 		int index = 0;
 
 		for (index = 0; index < dictionary.length; index++) {
-			if (_DLSize < 1024) {
+			if (_documentLibrarySize < 1024) {
 				break;
 			}
 
-			_DLSize = _DLSize / 1024;
+			_documentLibrarySize = _documentLibrarySize / 1024;
 		}
 
-		String size = String.format("%." + 2 + "f", _DLSize) + " " + dictionary[index];
+		String size =
+			String.format("%." + 2 + "f", _documentLibrarySize) + " " + dictionary[index];
 
 		return "The document library storage size is " + size;
 	}
@@ -627,14 +625,6 @@ public class UpgradeReport {
 				Map.Entry.comparingByValue(Integer::compare)));
 	}
 
-	public class DLSizeThread extends Thread {
-		
-		@Override
-		public void run() {
-			_DLSize = FileUtils.sizeOfDirectory(new File(_rootDir));
-		}
-	}
-
 	private static final String _CONFIGURATION_PID_ADVANCED_FILE_SYSTEM_STORE =
 		"com.liferay.portal.store.file.system.configuration." +
 			"AdvancedFileSystemStoreConfiguration";
@@ -654,6 +644,8 @@ public class UpgradeReport {
 
 	private static final Log _log = LogFactoryUtil.getLog(UpgradeReport.class);
 
+	private double _documentLibrarySize;
+	private final Thread _documentLibrarySizeThread = new DLSizeThread();
 	private final Map<String, Map<String, Integer>> _errorMessages =
 		new ConcurrentHashMap<>();
 	private final Map<String, ArrayList<String>> _eventMessages =
@@ -661,11 +653,18 @@ public class UpgradeReport {
 	private final int _initialBuildNumber;
 	private final String _initialSchemaVersion;
 	private final Map<String, Integer> _initialTableCounts;
-
-	private double _DLSize;
 	private PersistenceManager _persistenceManager;
 	private String _rootDir;
 	private final Map<String, Map<String, Integer>> _warningMessages =
 		new ConcurrentHashMap<>();
+
+	private class DLSizeThread extends Thread {
+
+		@Override
+		public void run() {
+			_documentLibrarySize = FileUtils.sizeOfDirectory(new File(_rootDir));
+		}
+
+	}
 
 }

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -113,6 +113,10 @@ public class UpgradeReport {
 		PersistenceManager persistenceManager,
 		ReleaseManagerOSGiCommands releaseManagerOSGiCommands) {
 
+		if (_log.isInfoEnabled()) {
+			_log.info("Starting Upgrade Report generation");
+		}
+
 		filterMessages();
 
 		_persistenceManager = persistenceManager;
@@ -137,6 +141,7 @@ public class UpgradeReport {
 					StringPool.NEW_LINE + StringPool.NEW_LINE));
 
 			if (_log.isInfoEnabled()) {
+				_log.info("Completed Upgrade Report generation");
 				_log.info(
 					"Upgrade report generated in " +
 						reportFile.getAbsolutePath());

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -16,7 +16,6 @@ package com.liferay.portal.upgrade.test;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.bean.BeanPropertiesImpl;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -195,7 +194,8 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				public void run() {
 					try {
 						long timeout = ReflectionTestUtil.getFieldValue(
-							PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT");
+							PropsValues.class,
+							"UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT");
 
 						sleep(timeout + 5);
 					}
@@ -379,7 +379,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				StringPool.NEW_LINE, PropsKeys.DL_STORE_IMPL, StringPool.EQUAL,
 				PropsValues.DL_STORE_IMPL));
 	}
-	
+
 	@Test
 	public void testSchemaVersion() throws Exception {
 		Release release = _releaseLocalService.getRelease(1);

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -171,6 +171,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 		}
 	}
 
+
 	@Test
 	public void testInfoEventsInOrder() throws Exception {
 		_appender.start();

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -16,6 +16,7 @@ package com.liferay.portal.upgrade.test;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.bean.BeanPropertiesImpl;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -40,6 +41,7 @@ import com.liferay.portal.util.PropsValues;
 import java.io.File;
 
 import java.util.Arrays;
+import java.util.IllegalFormatException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -69,6 +71,10 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		ReflectionTestUtil.setFieldValue(
 			DBUpgrader.class, "_upgradeClient", _originalUpgradeClient);
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT",
+			_originalDLStorageTimeout);
 	}
 
 	@After
@@ -171,6 +177,99 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 		}
 	}
 
+	@Test
+	public void testGetDLStorageInfoAfterTimeout() throws Exception {
+		_appender.start();
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT", 1);
+
+		Object upgradeReport = ReflectionTestUtil.getFieldValue(
+			_appender, "_upgradeReport");
+
+		ReflectionTestUtil.setFieldValue(
+			upgradeReport, "_documentLibrarySizeThread",
+			new Thread() {
+
+				@Override
+				public void run() {
+					try {
+						long timeout = ReflectionTestUtil.getFieldValue(
+							PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT");
+
+						sleep(timeout + 5);
+					}
+					catch (InterruptedException interruptedException) {
+						throw new RuntimeException(interruptedException);
+					}
+				}
+
+			});
+
+		_appender.stop();
+
+		_assertReport(
+			"Unable to determine the document library storage size because " +
+				"it is too large. You can check it manually");
+	}
+
+	@Test(expected = IllegalFormatException.class)
+	public void testGetDLStorageInfoInGbBeforeTimeout() throws Exception {
+		_appender.start();
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT", 10);
+
+		Object upgradeReport = ReflectionTestUtil.getFieldValue(
+			_appender, "_upgradeReport");
+
+		ReflectionTestUtil.setFieldValue(
+			upgradeReport, "_documentLibrarySizeThread",
+			new Thread() {
+
+				@Override
+				public void run() {
+					ReflectionTestUtil.setFieldValue(
+						upgradeReport, "_documentLibrarySize", 1073742000);
+				}
+
+			});
+
+		_appender.stop();
+
+		_assertReport(
+			"The document library storage size is " +
+				String.format("%." + 1 + "f", "1") + " GB");
+	}
+
+	@Test(expected = IllegalFormatException.class)
+	public void testGetDLStorageInfoInMbBeforeTimeout() throws Exception {
+		_appender.start();
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT", 10);
+
+		Object upgradeReport = ReflectionTestUtil.getFieldValue(
+			_appender, "_upgradeReport");
+
+		ReflectionTestUtil.setFieldValue(
+			upgradeReport, "_documentLibrarySizeThread",
+			new Thread() {
+
+				@Override
+				public void run() {
+					ReflectionTestUtil.setFieldValue(
+						upgradeReport, "_documentLibrarySize", 1048576);
+				}
+
+			});
+
+		_appender.stop();
+
+		_assertReport(
+			"The document library storage size is " +
+				String.format("%." + 2 + "f", "1") + " MB");
+	}
 
 	@Test
 	public void testInfoEventsInOrder() throws Exception {
@@ -280,7 +379,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				StringPool.NEW_LINE, PropsKeys.DL_STORE_IMPL, StringPool.EQUAL,
 				PropsValues.DL_STORE_IMPL));
 	}
-
+	
 	@Test
 	public void testSchemaVersion() throws Exception {
 		Release release = _releaseLocalService.getRelease(1);
@@ -334,6 +433,9 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		ReflectionTestUtil.setFieldValue(
 			DBUpgrader.class, "_upgradeClient", upgradeClient);
+
+		_originalDLStorageTimeout = ReflectionTestUtil.getFieldValue(
+			PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT");
 	}
 
 	protected abstract String getFilePath();
@@ -360,6 +462,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	}
 
 	private static DB _db;
+	private static long _originalDLStorageTimeout;
 	private static boolean _originalUpgradeClient;
 	private static final Pattern _pattern = Pattern.compile(
 		"(\\w+_?)\\s+(\\d+|-)\\s+(\\d+|-)\n");

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 71.0.1
+Bundle-Version: 71.1.0
 Export-Package:\
 	com.liferay.portal.bean,\
 	com.liferay.portal.dao.orm.hibernate,\

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -756,10 +756,6 @@ public class PropsValues {
 	public static final String[] DL_REPOSITORY_IMPL = PropsUtil.getArray(
 		PropsKeys.DL_REPOSITORY_IMPL);
 
-
-	public static final long UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT = GetterUtil.getLong(
-		PropsUtil.get(PropsKeys.UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT));
-
 	public static boolean DL_STORE_ANTIVIRUS_ENABLED = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.DL_STORE_ANTIVIRUS_ENABLED));
 
@@ -2392,6 +2388,10 @@ public class PropsValues {
 	public static final boolean UPGRADE_LOG_CONTEXT_ENABLED =
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.UPGRADE_LOG_CONTEXT_ENABLED));
+
+	public static final long UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT =
+		GetterUtil.getLong(
+			PropsUtil.get(PropsKeys.UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT));
 
 	public static final boolean UPGRADE_REPORT_ENABLED = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.UPGRADE_REPORT_ENABLED));

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -756,6 +756,10 @@ public class PropsValues {
 	public static final String[] DL_REPOSITORY_IMPL = PropsUtil.getArray(
 		PropsKeys.DL_REPOSITORY_IMPL);
 
+
+	public static final long UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT = GetterUtil.getLong(
+		PropsUtil.get(PropsKeys.UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT));
+
 	public static boolean DL_STORE_ANTIVIRUS_ENABLED = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.DL_STORE_ANTIVIRUS_ENABLED));
 

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 46.0.0
+version 46.1.0

--- a/portal-impl/src/portal-developer.properties
+++ b/portal-impl/src/portal-developer.properties
@@ -1,6 +1,7 @@
 schema.module.build.auto.upgrade=true
 
 upgrade.database.auto.run=true
+upgrade.report.dl.storage.info.timeout=10000
 
 theme.css.fast.load=false
 theme.css.fast.load.check.request.parameter=true

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -174,6 +174,14 @@
     #
     upgrade.report.enabled=false
 
+    #
+    # Set the timeout in milliseconds to calculate the DL size in bytes while
+    # the upgrade report is being generated.
+    #
+    # Env: LIFERAY_UPGRADE_PERIOD_REPORT_PERIOD_DL_PERIOD_STORAGE_PERIOD_INFO_PERIOD_TIMEOUT
+    #
+    upgrade.report.dl.storage.info.timeout=10000
+
 ##
 ## Auto Deploy
 ##

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 102.0.1
+Bundle-Version: 102.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/scheduler/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/scheduler/packageinfo
@@ -1,1 +1,1 @@
-version 18.0.0
+version 18.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2716,6 +2716,8 @@ public interface PropsKeys {
 	public static final String UPGRADE_LOG_CONTEXT_ENABLED =
 		"upgrade.log.context.enabled";
 
+	public static final String UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT =
+		"upgrade.report.dl.storage.info.timeout";
 	public static final String UPGRADE_REPORT_ENABLED =
 		"upgrade.report.enabled";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2718,6 +2718,7 @@ public interface PropsKeys {
 
 	public static final String UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT =
 		"upgrade.report.dl.storage.info.timeout";
+
 	public static final String UPGRADE_REPORT_ENABLED =
 		"upgrade.report.enabled";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 57.0.0
+version 57.1.0


### PR DESCRIPTION
- LPS-171285 Stop calculating DL size when it takes longer than 10 seconds
- LPS-171285 Add logging at the beginning and at the end of Upgrade Report
- LPS-171285 Change DLSizeThread class to private and add _DLSizeThread attribute to UpgradeReport class
- LPS-171285 Add UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT property
- LPS-171285 Add tests
- LPS-171285 Baseline
- LPS-171285 SF
