### PR TITLE
LPS-176185 Stop calculating DL size when it takes longer than 10 seconds

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -117,6 +117,10 @@ public class UpgradeReport {
 		PersistenceManager persistenceManager,
 		ReleaseManagerOSGiCommands releaseManagerOSGiCommands) {
 
+		if (_log.isInfoEnabled()) {
+			_log.info("Starting upgrade report generation");
+		}
+
 		filterMessages();
 
 		Map<String, Object> reportData = _getReportData(
@@ -715,6 +719,7 @@ public class UpgradeReport {
 					StringPool.NEW_LINE + StringPool.NEW_LINE));
 
 			if (_log.isInfoEnabled()) {
+				_log.info("Completed upgrade report generation");
 				_log.info(
 					"Upgrade report generated in " +
 					reportFile.getAbsolutePath());

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -128,9 +128,9 @@ public class UpgradeReport {
 
 	private int _getBuildNumber() {
 		try (Connection connection = DataAccess.getConnection();
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				"select buildNumber from Release_ where releaseId = " +
-					ReleaseConstants.DEFAULT_ID)) {
+			 PreparedStatement preparedStatement = connection.prepareStatement(
+				 "select buildNumber from Release_ where releaseId = " +
+				 ReleaseConstants.DEFAULT_ID)) {
 
 			ResultSet resultSet = preparedStatement.executeQuery();
 
@@ -267,18 +267,18 @@ public class UpgradeReport {
 			"property",
 			() -> {
 				if (StringUtil.equals(
-						PropsValues.DL_STORE_IMPL,
-						"com.liferay.portal.store.file.system." +
-							"AdvancedFileSystemStore")) {
+					PropsValues.DL_STORE_IMPL,
+					"com.liferay.portal.store.file.system." +
+					"AdvancedFileSystemStore")) {
 
 					_rootDir = _getRootDir(
 						_CONFIGURATION_PID_ADVANCED_FILE_SYSTEM_STORE,
 						persistenceManager);
 				}
 				else if (StringUtil.equals(
-							PropsValues.DL_STORE_IMPL,
-							"com.liferay.portal.store.file.system." +
-								"FileSystemStore")) {
+					PropsValues.DL_STORE_IMPL,
+					"com.liferay.portal.store.file.system." +
+					"FileSystemStore")) {
 
 					_rootDir = _getRootDir(
 						_CONFIGURATION_PID_FILE_SYSTEM_STORE,
@@ -307,26 +307,35 @@ public class UpgradeReport {
 			"document.library.storage.size",
 			() -> {
 				if (!StringUtil.endsWith(
-						PropsValues.DL_STORE_IMPL, "FileSystemStore")) {
+					PropsValues.DL_STORE_IMPL, "FileSystemStore")) {
 
 					return "Check externally";
 				}
 
 				if (_rootDir == null) {
 					return "Unable to determine. Document library " +
-						"\"rootDir\" was not set";
+						   "\"rootDir\" was not set";
 				}
 
-				double size = 0;
+				_documentLibrarySize = 0;
 
 				try {
-					size = FileUtils.sizeOfDirectory(new File(_rootDir));
+					_documentLibrarySizeThread.start();
+					_documentLibrarySizeThread.join(
+						PropsValues.UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT);
 				}
 				catch (Exception exception) {
 					return exception.getMessage();
 				}
 
-				return LanguageUtil.formatStorageSize(size, LocaleUtil.US);
+				if (_documentLibrarySizeThread.isAlive()) {
+					return
+						"Unable to determine the document library storage size" +
+						" because it is too large. You can check it manually";
+				}
+
+				return LanguageUtil.formatStorageSize(
+					_documentLibrarySize, LocaleUtil.US);
 			}
 		).put(
 			"tables.initial.final.rows",
@@ -375,10 +384,10 @@ public class UpgradeReport {
 						new TablePrinter(
 							(finalTableCount >= 0) ?
 								String.valueOf(finalTableCount) :
-									StringPool.DASH,
+								StringPool.DASH,
 							(initialTableCount >= 0) ?
 								String.valueOf(initialTableCount) :
-									StringPool.DASH,
+								StringPool.DASH,
 							tableName));
 				}
 
@@ -405,7 +414,7 @@ public class UpgradeReport {
 					String className = message.substring(startIndex, endIndex);
 
 					if (className.equals(
-							PortalUpgradeProcess.class.getName())) {
+						PortalUpgradeProcess.class.getName())) {
 
 						continue;
 					}
@@ -428,11 +437,11 @@ public class UpgradeReport {
 				int count = 0;
 
 				for (Map.Entry<String, Integer> entry :
-						ListUtil.sort(
-							new ArrayList<>(upgradeProcessDurations.entrySet()),
-							Collections.reverseOrder(
-								Map.Entry.comparingByValue(
-									Integer::compare)))) {
+					ListUtil.sort(
+						new ArrayList<>(upgradeProcessDurations.entrySet()),
+						Collections.reverseOrder(
+							Map.Entry.comparingByValue(
+								Integer::compare)))) {
 
 					longestRunningUpgradeProcesses.add(
 						new RunningUpgradeProcess(
@@ -545,9 +554,9 @@ public class UpgradeReport {
 
 	private String _getSchemaVersion() {
 		try (Connection connection = DataAccess.getConnection();
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				"select schemaVersion from Release_ where releaseId = " +
-					ReleaseConstants.DEFAULT_ID)) {
+			 PreparedStatement preparedStatement = connection.prepareStatement(
+				 "select schemaVersion from Release_ where releaseId = " +
+				 ReleaseConstants.DEFAULT_ID)) {
 
 			ResultSet resultSet = preparedStatement.executeQuery();
 
@@ -571,8 +580,8 @@ public class UpgradeReport {
 			DBInspector dbInspector = new DBInspector(connection);
 
 			try (ResultSet resultSet1 = databaseMetaData.getTables(
-					dbInspector.getCatalog(), dbInspector.getSchema(), null,
-					new String[] {"TABLE"})) {
+				dbInspector.getCatalog(), dbInspector.getSchema(), null,
+				new String[] {"TABLE"})) {
 
 				Map<String, Integer> tableCounts = new HashMap<>();
 
@@ -580,10 +589,10 @@ public class UpgradeReport {
 					String tableName = resultSet1.getString("TABLE_NAME");
 
 					try (PreparedStatement preparedStatement =
-							connection.prepareStatement(
-								"select count(*) from " + tableName);
-						ResultSet resultSet2 =
-							preparedStatement.executeQuery()) {
+							 connection.prepareStatement(
+								 "select count(*) from " + tableName);
+						 ResultSet resultSet2 =
+							 preparedStatement.executeQuery()) {
 
 						if (resultSet2.next()) {
 							tableCounts.put(tableName, resultSet2.getInt(1));
@@ -708,13 +717,13 @@ public class UpgradeReport {
 			if (_log.isInfoEnabled()) {
 				_log.info(
 					"Upgrade report generated in " +
-						reportFile.getAbsolutePath());
+					reportFile.getAbsolutePath());
 			}
 		}
 		catch (IOException ioException) {
 			_log.error(
 				"Unable to generate the upgrade report in " +
-					reportFile.getAbsolutePath(),
+				reportFile.getAbsolutePath(),
 				ioException);
 		}
 		finally {
@@ -726,21 +735,22 @@ public class UpgradeReport {
 
 	private static final String _CONFIGURATION_PID_ADVANCED_FILE_SYSTEM_STORE =
 		"com.liferay.portal.store.file.system.configuration." +
-			"AdvancedFileSystemStoreConfiguration";
+		"AdvancedFileSystemStoreConfiguration";
 
 	private static final String _CONFIGURATION_PID_FILE_SYSTEM_STORE =
 		"com.liferay.portal.store.file.system.configuration." +
-			"FileSystemStoreConfiguration";
+		"FileSystemStoreConfiguration";
 
 	private static final String[] _FILTERED_CLASS_NAMES = {
 		"com.liferay.portal.search.elasticsearch7.internal.sidecar." +
-			"SidecarManager"
+		"SidecarManager"
 	};
 
 	private static final int _UPGRADE_PROCESSES_COUNT = 20;
 
 	private static final Log _log = LogFactoryUtil.getLog(UpgradeReport.class);
 
+	private final Thread _documentLibrarySizeThread = new DLSizeThread();
 	private final Map<String, Map<String, Integer>> _errorMessages =
 		new ConcurrentHashMap<>();
 	private final Map<String, ArrayList<String>> _eventMessages =
@@ -748,10 +758,19 @@ public class UpgradeReport {
 	private final int _initialBuildNumber;
 	private final String _initialSchemaVersion;
 	private final Map<String, Integer> _initialTableCounts;
+	private double _documentLibrarySize;
 	private boolean _logContext;
 	private String _rootDir;
 	private final Map<String, Map<String, Integer>> _warningMessages =
 		new ConcurrentHashMap<>();
+
+	private class DLSizeThread extends Thread {
+
+		@Override
+		public void run() {
+			_documentLibrarySize = FileUtils.sizeOfDirectory(new File(_rootDir));
+		}
+	}
 
 	private class MessagesPrinter {
 
@@ -767,7 +786,7 @@ public class UpgradeReport {
 		public String toString() {
 			if (_logContext) {
 				return _className + StringPool.COLON +
-					_messagePrinters.toString();
+					   _messagePrinters.toString();
 			}
 
 			StringBundler sb = new StringBundler();

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -719,7 +719,6 @@ public class UpgradeReport {
 					StringPool.NEW_LINE + StringPool.NEW_LINE));
 
 			if (_log.isInfoEnabled()) {
-				_log.info("Completed upgrade report generation");
 				_log.info(
 					"Upgrade report generated in " +
 						reportFile.getAbsolutePath());

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -132,9 +132,9 @@ public class UpgradeReport {
 
 	private int _getBuildNumber() {
 		try (Connection connection = DataAccess.getConnection();
-			 PreparedStatement preparedStatement = connection.prepareStatement(
-				 "select buildNumber from Release_ where releaseId = " +
-				 ReleaseConstants.DEFAULT_ID)) {
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select buildNumber from Release_ where releaseId = " +
+					ReleaseConstants.DEFAULT_ID)) {
 
 			ResultSet resultSet = preparedStatement.executeQuery();
 
@@ -271,18 +271,18 @@ public class UpgradeReport {
 			"property",
 			() -> {
 				if (StringUtil.equals(
-					PropsValues.DL_STORE_IMPL,
-					"com.liferay.portal.store.file.system." +
-					"AdvancedFileSystemStore")) {
+						PropsValues.DL_STORE_IMPL,
+						"com.liferay.portal.store.file.system." +
+							"AdvancedFileSystemStore")) {
 
 					_rootDir = _getRootDir(
 						_CONFIGURATION_PID_ADVANCED_FILE_SYSTEM_STORE,
 						persistenceManager);
 				}
 				else if (StringUtil.equals(
-					PropsValues.DL_STORE_IMPL,
-					"com.liferay.portal.store.file.system." +
-					"FileSystemStore")) {
+							PropsValues.DL_STORE_IMPL,
+							"com.liferay.portal.store.file.system." +
+								"FileSystemStore")) {
 
 					_rootDir = _getRootDir(
 						_CONFIGURATION_PID_FILE_SYSTEM_STORE,
@@ -311,14 +311,14 @@ public class UpgradeReport {
 			"document.library.storage.size",
 			() -> {
 				if (!StringUtil.endsWith(
-					PropsValues.DL_STORE_IMPL, "FileSystemStore")) {
+						PropsValues.DL_STORE_IMPL, "FileSystemStore")) {
 
 					return "Check externally";
 				}
 
 				if (_rootDir == null) {
 					return "Unable to determine. Document library " +
-						   "\"rootDir\" was not set";
+						"\"rootDir\" was not set";
 				}
 
 				_documentLibrarySize = 0;
@@ -333,9 +333,9 @@ public class UpgradeReport {
 				}
 
 				if (_documentLibrarySizeThread.isAlive()) {
-					return
-						"Unable to determine the document library storage size" +
-						" because it is too large. You can check it manually";
+					return "Unable to determine the document library storage " +
+						"size because it is too large. You can check it " +
+							"manually";
 				}
 
 				return LanguageUtil.formatStorageSize(
@@ -388,10 +388,10 @@ public class UpgradeReport {
 						new TablePrinter(
 							(finalTableCount >= 0) ?
 								String.valueOf(finalTableCount) :
-								StringPool.DASH,
+									StringPool.DASH,
 							(initialTableCount >= 0) ?
 								String.valueOf(initialTableCount) :
-								StringPool.DASH,
+									StringPool.DASH,
 							tableName));
 				}
 
@@ -418,7 +418,7 @@ public class UpgradeReport {
 					String className = message.substring(startIndex, endIndex);
 
 					if (className.equals(
-						PortalUpgradeProcess.class.getName())) {
+							PortalUpgradeProcess.class.getName())) {
 
 						continue;
 					}
@@ -441,11 +441,11 @@ public class UpgradeReport {
 				int count = 0;
 
 				for (Map.Entry<String, Integer> entry :
-					ListUtil.sort(
-						new ArrayList<>(upgradeProcessDurations.entrySet()),
-						Collections.reverseOrder(
-							Map.Entry.comparingByValue(
-								Integer::compare)))) {
+						ListUtil.sort(
+							new ArrayList<>(upgradeProcessDurations.entrySet()),
+							Collections.reverseOrder(
+								Map.Entry.comparingByValue(
+									Integer::compare)))) {
 
 					longestRunningUpgradeProcesses.add(
 						new RunningUpgradeProcess(
@@ -558,9 +558,9 @@ public class UpgradeReport {
 
 	private String _getSchemaVersion() {
 		try (Connection connection = DataAccess.getConnection();
-			 PreparedStatement preparedStatement = connection.prepareStatement(
-				 "select schemaVersion from Release_ where releaseId = " +
-				 ReleaseConstants.DEFAULT_ID)) {
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select schemaVersion from Release_ where releaseId = " +
+					ReleaseConstants.DEFAULT_ID)) {
 
 			ResultSet resultSet = preparedStatement.executeQuery();
 
@@ -584,8 +584,8 @@ public class UpgradeReport {
 			DBInspector dbInspector = new DBInspector(connection);
 
 			try (ResultSet resultSet1 = databaseMetaData.getTables(
-				dbInspector.getCatalog(), dbInspector.getSchema(), null,
-				new String[] {"TABLE"})) {
+					dbInspector.getCatalog(), dbInspector.getSchema(), null,
+					new String[] {"TABLE"})) {
 
 				Map<String, Integer> tableCounts = new HashMap<>();
 
@@ -593,10 +593,10 @@ public class UpgradeReport {
 					String tableName = resultSet1.getString("TABLE_NAME");
 
 					try (PreparedStatement preparedStatement =
-							 connection.prepareStatement(
-								 "select count(*) from " + tableName);
-						 ResultSet resultSet2 =
-							 preparedStatement.executeQuery()) {
+							connection.prepareStatement(
+								"select count(*) from " + tableName);
+						ResultSet resultSet2 =
+							preparedStatement.executeQuery()) {
 
 						if (resultSet2.next()) {
 							tableCounts.put(tableName, resultSet2.getInt(1));
@@ -722,13 +722,13 @@ public class UpgradeReport {
 				_log.info("Completed upgrade report generation");
 				_log.info(
 					"Upgrade report generated in " +
-					reportFile.getAbsolutePath());
+						reportFile.getAbsolutePath());
 			}
 		}
 		catch (IOException ioException) {
 			_log.error(
 				"Unable to generate the upgrade report in " +
-				reportFile.getAbsolutePath(),
+					reportFile.getAbsolutePath(),
 				ioException);
 		}
 		finally {
@@ -740,21 +740,22 @@ public class UpgradeReport {
 
 	private static final String _CONFIGURATION_PID_ADVANCED_FILE_SYSTEM_STORE =
 		"com.liferay.portal.store.file.system.configuration." +
-		"AdvancedFileSystemStoreConfiguration";
+			"AdvancedFileSystemStoreConfiguration";
 
 	private static final String _CONFIGURATION_PID_FILE_SYSTEM_STORE =
 		"com.liferay.portal.store.file.system.configuration." +
-		"FileSystemStoreConfiguration";
+			"FileSystemStoreConfiguration";
 
 	private static final String[] _FILTERED_CLASS_NAMES = {
 		"com.liferay.portal.search.elasticsearch7.internal.sidecar." +
-		"SidecarManager"
+			"SidecarManager"
 	};
 
 	private static final int _UPGRADE_PROCESSES_COUNT = 20;
 
 	private static final Log _log = LogFactoryUtil.getLog(UpgradeReport.class);
 
+	private double _documentLibrarySize;
 	private final Thread _documentLibrarySizeThread = new DLSizeThread();
 	private final Map<String, Map<String, Integer>> _errorMessages =
 		new ConcurrentHashMap<>();
@@ -763,7 +764,6 @@ public class UpgradeReport {
 	private final int _initialBuildNumber;
 	private final String _initialSchemaVersion;
 	private final Map<String, Integer> _initialTableCounts;
-	private double _documentLibrarySize;
 	private boolean _logContext;
 	private String _rootDir;
 	private final Map<String, Map<String, Integer>> _warningMessages =
@@ -773,8 +773,10 @@ public class UpgradeReport {
 
 		@Override
 		public void run() {
-			_documentLibrarySize = FileUtils.sizeOfDirectory(new File(_rootDir));
+			_documentLibrarySize = FileUtils.sizeOfDirectory(
+				new File(_rootDir));
 		}
+
 	}
 
 	private class MessagesPrinter {
@@ -791,7 +793,7 @@ public class UpgradeReport {
 		public String toString() {
 			if (_logContext) {
 				return _className + StringPool.COLON +
-					   _messagePrinters.toString();
+					_messagePrinters.toString();
 			}
 
 			StringBundler sb = new StringBundler();

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -19,6 +19,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Release;
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -42,6 +44,7 @@ import java.io.File;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.IllegalFormatException;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -81,6 +84,10 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 		ReflectionTestUtil.setFieldValue(
 			PropsValues.class, "UPGRADE_LOG_CONTEXT_ENABLED",
 			_originalUpgradeLogContextEnabled);
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT",
+			_originalDLStorageTimeout);
 	}
 
 	@Before
@@ -173,7 +180,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				Assert.assertEquals(1, finalTableCount);
 			}
 			else if (StringUtil.equalsIgnoreCase(
-						tableName, "UpgradeReportTable2")) {
+				tableName, "UpgradeReportTable2")) {
 
 				table2Exists = true;
 
@@ -197,6 +204,106 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	}
 
 	@Test
+	public void testGetDLStorageInfoAfterTimeout() throws Exception {
+		_appender.start();
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT", 1);
+
+		Object upgradeReport = ReflectionTestUtil.getFieldValue(
+			_appender, "_upgradeReport");
+
+		ReflectionTestUtil.setFieldValue(
+			upgradeReport, "_documentLibrarySizeThread",
+			new Thread() {
+
+				@Override
+				public void run() {
+					try {
+						long timeout = ReflectionTestUtil.getFieldValue(
+							PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT");
+
+						sleep(timeout + 5);
+					}
+					catch (InterruptedException interruptedException) {
+						throw new RuntimeException(interruptedException);
+					}
+				}
+
+			});
+
+		_appender.stop();
+
+		_assertReport(
+			"Unable to determine the document library storage size because " +
+			"it is too large. You can check it manually");
+	}
+
+	@Test
+	public void testGetDLStorageInfoInGbBeforeTimeout() throws Exception {
+		_appender.start();
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT", 10);
+
+		Object upgradeReport = ReflectionTestUtil.getFieldValue(
+			_appender, "_upgradeReport");
+
+		ReflectionTestUtil.setFieldValue(
+			upgradeReport, "_documentLibrarySizeThread",
+			new Thread() {
+
+				@Override
+				public void run() {
+					ReflectionTestUtil.setFieldValue(
+						upgradeReport, "_documentLibrarySize", 1073742000);
+				}
+
+			});
+
+		_appender.stop();
+		
+			_assertReport(LanguageUtil.formatStorageSize(1073742000,
+				LocaleUtil.US));
+		}
+	}
+
+	@Test
+	public void testGetDLStorageInfoInMbBeforeTimeout() throws Exception {
+		_appender.start();
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT", 10);
+
+		Object upgradeReport = ReflectionTestUtil.getFieldValue(
+			_appender, "_upgradeReport");
+
+		ReflectionTestUtil.setFieldValue(
+			upgradeReport, "_documentLibrarySizeThread",
+			new Thread() {
+
+				@Override
+				public void run() {
+					ReflectionTestUtil.setFieldValue(
+						upgradeReport, "_documentLibrarySize", 1048576);
+				}
+
+			});
+
+		_appender.stop();
+
+<<<<<<< HEAD
+		_assertReport(
+			"The document library storage size is " +
+			LanguageUtil.formatStorageSize(1048576, LocaleUtil.US));
+=======
+			_assertReport(LanguageUtil.formatStorageSize(1048576,
+				LocaleUtil.US));
+		}
+>>>>>>> 83ef2de90136 (LPS-171285 tmp)
+	}
+
+	@Test
 	public void testInfoEventsInOrder() throws Exception {
 		_appender.start();
 
@@ -207,14 +314,14 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		log.info(
 			"Completed upgrade process " + fasterUpgradeProcessName +
-				" in 10 ms");
+			" in 10 ms");
 
 		String slowerUpgradeProcessName =
 			"com.liferay.portal.SlowerUpgradeTest";
 
 		log.info(
 			"Completed upgrade process " + slowerUpgradeProcessName +
-				" in 20401 ms");
+			" in 20401 ms");
 
 		_appender.stop();
 
@@ -222,14 +329,14 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		Assert.assertTrue(
 			reportContent.indexOf(slowerUpgradeProcessName) <
-				reportContent.indexOf(fasterUpgradeProcessName));
+			reportContent.indexOf(fasterUpgradeProcessName));
 
 		String longestUpgradeProcessesValue = _getLogContextValue(
 			"upgrade.report.longest.upgrade.processes");
 
 		Assert.assertTrue(
 			longestUpgradeProcessesValue.indexOf(slowerUpgradeProcessName) <
-				longestUpgradeProcessesValue.indexOf(fasterUpgradeProcessName));
+			longestUpgradeProcessesValue.indexOf(fasterUpgradeProcessName));
 	}
 
 	@Test
@@ -246,7 +353,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		log.info(
 			"Completed upgrade process com.liferay.portal.UpgradeTest in " +
-				"20401 ms");
+			"20401 ms");
 
 		_appender.stop();
 
@@ -413,6 +520,9 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		ReflectionTestUtil.setFieldValue(
 			PropsValues.class, "UPGRADE_LOG_CONTEXT_ENABLED", true);
+
+		_originalDLStorageTimeout = ReflectionTestUtil.getFieldValue(
+			PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT");
 	}
 
 	protected abstract String getFilePath();
@@ -464,7 +574,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		Pattern pattern = Pattern.compile(
 			"(?s)INFO - Upgrade report generated in " + file.getAbsolutePath() +
-				"\\n\\s+\\{(.+)\\}");
+			"\\n\\s+\\{(.+)\\}");
 
 		Matcher matcher = pattern.matcher(_getLogContextContent());
 
@@ -508,6 +618,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	private static Appender _logContextAppender;
 	private static final Pattern _logContextTablesInitialFinalRowsPattern =
 		Pattern.compile("(\\w+_?):(\\d+|-):(\\d+|-)");
+	private static long _originalDLStorageTimeout;
 	private static boolean _originalUpgradeClient;
 	private static boolean _originalUpgradeLogContextEnabled;
 	private static final Pattern _pattern = Pattern.compile(

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -572,7 +572,13 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 			"(?s)INFO - Upgrade report generated in " + file.getAbsolutePath() +
 				"\\n\\s+\\{(.+)\\}");
 
-		Matcher matcher = pattern.matcher(_getLogContextContent());
+		int index = _getLogContextContent().indexOf(
+			"INFO - Upgrade report generated in " + file.getAbsolutePath());
+
+		String substringLogContextContent = _getLogContextContent().substring(
+			index);
+
+		Matcher matcher = pattern.matcher(substringLogContextContent);
 
 		Assert.assertTrue(matcher.matches());
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -180,7 +180,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				Assert.assertEquals(1, finalTableCount);
 			}
 			else if (StringUtil.equalsIgnoreCase(
-				tableName, "UpgradeReportTable2")) {
+						tableName, "UpgradeReportTable2")) {
 
 				table2Exists = true;
 
@@ -221,7 +221,8 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 				public void run() {
 					try {
 						long timeout = ReflectionTestUtil.getFieldValue(
-							PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT");
+							PropsValues.class,
+							"UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT");
 
 						sleep(timeout + 5);
 					}
@@ -236,7 +237,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_assertReport(
 			"Unable to determine the document library storage size because " +
-			"it is too large. You can check it manually");
+				"it is too large. You can check it manually");
 	}
 
 	@Test
@@ -262,10 +263,11 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 			});
 
 		_appender.stop();
-		
-			_assertReport(LanguageUtil.formatStorageSize(1073742000,
-				LocaleUtil.US));
+
+			_assertReport(
+				LanguageUtil.formatStorageSize(1073742000, LocaleUtil.US));
 		}
+
 	}
 
 	@Test
@@ -292,15 +294,9 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		_appender.stop();
 
-<<<<<<< HEAD
 		_assertReport(
-			"The document library storage size is " +
-			LanguageUtil.formatStorageSize(1048576, LocaleUtil.US));
-=======
-			_assertReport(LanguageUtil.formatStorageSize(1048576,
-				LocaleUtil.US));
-		}
->>>>>>> 83ef2de90136 (LPS-171285 tmp)
+				LanguageUtil.formatStorageSize(1048576, LocaleUtil.US));
+
 	}
 
 	@Test
@@ -314,14 +310,14 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		log.info(
 			"Completed upgrade process " + fasterUpgradeProcessName +
-			" in 10 ms");
+				" in 10 ms");
 
 		String slowerUpgradeProcessName =
 			"com.liferay.portal.SlowerUpgradeTest";
 
 		log.info(
 			"Completed upgrade process " + slowerUpgradeProcessName +
-			" in 20401 ms");
+				" in 20401 ms");
 
 		_appender.stop();
 
@@ -329,14 +325,14 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		Assert.assertTrue(
 			reportContent.indexOf(slowerUpgradeProcessName) <
-			reportContent.indexOf(fasterUpgradeProcessName));
+				reportContent.indexOf(fasterUpgradeProcessName));
 
 		String longestUpgradeProcessesValue = _getLogContextValue(
 			"upgrade.report.longest.upgrade.processes");
 
 		Assert.assertTrue(
 			longestUpgradeProcessesValue.indexOf(slowerUpgradeProcessName) <
-			longestUpgradeProcessesValue.indexOf(fasterUpgradeProcessName));
+				longestUpgradeProcessesValue.indexOf(fasterUpgradeProcessName));
 	}
 
 	@Test
@@ -353,7 +349,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		log.info(
 			"Completed upgrade process com.liferay.portal.UpgradeTest in " +
-			"20401 ms");
+				"20401 ms");
 
 		_appender.stop();
 
@@ -574,7 +570,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		Pattern pattern = Pattern.compile(
 			"(?s)INFO - Upgrade report generated in " + file.getAbsolutePath() +
-			"\\n\\s+\\{(.+)\\}");
+				"\\n\\s+\\{(.+)\\}");
 
 		Matcher matcher = pattern.matcher(_getLogContextContent());
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -263,7 +263,7 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 			_assertReport(
 				LanguageUtil.formatStorageSize(1073742000, LocaleUtil.US));
-
+		}
 	}
 
 	@Test
@@ -290,16 +290,9 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 			_appender.stop();
 
-<<<<<<< HEAD
-		_assertReport(
-				LanguageUtil.formatStorageSize(1048576, LocaleUtil.US));
-
-=======
 			_assertReport(
-				"The document library storage size is " +
-					LanguageUtil.formatStorageSize(1048576, LocaleUtil.US));
+				LanguageUtil.formatStorageSize(1048576, LocaleUtil.US));
 		}
->>>>>>> e351a547abc9 (LPS-176185 Let's set the original value after the method completion)
 	}
 
 	@Test

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeReportLogAppenderTestCase.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.upgrade.test;
 
 import com.liferay.petra.io.unsync.UnsyncStringWriter;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DB;
@@ -44,7 +45,6 @@ import java.io.File;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.IllegalFormatException;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -84,10 +84,6 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 		ReflectionTestUtil.setFieldValue(
 			PropsValues.class, "UPGRADE_LOG_CONTEXT_ENABLED",
 			_originalUpgradeLogContextEnabled);
-
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT",
-			_originalDLStorageTimeout);
 	}
 
 	@Before
@@ -207,66 +203,66 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	public void testGetDLStorageInfoAfterTimeout() throws Exception {
 		_appender.start();
 
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT", 1);
+		try (SafeCloseable safeCloseable =
+				_setUpgradeReportDLStorageInfoTimeout(1)) {
 
-		Object upgradeReport = ReflectionTestUtil.getFieldValue(
-			_appender, "_upgradeReport");
+			Object upgradeReport = ReflectionTestUtil.getFieldValue(
+				_appender, "_upgradeReport");
 
-		ReflectionTestUtil.setFieldValue(
-			upgradeReport, "_documentLibrarySizeThread",
-			new Thread() {
+			ReflectionTestUtil.setFieldValue(
+				upgradeReport, "_documentLibrarySizeThread",
+				new Thread() {
 
-				@Override
-				public void run() {
-					try {
-						long timeout = ReflectionTestUtil.getFieldValue(
-							PropsValues.class,
-							"UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT");
+					@Override
+					public void run() {
+						try {
+							long timeout = ReflectionTestUtil.getFieldValue(
+								PropsValues.class,
+								"UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT");
 
-						sleep(timeout + 5);
+							sleep(timeout + 5);
+						}
+						catch (InterruptedException interruptedException) {
+							throw new RuntimeException(interruptedException);
+						}
 					}
-					catch (InterruptedException interruptedException) {
-						throw new RuntimeException(interruptedException);
-					}
-				}
 
-			});
+				});
 
-		_appender.stop();
+			_appender.stop();
 
-		_assertReport(
-			"Unable to determine the document library storage size because " +
-				"it is too large. You can check it manually");
+			_assertReport(
+				"Unable to determine the document library storage size " +
+					"because it is too large. You can check it manually");
+		}
 	}
 
 	@Test
 	public void testGetDLStorageInfoInGbBeforeTimeout() throws Exception {
 		_appender.start();
 
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT", 10);
+		try (SafeCloseable safeCloseable =
+				_setUpgradeReportDLStorageInfoTimeout(10)) {
 
-		Object upgradeReport = ReflectionTestUtil.getFieldValue(
-			_appender, "_upgradeReport");
+			Object upgradeReport = ReflectionTestUtil.getFieldValue(
+				_appender, "_upgradeReport");
 
-		ReflectionTestUtil.setFieldValue(
-			upgradeReport, "_documentLibrarySizeThread",
-			new Thread() {
+			ReflectionTestUtil.setFieldValue(
+				upgradeReport, "_documentLibrarySizeThread",
+				new Thread() {
 
-				@Override
-				public void run() {
-					ReflectionTestUtil.setFieldValue(
-						upgradeReport, "_documentLibrarySize", 1073742000);
-				}
+					@Override
+					public void run() {
+						ReflectionTestUtil.setFieldValue(
+							upgradeReport, "_documentLibrarySize", 1073742000);
+					}
 
-			});
+				});
 
-		_appender.stop();
+			_appender.stop();
 
 			_assertReport(
 				LanguageUtil.formatStorageSize(1073742000, LocaleUtil.US));
-		}
 
 	}
 
@@ -274,29 +270,36 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 	public void testGetDLStorageInfoInMbBeforeTimeout() throws Exception {
 		_appender.start();
 
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT", 10);
+		try (SafeCloseable safeCloseable =
+				_setUpgradeReportDLStorageInfoTimeout(10)) {
 
-		Object upgradeReport = ReflectionTestUtil.getFieldValue(
-			_appender, "_upgradeReport");
+			Object upgradeReport = ReflectionTestUtil.getFieldValue(
+				_appender, "_upgradeReport");
 
-		ReflectionTestUtil.setFieldValue(
-			upgradeReport, "_documentLibrarySizeThread",
-			new Thread() {
+			ReflectionTestUtil.setFieldValue(
+				upgradeReport, "_documentLibrarySizeThread",
+				new Thread() {
 
-				@Override
-				public void run() {
-					ReflectionTestUtil.setFieldValue(
-						upgradeReport, "_documentLibrarySize", 1048576);
-				}
+					@Override
+					public void run() {
+						ReflectionTestUtil.setFieldValue(
+							upgradeReport, "_documentLibrarySize", 1048576);
+					}
 
-			});
+				});
 
-		_appender.stop();
+			_appender.stop();
 
+<<<<<<< HEAD
 		_assertReport(
 				LanguageUtil.formatStorageSize(1048576, LocaleUtil.US));
 
+=======
+			_assertReport(
+				"The document library storage size is " +
+					LanguageUtil.formatStorageSize(1048576, LocaleUtil.US));
+		}
+>>>>>>> e351a547abc9 (LPS-176185 Let's set the original value after the method completion)
 	}
 
 	@Test
@@ -516,9 +519,6 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 
 		ReflectionTestUtil.setFieldValue(
 			PropsValues.class, "UPGRADE_LOG_CONTEXT_ENABLED", true);
-
-		_originalDLStorageTimeout = ReflectionTestUtil.getFieldValue(
-			PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT");
 	}
 
 	protected abstract String getFilePath();
@@ -610,11 +610,23 @@ public abstract class BaseUpgradeReportLogAppenderTestCase {
 		return FileUtil.read(reportFile);
 	}
 
+	private SafeCloseable _setUpgradeReportDLStorageInfoTimeout(
+		long milliseconds) {
+
+		long originalUpgradeReportDLStorageInfoTimeout =
+			ReflectionTestUtil.getAndSetFieldValue(
+				PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT",
+				milliseconds);
+
+		return () -> ReflectionTestUtil.getAndSetFieldValue(
+			PropsValues.class, "UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT",
+			originalUpgradeReportDLStorageInfoTimeout);
+	}
+
 	private static DB _db;
 	private static Appender _logContextAppender;
 	private static final Pattern _logContextTablesInitialFinalRowsPattern =
 		Pattern.compile("(\\w+_?):(\\d+|-):(\\d+|-)");
-	private static long _originalDLStorageTimeout;
 	private static boolean _originalUpgradeClient;
 	private static boolean _originalUpgradeLogContextEnabled;
 	private static final Pattern _pattern = Pattern.compile(

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -2389,6 +2389,9 @@ public class PropsValues {
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.UPGRADE_LOG_CONTEXT_ENABLED));
 
+	public static final long UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT = GetterUtil.getLong(
+		PropsUtil.get(PropsKeys.UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT));
+
 	public static final boolean UPGRADE_REPORT_ENABLED = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.UPGRADE_REPORT_ENABLED));
 

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -2389,8 +2389,9 @@ public class PropsValues {
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.UPGRADE_LOG_CONTEXT_ENABLED));
 
-	public static final long UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT = GetterUtil.getLong(
-		PropsUtil.get(PropsKeys.UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT));
+	public static final long UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT =
+		GetterUtil.getLong(
+			PropsUtil.get(PropsKeys.UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT));
 
 	public static final boolean UPGRADE_REPORT_ENABLED = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.UPGRADE_REPORT_ENABLED));

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 46.0.0
+version 46.1.0

--- a/portal-impl/src/portal-developer.properties
+++ b/portal-impl/src/portal-developer.properties
@@ -1,6 +1,7 @@
 schema.module.build.auto.upgrade=true
 
 upgrade.database.auto.run=true
+upgrade.report.dl.storage.info.timeout=10000
 
 theme.css.fast.load=false
 theme.css.fast.load.check.request.parameter=true

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -174,6 +174,14 @@
     #
     upgrade.report.enabled=false
 
+    #
+    # Set the timeout in milliseconds to calculate the DL size in bytes while
+    # the upgrade report is being generated.
+    #
+    # Env: LIFERAY_UPGRADE_PERIOD_REPORT_PERIOD_DL_PERIOD_STORAGE_PERIOD_INFO_PERIOD_TIMEOUT
+    #
+    upgrade.report.dl.storage.info.timeout=10000
+
 ##
 ## Auto Deploy
 ##

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2716,6 +2716,8 @@ public interface PropsKeys {
 	public static final String UPGRADE_LOG_CONTEXT_ENABLED =
 		"upgrade.log.context.enabled";
 
+	public static final String UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT =
+		"upgrade.report.dl.storage.info.timeout";
 	public static final String UPGRADE_REPORT_ENABLED =
 		"upgrade.report.enabled";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2718,6 +2718,7 @@ public interface PropsKeys {
 
 	public static final String UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT =
 		"upgrade.report.dl.storage.info.timeout";
+
 	public static final String UPGRADE_REPORT_ENABLED =
 		"upgrade.report.enabled";
 


### PR DESCRIPTION
- LPS-171285 Add UPGRADE_REPORT_DL_STORAGE_INFO_TIMEOUT property
- LPS-171285 Stop calculating DL size when it takes longer than 10 seconds
- LPS-171285 Add logging at the beginning and at the end of Upgrade Report
- LPS-171285 Add testcases
- LPS-171285 SF
- LPS-176185 One log trace is enough to mark the upgrade report as completed
- LPS-176185 Let's set the original value after the method completion
- LPS-171285 Ignore lines before upgrade report generated message
