### PR TITLE
[SF] LPS-154671 Check for company iteration via SQL queries

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/CompanyIterationCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/CompanyIterationCheck.java
@@ -136,10 +136,10 @@ public class CompanyIterationCheck extends BaseCheck {
 		Matcher matcher = _selectCompanySQLPattern.matcher(stringLiteral);
 
 		if (matcher.find()) {
-			if (_isCoreUpgrade() &&
-				Objects.equals(matcher.group(1), "companyId")) {
-
-				log(methodCallDetailAST, _MSG_USE_PORTAL_INSTANCES);
+			if (_isCoreUpgrade()) {
+				if (Objects.equals(matcher.group(1), "companyId")) {
+					log(methodCallDetailAST, _MSG_USE_PORTAL_INSTANCES);
+				}
 			}
 			else {
 				log(methodCallDetailAST, _MSG_USE_COMPANY_LOCAL_SERVICE_SQL);

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/CompanyIterationCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/CompanyIterationCheck.java
@@ -14,8 +14,19 @@
 
 package com.liferay.source.formatter.checkstyle.check;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.SetUtil;
+
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author Hugo Huijser
@@ -24,20 +35,25 @@ public class CompanyIterationCheck extends BaseCheck {
 
 	@Override
 	public int[] getDefaultTokens() {
-		return new int[] {TokenTypes.LITERAL_FOR};
+		return new int[] {TokenTypes.LITERAL_FOR, TokenTypes.METHOD_CALL};
 	}
 
 	@Override
 	protected void doVisitToken(DetailAST detailAST) {
-		String absolutePath = getAbsolutePath();
+		if (detailAST.getType() == TokenTypes.LITERAL_FOR) {
+			_checkForLoop(detailAST);
+		}
+		else {
+			_checkMethodCall(detailAST);
+		}
+	}
 
-		if (absolutePath.contains("com/liferay/portal/") &&
-			absolutePath.contains("/upgrade/")) {
-
+	private void _checkForLoop(DetailAST literalForDetailAST) {
+		if (_isCoreUpgrade()) {
 			return;
 		}
 
-		DetailAST forEachClauseDetailAST = detailAST.findFirstToken(
+		DetailAST forEachClauseDetailAST = literalForDetailAST.findFirstToken(
 			TokenTypes.FOR_EACH_CLAUSE);
 
 		if (forEachClauseDetailAST == null) {
@@ -57,19 +73,122 @@ public class CompanyIterationCheck extends BaseCheck {
 
 		if (typeName.equals("Company")) {
 			log(
-				detailAST, _MSG_USE_COMPANY_LOCAL_SERVICE, "forEachCompany",
-				typeName + " " + variableName);
+				literalForDetailAST, _MSG_USE_COMPANY_LOCAL_SERVICE_FOR_LOOP,
+				"forEachCompany", typeName + " " + variableName);
 		}
 		else if ((typeName.equals("Long") || typeName.equals("long")) &&
 				 variableName.equals("companyId")) {
 
 			log(
-				detailAST, _MSG_USE_COMPANY_LOCAL_SERVICE, "forEachCompanyId",
-				typeName + " " + variableName);
+				literalForDetailAST, _MSG_USE_COMPANY_LOCAL_SERVICE_FOR_LOOP,
+				"forEachCompanyId", typeName + " " + variableName);
 		}
 	}
 
-	private static final String _MSG_USE_COMPANY_LOCAL_SERVICE =
-		"company.local.service.use";
+	private void _checkMethodCall(DetailAST methodCallDetailAST) {
+		Set<String> methodNames = _methodNamesMap.get(
+			getClassOrVariableName(methodCallDetailAST));
+
+		if ((methodNames == null) ||
+			!methodNames.contains(getMethodName(methodCallDetailAST))) {
+
+			return;
+		}
+
+		DetailAST elistDetailAST = methodCallDetailAST.findFirstToken(
+			TokenTypes.ELIST);
+
+		DetailAST exprDetailAST = elistDetailAST.getLastChild();
+
+		String stringLiteral = _getStringLiteral(exprDetailAST);
+
+		if (stringLiteral.isEmpty()) {
+			DetailAST identDetailAST = exprDetailAST.findFirstToken(
+				TokenTypes.IDENT);
+
+			if (identDetailAST == null) {
+				return;
+			}
+
+			String name = identDetailAST.getText();
+
+			DetailAST variableDefinitionDetailAST =
+				getVariableDefinitionDetailAST(methodCallDetailAST, name, true);
+
+			if ((variableDefinitionDetailAST == null) ||
+				(variableDefinitionDetailAST.getType() ==
+					TokenTypes.PARAMETER_DEF)) {
+
+				return;
+			}
+
+			DetailAST assignDetailAST =
+				variableDefinitionDetailAST.findFirstToken(TokenTypes.ASSIGN);
+
+			if (assignDetailAST == null) {
+				return;
+			}
+
+			stringLiteral = _getStringLiteral(
+				assignDetailAST.findFirstToken(TokenTypes.EXPR));
+		}
+
+		Matcher matcher = _selectCompanySQLPattern.matcher(stringLiteral);
+
+		if (matcher.find()) {
+			if (_isCoreUpgrade() &&
+				Objects.equals(matcher.group(1), "companyId")) {
+
+				log(methodCallDetailAST, _MSG_USE_PORTAL_INSTANCES);
+			}
+			else {
+				log(methodCallDetailAST, _MSG_USE_COMPANY_LOCAL_SERVICE_SQL);
+			}
+		}
+	}
+
+	private String _getStringLiteral(DetailAST detailAST) {
+		List<DetailAST> stringLiteralDetailASTs = getAllChildTokens(
+			detailAST, true, TokenTypes.STRING_LITERAL);
+
+		StringBundler sb = new StringBundler(stringLiteralDetailASTs.size());
+
+		for (DetailAST stringLiteralDetailAST : stringLiteralDetailASTs) {
+			sb.append(stringLiteralDetailAST.getText());
+		}
+
+		return sb.toString();
+	}
+
+	private boolean _isCoreUpgrade() {
+		String absolutePath = getAbsolutePath();
+
+		if (absolutePath.contains("com/liferay/portal/") &&
+			absolutePath.contains("/upgrade/")) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private static final String _MSG_USE_COMPANY_LOCAL_SERVICE_FOR_LOOP =
+		"company.local.service.use.for.loop";
+
+	private static final String _MSG_USE_COMPANY_LOCAL_SERVICE_SQL =
+		"company.local.service.use.sql";
+
+	private static final String _MSG_USE_PORTAL_INSTANCES =
+		"portal.instances.use";
+
+	private static final Map<String, Set<String>> _methodNamesMap =
+		HashMapBuilder.<String, Set<String>>put(
+			"AutoBatchPreparedStatementUtil",
+			SetUtil.fromArray("autoBatch", "concurrentAutoBatch")
+		).put(
+			"connection", SetUtil.fromArray("prepareCall", "prepareStatement")
+		).build();
+	private static final Pattern _selectCompanySQLPattern = Pattern.compile(
+		"select\\s+(.+)\\s+from\\s+Company");
 
 }

--- a/modules/util/source-formatter/src/main/resources/checkstyle-jsp.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle-jsp.xml
@@ -203,7 +203,9 @@
 			<property name="category" value="Bug Prevention" />
 			<property name="description" value="Checks that `CompanyLocalService.forEachCompany` or `CompanyLocalService.forEachCompanyId` is used when iterating over companies" />
 			<property name="enabled" value="false" />
-			<message key="company.local.service.use" value="Use ''CompanyLocalService.{0}'' when iterating over ''{1}''" />
+			<message key="company.local.service.use.for.loop" value="Use ''CompanyLocalService.{0}'' when iterating over ''{1}''" />
+			<message key="company.local.service.use.sql" value="Use ''CompanyLocalService.forEachCompany'' instead of SQL" />
+			<message key="portal.instances.use" value="Use ''PortalInstances.getCompanyIdsBySQL'' instead to fetch company IDs" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ConcatCheck">
 			<property name="category" value="Performance" />

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -273,7 +273,9 @@
 			<property name="category" value="Bug Prevention" />
 			<property name="description" value="Checks that `CompanyLocalService.forEachCompany` or `CompanyLocalService.forEachCompanyId` is used when iterating over companies" />
 			<property name="enabled" value="false" />
-			<message key="company.local.service.use" value="Use ''CompanyLocalService.{0}'' when iterating over ''{1}''" />
+			<message key="company.local.service.use.for.loop" value="Use ''CompanyLocalService.{0}'' when iterating over ''{1}''" />
+			<message key="company.local.service.use.sql" value="Use ''CompanyLocalService.forEachCompany'' instead of SQL" />
+			<message key="portal.instances.use" value="Use ''PortalInstances.getCompanyIdsBySQL'' instead to fetch company IDs" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ComponentAnnotationCheck">
 			<property name="category" value="Bug Prevention" />

--- a/modules/util/source-formatter/src/main/resources/documentation/check/company_iteration_check.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/check/company_iteration_check.markdown
@@ -1,10 +1,13 @@
 ## CompanyIterationCheck
 
-It is required to use one of the following methods:
+It is required to use one of the following methods when iterating companies:
 - `com.liferay.portal.kernel.service.CompanyLocalService#forEachCompany`
 - `com.liferay.portal.kernel.service.CompanyLocalService#forEachCompanyId`
 
-When iterating companies. In that way, we ensure that the thread locals are initialized properly.
+This way, we process companies in the correct order and ensure that the thread
+locals are initialized properly.
+
+This applies to SQL queries as well.
 
 #### Example 1
 
@@ -24,7 +27,6 @@ _companyLocalService.forEachCompanyId(
 	companyId ->
 		_commerceAccountGroupLocalService.
 			checkGuestCommerceAccountGroup(companyId));
-	}
 ```
 #### Example 2
 
@@ -43,4 +45,24 @@ public void cleanUp(String... companyIds) {
 	_companyLocalService.forEachCompanyId(
 		companyId -> _cleanUp(companyId), companyIds);
 }
+```
+
+#### Example 3
+
+Instead of:
+```java
+PreparedStatement preparedStatement = connection.prepareStatement(
+	"select companyId, userId from Company");
+
+ResultSet resultSet = preparedStatement.executeQuery();
+
+while (resultSet.next()) {
+	processCompany(resultSet.getLong("companyId"), resultSet.getLong("userId"));
+}
+```
+
+We should do:
+```java
+_companyLocalService.forEachCompany(
+	company -> processCompany(company.getCompanyId(), company.getUserId()));
 ```

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeCompanyId.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeCompanyId.java
@@ -17,6 +17,7 @@ package com.liferay.portal.upgrade.v7_0_0;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.upgrade.BaseCompanyIdUpgradeProcess;
 import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.util.PortalInstances;
 
 import java.io.IOException;
 
@@ -160,12 +161,10 @@ public class UpgradeCompanyId extends BaseCompanyIdUpgradeProcess {
 		public void update(Connection connection)
 			throws IOException, SQLException {
 
-			List<Long> companyIds = getCompanyIds(connection);
+			long[] companyIds = PortalInstances.getCompanyIdsBySQL();
 
-			if (companyIds.size() == 1) {
-				String selectSQL = String.valueOf(companyIds.get(0));
-
-				runSQL(connection, getUpdateSQL(selectSQL));
+			if (companyIds.length == 1) {
+				runSQL(connection, getUpdateSQL(String.valueOf(companyIds[0])));
 
 				return;
 			}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeGroup.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeGroup.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.language.LanguageResources;
+import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.PortalPreferencesImpl;
 import com.liferay.portlet.PortalPreferencesWrapper;
@@ -43,9 +44,7 @@ import com.liferay.portlet.PortalPreferencesWrapper;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -69,21 +68,7 @@ public class UpgradeGroup extends UpgradeProcess {
 	}
 
 	protected void updateGlobalGroupName() throws Exception {
-		List<Long> companyIds = new ArrayList<>();
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				"select companyId from Company")) {
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					long companyId = resultSet.getLong("companyId");
-
-					companyIds.add(companyId);
-				}
-			}
-		}
-
-		for (Long companyId : companyIds) {
+		for (Long companyId : PortalInstances.getCompanyIdsBySQL()) {
 			LocalizedValuesMap localizedValuesMap = new LocalizedValuesMap();
 
 			for (String languageId : PropsValues.LOCALES_ENABLED) {

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradePortalPreferences.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradePortalPreferences.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.Node;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.kernel.xml.XPath;
+import com.liferay.portal.util.PortalInstances;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -39,15 +40,11 @@ public class UpgradePortalPreferences extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		try (LoggingTimer loggingTimer = new LoggingTimer();
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				"select companyId from Company");
-			ResultSet resultSet = preparedStatement.executeQuery()) {
-
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
 			upgradePortalPreferences(PortletKeys.PREFS_OWNER_ID_DEFAULT);
 
-			while (resultSet.next()) {
-				upgradePortalPreferences(resultSet.getLong("companyId"));
+			for (long companyId : PortalInstances.getCompanyIdsBySQL()) {
+				upgradePortalPreferences(companyId);
 			}
 		}
 	}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeCompanyId.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeCompanyId.java
@@ -17,6 +17,7 @@ package com.liferay.portal.upgrade.v7_4_x;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.upgrade.BaseCompanyIdUpgradeProcess;
 import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.util.PortalInstances;
 
 import java.io.IOException;
 
@@ -64,12 +65,10 @@ public class UpgradeCompanyId extends BaseCompanyIdUpgradeProcess {
 		public void update(Connection connection)
 			throws IOException, SQLException {
 
-			List<Long> companyIds = getCompanyIds(connection);
+			long[] companyIds = PortalInstances.getCompanyIdsBySQL();
 
-			if (companyIds.size() == 1) {
-				String selectSQL = String.valueOf(companyIds.get(0));
-
-				runSQL(connection, getUpdateSQL(selectSQL));
+			if (companyIds.length == 1) {
+				runSQL(connection, getUpdateSQL(String.valueOf(companyIds[0])));
 
 				return;
 			}

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 102.1.1
+Bundle-Version: 103.0.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseCompanyIdUpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseCompanyIdUpgradeProcess.java
@@ -88,7 +88,9 @@ public abstract class BaseCompanyIdUpgradeProcess extends UpgradeProcess {
 			}
 		}
 
-		protected List<Long> getCompanyIds(Connection connection)
+		protected String getSelectSQL(
+				Connection connection, String foreignTableName,
+				String foreignColumnName)
 			throws SQLException {
 
 			List<Long> companyIds = new ArrayList<>();
@@ -99,21 +101,9 @@ public abstract class BaseCompanyIdUpgradeProcess extends UpgradeProcess {
 				ResultSet resultSet = preparedStatement.executeQuery()) {
 
 				while (resultSet.next()) {
-					long companyId = resultSet.getLong(1);
-
-					companyIds.add(companyId);
+					companyIds.add(resultSet.getLong(1));
 				}
 			}
-
-			return companyIds;
-		}
-
-		protected String getSelectSQL(
-				Connection connection, String foreignTableName,
-				String foreignColumnName)
-			throws SQLException {
-
-			List<Long> companyIds = getCompanyIds(connection);
 
 			if (companyIds.size() == 1) {
 				return String.valueOf(companyIds.get(0));

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
@@ -1,1 +1,1 @@
-version 19.2.0
+version 20.0.0

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -15,6 +15,7 @@
 		<suppress checks="CompanyIterationCheck" files="portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil\.java" />
 		<suppress checks="CompanyIterationCheck" files="portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl\.java" />
 		<suppress checks="CompanyIterationCheck" files="portal-impl/src/com/liferay/portal/util/PortalInstances\.java" />
+		<suppress checks="CompanyIterationCheck" files="portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseCompanyIdUpgradeProcess\.java" />
 		<suppress checks="ConcatCheck" files="portal-kernel/test/unit/com/liferay/portal/kernel/util/StringBundlerTest\.java" />
 		<suppress checks="ConstantNameCheck" files="portal-test/src/com/liferay/portal/kernel/test/rule/CodeCoverageAssertor\.java" />
 		<suppress checks="FactoryCheck" files="portal-kernel/src/com/liferay/portal/kernel/service/ServiceContext\.java" />

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -14,6 +14,7 @@
 		<suppress checks="ChainingCheck" files="portal-kernel/src/com/liferay/portal/kernel/util/StringBundler\.java" />
 		<suppress checks="CompanyIterationCheck" files="portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil\.java" />
 		<suppress checks="CompanyIterationCheck" files="portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl\.java" />
+		<suppress checks="CompanyIterationCheck" files="portal-impl/src/com/liferay/portal/util/PortalInstances\.java" />
 		<suppress checks="ConcatCheck" files="portal-kernel/test/unit/com/liferay/portal/kernel/util/StringBundlerTest\.java" />
 		<suppress checks="ConstantNameCheck" files="portal-test/src/com/liferay/portal/kernel/test/rule/CodeCoverageAssertor\.java" />
 		<suppress checks="FactoryCheck" files="portal-kernel/src/com/liferay/portal/kernel/service/ServiceContext\.java" />


### PR DESCRIPTION
__Ticket:__
<https://issues.liferay.com/browse/LPS-154671>

__Previous pull request:__
<https://github.com/liferay-uniform/liferay-portal/pull/1031>

This pull request expands `CompanyIterationCheck` so that it checks for company iteration via SQL. Module upgrade processes should no longer be able to iterate over the `Company` table using SQL.

For core upgrade, upgrade processes that fetch **only** company IDs using SQL will be asked to use `PortalInstances.getCompanyIdsBySQL()`. This is slightly different from the third request of the previous pull request: <https://github.com/liferay-uniform/liferay-portal/pull/1031#issuecomment-1470271607>. Checking for instances of arrays/lists being populated with company IDs would lead to false positives for cases like this:

<https://github.com/liferay-uniform/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSharding.java#L214-L227>

I think checking for core upgrade processes that only fetch company IDs from the `Company` table should still satisfy the goal of the third request.

Let me know if you have any questions and if I need to make any changes.