### PR TITLE
LPS-161525 Disable Auto Upgrade by default if HSQL is being used.

### DIFF
--- a/portal-impl/src/com/liferay/portal/spring/hibernate/DialectDetector.java
+++ b/portal-impl/src/com/liferay/portal/spring/hibernate/DialectDetector.java
@@ -27,6 +27,9 @@ import com.liferay.portal.dao.orm.hibernate.SybaseASE157Dialect;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.util.PropsUtil;
+import com.liferay.portal.util.PropsValues;
 
 import java.sql.Connection;
 
@@ -77,6 +80,10 @@ public class DialectDetector {
 
 			if (dbName.startsWith("HSQL")) {
 				dialect = new HSQLDialect();
+
+				PropsUtil.set(PropsKeys.UPGRADE_DATABASE_AUTO_RUN, "false");
+
+				PropsValues.UPGRADE_DATABASE_AUTO_RUN = false;
 
 				if (_log.isWarnEnabled()) {
 					_log.warn(

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -2377,9 +2377,8 @@ public class PropsValues {
 	public static final String UNICODE_TEXT_NORMALIZER_FORM = PropsUtil.get(
 		PropsKeys.UNICODE_TEXT_NORMALIZER_FORM);
 
-	public static final boolean UPGRADE_DATABASE_AUTO_RUN =
-		GetterUtil.getBoolean(
-			PropsUtil.get(PropsKeys.UPGRADE_DATABASE_AUTO_RUN));
+	public static boolean UPGRADE_DATABASE_AUTO_RUN = GetterUtil.getBoolean(
+		PropsUtil.get(PropsKeys.UPGRADE_DATABASE_AUTO_RUN));
 
 	public static final boolean UPGRADE_DATABASE_TRANSACTIONS_DISABLED =
 		GetterUtil.getBoolean(

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 47.0.0
+version 47.1.0

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -145,7 +145,9 @@
 
     #
     # Set this to true to execute the upgrade process when the portal starts and
-    # modules are activated.
+    # modules are activated. This is set to false if HSQL is detected.
+    #
+    #
     #
     # Env: LIFERAY_UPGRADE_PERIOD_DATABASE_PERIOD_AUTO_PERIOD_RUN
     #


### PR DESCRIPTION
Ticket:  [LPS-161525](https://issues.liferay.com/browse/LPS-161525)

Issue:  If the auto upgrade property is set to true  while using HSQL, then there will be connection exceptions  when shutting down the portal since the HSQL server is closed. 


Solution:
 We can mitigate this by setting the auto upgrade property to false to prevent this issue as well as any potential issues since HSQL is not a supported production database. 

