### PR TITLE
LPS-182452 Add support for copying tables to `BaseDB`

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -271,6 +271,54 @@ public class DBTest {
 	}
 
 	@Test
+	public void testCopyExistentTable() throws Exception {
+		String[] indexColumnNames = {"typeVarchar", "typeBoolean"};
+
+		_addIndex(indexColumnNames);
+
+		_db.runSQL(
+			"insert into " + _TABLE_NAME_1 +
+				" (id, notNilColumn, typeString) values (1, '1', 'testValue')");
+
+		_db.copyTable(_connection, _TABLE_NAME_1, _TABLE_NAME_2);
+
+		Assert.assertTrue(_dbInspector.hasTable(_TABLE_NAME_2));
+		Assert.assertTrue(_dbInspector.hasRows(_TABLE_NAME_2));
+
+		Assert.assertArrayEquals(
+			new String[] {"id"},
+			_db.getPrimaryKeyColumnNames(_connection, _TABLE_NAME_2));
+
+		List<IndexMetadata> indexMetadatas = _getIndexes(
+			_TABLE_NAME_2, indexColumnNames);
+
+		Assert.assertEquals(
+			indexMetadatas.toString(), 1, indexMetadatas.size());
+	}
+
+	@Test
+	public void testCopyNonexistentTable() {
+		try {
+			_db.copyTable(_connection, "DoesNotExist", _TABLE_NAME_2);
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+		}
+	}
+
+	@Test
+	public void testCopyTableBadNewName() {
+		try {
+			_db.copyTable(_connection, _TABLE_NAME_1, _TABLE_NAME_1);
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+		}
+	}
+
+	@Test
 	public void testGetPrimaryKeyColumnNames() throws Exception {
 		_db.runSQL(_SQL_CREATE_TABLE_2);
 
@@ -298,13 +346,20 @@ public class DBTest {
 			_connection, indexMetadatas);
 	}
 
-	private void _validateIndex(String[] columnNames) throws Exception {
-		List<IndexMetadata> indexMetadatas = ReflectionTestUtil.invoke(
+	private List<IndexMetadata> _getIndexes(
+		String tableName, String[] columnNames) {
+
+		return ReflectionTestUtil.invoke(
 			_db, "getIndexes",
 			new Class<?>[] {
 				Connection.class, String.class, String.class, boolean.class
 			},
-			_connection, _TABLE_NAME_1, columnNames[0], false);
+			_connection, tableName, columnNames[0], false);
+	}
+
+	private void _validateIndex(String[] columnNames) throws Exception {
+		List<IndexMetadata> indexMetadatas = _getIndexes(
+			_TABLE_NAME_1, columnNames);
 
 		Assert.assertEquals(
 			indexMetadatas.toString(), 1, indexMetadatas.size());

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -107,6 +107,12 @@ public class SQLServerDB extends BaseDB {
 	}
 
 	@Override
+	public String getCopyTableSQL(String tableName, String newTableName) {
+		return StringBundler.concat(
+			"select * into ", newTableName, " from ", tableName);
+	}
+
+	@Override
 	public List<Index> getIndexes(Connection connection) throws SQLException {
 		List<Index> indexes = new ArrayList<>();
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SybaseDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SybaseDB.java
@@ -67,6 +67,12 @@ public class SybaseDB extends BaseDB {
 	}
 
 	@Override
+	public String getCopyTableSQL(String tableName, String newTableName) {
+		return StringBundler.concat(
+			"select * into ", newTableName, " from ", tableName);
+	}
+
+	@Override
 	public String getNewUuidFunctionName() {
 		return "newid(1)";
 	}

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -198,6 +198,31 @@ public abstract class BaseDB implements DB {
 		throws IOException, SQLException;
 
 	@Override
+	public void copyTable(
+			Connection connection, String tableName, String newTableName)
+		throws Exception {
+
+		runSQL(connection, getCopyTableSQL(tableName, newTableName));
+
+		addPrimaryKey(
+			connection, newTableName,
+			getPrimaryKeyColumnNames(connection, tableName));
+
+		List<IndexMetadata> indexMetadatas = new ArrayList<>();
+
+		for (IndexMetadata indexMetadata :
+				getIndexes(connection, tableName, null, false)) {
+
+			indexMetadatas.add(
+				IndexMetadataFactoryUtil.createIndexMetadata(
+					indexMetadata.isUnique(), newTableName,
+					indexMetadata.getColumnNames()));
+		}
+
+		addIndexes(connection, indexMetadatas);
+	}
+
+	@Override
 	public List<IndexMetadata> dropIndexes(
 			Connection connection, String tableName, String columnName)
 		throws IOException, SQLException {
@@ -210,6 +235,13 @@ public abstract class BaseDB implements DB {
 		}
 
 		return indexMetadatas;
+	}
+
+	@Override
+	public String getCopyTableSQL(String tableName, String newTableName) {
+		return StringBundler.concat(
+			"create table ", newTableName, " as (select * from ", tableName,
+			")");
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
@@ -48,6 +48,13 @@ public class HypersonicDB extends BaseDB {
 	}
 
 	@Override
+	public String getCopyTableSQL(String tableName, String newTableName) {
+		return StringBundler.concat(
+			"create table ", newTableName, " as (select * from ", tableName,
+			") with data");
+	}
+
+	@Override
 	public String getPopulateSQL(String databaseName, String sqlContent) {
 		return StringPool.BLANK;
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -65,9 +65,15 @@ public interface DB {
 
 	public String buildSQL(String template) throws IOException, SQLException;
 
+	public void copyTable(
+			Connection connection, String tableName, String newTableName)
+		throws Exception;
+
 	public List<IndexMetadata> dropIndexes(
 			Connection connection, String tableName, String columnName)
 		throws IOException, SQLException;
+
+	public String getCopyTableSQL(String tableName, String newTableName);
 
 	public DBType getDBType();
 


### PR DESCRIPTION
__Ticket:__ <https://issues.liferay.com/browse/LPS-182452>

This pull request allows the DB framework to copy tables across all supported databases. The copy includes the rows, primary keys, indexes, etc.

Let me know if I need to make changes.