### PR TITLE
LPS-182452 Support for copying tables

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -322,6 +322,68 @@ public class DBTest {
 	}
 
 	@Test
+	public void testCopyTableRows() throws Exception {
+		_db.runSQL(
+			StringBundler.concat(
+				"create table ", _TABLE_NAME_2, " (id LONG not null primary ",
+				"key, notNilColumn VARCHAR(75) not null, nilColumn ",
+				"VARCHAR(75) null, typeBlob BLOB, typeBoolean BOOLEAN,",
+				"typeDate DATE null, typeDouble DOUBLE, typeInteger INTEGER, ",
+				"typeLong LONG null, typeSBlob SBLOB, typeString STRING null, ",
+				"typeText TEXT null, typeVarchar VARCHAR(75) null);"));
+
+		_db.runSQL(
+			StringBundler.concat(
+				"insert into ", _TABLE_NAME_1,
+				" (id, notNilColumn, typeString) values (1, '1', ",
+				"'testValue1'), (2, '2', 'testValue2')"));
+
+		_db.runSQL(
+			StringBundler.concat(
+				"insert into ", _TABLE_NAME_2,
+				" (id, notNilColumn, typeString) values (1, '1', ",
+				"'testValue1')"));
+
+		_db.copyTableRows(_connection, _TABLE_NAME_1, _TABLE_NAME_2);
+
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				"select * from " + _TABLE_NAME_2 + " order by id asc");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			Assert.assertTrue(resultSet.next());
+			Assert.assertEquals(1, resultSet.getLong("id"));
+			Assert.assertEquals("1", resultSet.getString("notNilColumn"));
+			Assert.assertEquals(
+				"testValue1", resultSet.getString("typeString"));
+
+			Assert.assertTrue(resultSet.next());
+			Assert.assertEquals(2, resultSet.getLong("id"));
+			Assert.assertEquals("2", resultSet.getString("notNilColumn"));
+			Assert.assertEquals(
+				"testValue2", resultSet.getString("typeString"));
+
+			Assert.assertFalse(resultSet.next());
+		}
+	}
+
+	@Test
+	public void testCopyTableStructure() throws Exception {
+		String[] indexColumnNames = {"typeVarchar", "typeBoolean"};
+
+		_addIndex(indexColumnNames);
+
+		_db.copyTableStructure(
+			_connection, _TABLE_NAME_1, _TABLE_NAME_2, "tmp_");
+
+		Assert.assertTrue(_dbInspector.hasTable(_TABLE_NAME_2));
+		Assert.assertTrue(
+			_dbInspector.hasIndex(_TABLE_NAME_2, "tmp_" + _INDEX_NAME));
+		Assert.assertArrayEquals(
+			new String[] {_dbInspector.normalizeName("id")},
+			_db.getPrimaryKeyColumnNames(_connection, _TABLE_NAME_2));
+	}
+
+	@Test
 	public void testGetPrimaryKeyColumnNames() throws Exception {
 		_db.runSQL(_SQL_CREATE_TABLE_2);
 
@@ -355,13 +417,20 @@ public class DBTest {
 			_connection, indexMetadatas);
 	}
 
-	private void _validateIndex(String[] columnNames) throws Exception {
-		List<IndexMetadata> indexMetadatas = ReflectionTestUtil.invoke(
+	private List<IndexMetadata> _getIndexes(
+		String tableName, String[] columnNames) {
+
+		return ReflectionTestUtil.invoke(
 			_db, "getIndexes",
 			new Class<?>[] {
 				Connection.class, String.class, String.class, boolean.class
 			},
-			_connection, _TABLE_NAME_1, columnNames[0], false);
+			_connection, tableName, columnNames[0], false);
+	}
+
+	private void _validateIndex(String[] columnNames) throws Exception {
+		List<IndexMetadata> indexMetadatas = _getIndexes(
+			_TABLE_NAME_1, columnNames);
 
 		Assert.assertEquals(
 			indexMetadatas.toString(), 1, indexMetadatas.size());

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -211,6 +211,15 @@ public class DB2DB extends BaseDB {
 	}
 
 	@Override
+	public String getCopyTableStructureSQL(
+		String tableName, String newTableName) {
+
+		return StringBundler.concat(
+			"create table ", newTableName, " as (select * from ", tableName,
+			") with no data");
+	}
+
+	@Override
 	public String getPopulateSQL(String databaseName, String sqlContent) {
 		return StringBundler.concat(
 			"connect to ", databaseName, ";\n", sqlContent);

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -107,6 +107,14 @@ public class SQLServerDB extends BaseDB {
 	}
 
 	@Override
+	public String getCopyTableStructureSQL(
+		String tableName, String newTableName) {
+
+		return StringBundler.concat(
+			"select into ", newTableName, " from ", tableName, " where 1 = 0");
+	}
+
+	@Override
 	public List<Index> getIndexes(Connection connection) throws SQLException {
 		List<Index> indexes = new ArrayList<>();
 

--- a/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
@@ -48,6 +48,15 @@ public class HypersonicDB extends BaseDB {
 	}
 
 	@Override
+	public String getCopyTableStructureSQL(
+		String tableName, String newTableName) {
+
+		return StringBundler.concat(
+			"create table ", newTableName, " as (select * from ", tableName,
+			") without data");
+	}
+
+	@Override
 	public String getPopulateSQL(String databaseName, String sqlContent) {
 		return StringPool.BLANK;
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -65,9 +65,22 @@ public interface DB {
 
 	public String buildSQL(String template) throws IOException, SQLException;
 
+	public void copyTableRows(
+			Connection connection, String sourceTableName,
+			String targetTableName)
+		throws Exception;
+
+	public void copyTableStructure(
+			Connection connection, String tableName, String newTableName,
+			String indexNamePrefix)
+		throws Exception;
+
 	public List<IndexMetadata> dropIndexes(
 			Connection connection, String tableName, String columnName)
 		throws IOException, SQLException;
+
+	public String getCopyTableStructureSQL(
+		String tableName, String newTableName);
 
 	public DBType getDBType();
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
@@ -1,1 +1,1 @@
-version 12.0.0
+version 12.1.0


### PR DESCRIPTION
Ticket: <https://issues.liferay.com/browse/LPS-182452>

This pull request allows the DB framework to copy tables across all supported databases. As requested [here](https://github.com/liferay-uniform/liferay-portal/pull/1132#issuecomment-1523800486), I have split up the table creation and row copying into multiple methods to allow intermediate database operations (e.g. adding triggers). I also check to make sure duplicates are not inserted into the new table from the original table and use a prefix for the copied index names.

Let me know if I need to make changes.