### PR TITLE
LPS-182452 Support for copying tables

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -322,6 +322,68 @@ public class DBTest {
 	}
 
 	@Test
+	public void testCopyTableRows() throws Exception {
+		_db.runSQL(
+			StringBundler.concat(
+				"create table ", _TABLE_NAME_2, " (id LONG not null primary ",
+				"key, notNilColumn VARCHAR(75) not null, nilColumn ",
+				"VARCHAR(75) null, typeBlob BLOB, typeBoolean BOOLEAN,",
+				"typeDate DATE null, typeDouble DOUBLE, typeInteger INTEGER, ",
+				"typeLong LONG null, typeSBlob SBLOB, typeString STRING null, ",
+				"typeText TEXT null, typeVarchar VARCHAR(75) null);"));
+
+		_db.runSQL(
+			StringBundler.concat(
+				"insert into ", _TABLE_NAME_1,
+				" (id, notNilColumn, typeString) values (1, '1', ",
+				"'testValue1'), (2, '2', 'testValue2')"));
+
+		_db.runSQL(
+			StringBundler.concat(
+				"insert into ", _TABLE_NAME_2,
+				" (id, notNilColumn, typeString) values (1, '1', ",
+				"'testValue1')"));
+
+		_db.copyTableRows(_connection, _TABLE_NAME_1, _TABLE_NAME_2);
+
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				"select * from " + _TABLE_NAME_2 + " order by id asc");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			Assert.assertTrue(resultSet.next());
+			Assert.assertEquals(1, resultSet.getLong("id"));
+			Assert.assertEquals("1", resultSet.getString("notNilColumn"));
+			Assert.assertEquals(
+				"testValue1", resultSet.getString("typeString"));
+
+			Assert.assertTrue(resultSet.next());
+			Assert.assertEquals(2, resultSet.getLong("id"));
+			Assert.assertEquals("2", resultSet.getString("notNilColumn"));
+			Assert.assertEquals(
+				"testValue2", resultSet.getString("typeString"));
+
+			Assert.assertFalse(resultSet.next());
+		}
+	}
+
+	@Test
+	public void testCopyTableStructure() throws Exception {
+		String[] indexColumnNames = {"typeVarchar", "typeBoolean"};
+
+		_addIndex(indexColumnNames);
+
+		_db.copyTableStructure(
+			_connection, _TABLE_NAME_1, _TABLE_NAME_2, "tmp_");
+
+		Assert.assertTrue(_dbInspector.hasTable(_TABLE_NAME_2));
+		Assert.assertTrue(
+			_dbInspector.hasIndex(_TABLE_NAME_2, "tmp_" + _INDEX_NAME));
+		Assert.assertArrayEquals(
+			new String[] {_dbInspector.normalizeName("id")},
+			_db.getPrimaryKeyColumnNames(_connection, _TABLE_NAME_2));
+	}
+
+	@Test
 	public void testGetPrimaryKeyColumnNames() throws Exception {
 		_db.runSQL(_SQL_CREATE_TABLE_2);
 
@@ -355,13 +417,20 @@ public class DBTest {
 			_connection, indexMetadatas);
 	}
 
-	private void _validateIndex(String[] columnNames) throws Exception {
-		List<IndexMetadata> indexMetadatas = ReflectionTestUtil.invoke(
+	private List<IndexMetadata> _getIndexes(
+		String tableName, String[] columnNames) {
+
+		return ReflectionTestUtil.invoke(
 			_db, "getIndexes",
 			new Class<?>[] {
 				Connection.class, String.class, String.class, boolean.class
 			},
-			_connection, _TABLE_NAME_1, columnNames[0], false);
+			_connection, tableName, columnNames[0], false);
+	}
+
+	private void _validateIndex(String[] columnNames) throws Exception {
+		List<IndexMetadata> indexMetadatas = _getIndexes(
+			_TABLE_NAME_1, columnNames);
 
 		Assert.assertEquals(
 			indexMetadatas.toString(), 1, indexMetadatas.size());

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -336,13 +336,13 @@ public class DBTest {
 			StringBundler.concat(
 				"insert into ", _TABLE_NAME_1,
 				" (id, notNilColumn, typeString) values (1, '1', ",
-				"'testValue1'), (2, '2', 'testValue2')"));
+				"'testTable1Value1'), (2, '2', 'testTable1Value2')"));
 
 		_db.runSQL(
 			StringBundler.concat(
 				"insert into ", _TABLE_NAME_2,
 				" (id, notNilColumn, typeString) values (1, '1', ",
-				"'testValue1')"));
+				"'testTable2Value1')"));
 
 		_db.copyTableRows(_connection, _TABLE_NAME_1, _TABLE_NAME_2);
 
@@ -354,13 +354,13 @@ public class DBTest {
 			Assert.assertEquals(1, resultSet.getLong("id"));
 			Assert.assertEquals("1", resultSet.getString("notNilColumn"));
 			Assert.assertEquals(
-				"testValue1", resultSet.getString("typeString"));
+				"testTable2Value1", resultSet.getString("typeString"));
 
 			Assert.assertTrue(resultSet.next());
 			Assert.assertEquals(2, resultSet.getLong("id"));
 			Assert.assertEquals("2", resultSet.getString("notNilColumn"));
 			Assert.assertEquals(
-				"testValue2", resultSet.getString("typeString"));
+				"testTable1Value2", resultSet.getString("typeString"));
 
 			Assert.assertFalse(resultSet.next());
 		}

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -336,7 +336,13 @@ public class DBTest {
 			StringBundler.concat(
 				"insert into ", _TABLE_NAME_1,
 				" (id, notNilColumn, typeString) values (1, '1', ",
-				"'testTable1Value1'), (2, '2', 'testTable1Value2')"));
+				"'testTable1Value1')"));
+
+		_db.runSQL(
+			StringBundler.concat(
+				"insert into ", _TABLE_NAME_1,
+				" (id, notNilColumn, typeString) values (2, '2', ",
+				"'testTable1Value2')"));
 
 		_db.runSQL(
 			StringBundler.concat(

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -372,12 +372,21 @@ public class DBTest {
 
 		_addIndex(indexColumnNames);
 
-		_db.copyTableStructure(
-			_connection, _TABLE_NAME_1, _TABLE_NAME_2, "tmp_");
+		_db.copyTableStructure(_connection, _TABLE_NAME_1, _TABLE_NAME_2);
+
+		boolean supportsDuplicatedIndexName = ReflectionTestUtil.invoke(
+			_db, "isSupportsDuplicatedIndexName", new Class<?>[0]);
+
+		String indexNamePrefix = StringPool.BLANK;
+
+		if (!supportsDuplicatedIndexName) {
+			indexNamePrefix = "TMP_";
+		}
 
 		Assert.assertTrue(_dbInspector.hasTable(_TABLE_NAME_2));
 		Assert.assertTrue(
-			_dbInspector.hasIndex(_TABLE_NAME_2, "tmp_" + _INDEX_NAME));
+			_dbInspector.hasIndex(
+				_TABLE_NAME_2, indexNamePrefix + _INDEX_NAME));
 		Assert.assertArrayEquals(
 			new String[] {_dbInspector.normalizeName("id")},
 			_db.getPrimaryKeyColumnNames(_connection, _TABLE_NAME_2));

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -211,15 +211,6 @@ public class DB2DB extends BaseDB {
 	}
 
 	@Override
-	public String getCopyTableStructureSQL(
-		String tableName, String newTableName) {
-
-		return StringBundler.concat(
-			"create table ", newTableName, " as (select * from ", tableName,
-			") with no data");
-	}
-
-	@Override
 	public String getPopulateSQL(String databaseName, String sqlContent) {
 		return StringBundler.concat(
 			"connect to ", databaseName, ";\n", sqlContent);
@@ -273,6 +264,14 @@ public class DB2DB extends BaseDB {
 		else {
 			super.runSQL(template);
 		}
+	}
+
+	protected String getCopyTableStructureSQL(
+		String tableName, String newTableName) {
+
+		return StringBundler.concat(
+			"create table ", newTableName, " as (select * from ", tableName,
+			") with no data");
 	}
 
 	@Override

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -315,6 +315,10 @@ public class DB2DB extends BaseDB {
 		return reorgTableRequired;
 	}
 
+	protected boolean isSupportsDuplicatedIndexName() {
+		return _SUPPORTS_DUPLICATED_INDEX_NAME;
+	}
+
 	protected void reorgTable(Connection connection, String tableName)
 		throws SQLException {
 
@@ -456,6 +460,8 @@ public class DB2DB extends BaseDB {
 	private static final int[] _SQL_VARCHAR_SIZES = {
 		_SQL_STRING_SIZE, SQL_SIZE_NONE
 	};
+
+	private static final boolean _SUPPORTS_DUPLICATED_INDEX_NAME = false;
 
 	private static final boolean _SUPPORTS_INLINE_DISTINCT = false;
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -211,6 +211,15 @@ public class DB2DB extends BaseDB {
 	}
 
 	@Override
+	public String getCopyTableStructureSQL(
+		String tableName, String newTableName) {
+
+		return StringBundler.concat(
+			"create table ", newTableName, " as (select * from ", tableName,
+			") with no data");
+	}
+
+	@Override
 	public String getPopulateSQL(String databaseName, String sqlContent) {
 		return StringBundler.concat(
 			"connect to ", databaseName, ";\n", sqlContent);

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -244,6 +244,10 @@ public class OracleDB extends BaseDB {
 		}
 	}
 
+	protected boolean isSupportsDuplicatedIndexName() {
+		return _SUPPORTS_DUPLICATED_INDEX_NAME;
+	}
+
 	@Override
 	protected String limitColumnLength(String column, int length) {
 		return StringBundler.concat("substr(", column, ", 1, ", length, ")");
@@ -359,6 +363,8 @@ public class OracleDB extends BaseDB {
 	private static final int[] _SQL_VARCHAR_SIZES = {
 		_SQL_STRING_SIZE, SQL_SIZE_NONE
 	};
+
+	private static final boolean _SUPPORTS_DUPLICATED_INDEX_NAME = false;
 
 	private static final boolean _SUPPORTS_INLINE_DISTINCT = false;
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -107,6 +107,14 @@ public class SQLServerDB extends BaseDB {
 	}
 
 	@Override
+	public String getCopyTableStructureSQL(
+		String tableName, String newTableName) {
+
+		return StringBundler.concat(
+			"select into ", newTableName, " from ", tableName, " where 1 = 0");
+	}
+
+	@Override
 	public List<Index> getIndexes(Connection connection) throws SQLException {
 		List<Index> indexes = new ArrayList<>();
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -107,14 +107,6 @@ public class SQLServerDB extends BaseDB {
 	}
 
 	@Override
-	public String getCopyTableStructureSQL(
-		String tableName, String newTableName) {
-
-		return StringBundler.concat(
-			"select into ", newTableName, " from ", tableName, " where 1 = 0");
-	}
-
-	@Override
 	public List<Index> getIndexes(Connection connection) throws SQLException {
 		List<Index> indexes = new ArrayList<>();
 
@@ -218,6 +210,13 @@ public class SQLServerDB extends BaseDB {
 					"Primary key with name ", primaryKeyConstraintName,
 					" does not exist"));
 		}
+	}
+
+	protected String getCopyTableStructureSQL(
+		String tableName, String newTableName) {
+
+		return StringBundler.concat(
+			"select into ", newTableName, " from ", tableName, " where 1 = 0");
 	}
 
 	@Override

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -216,7 +216,8 @@ public class SQLServerDB extends BaseDB {
 		String tableName, String newTableName) {
 
 		return StringBundler.concat(
-			"select into ", newTableName, " from ", tableName, " where 1 = 0");
+			"select * into ", newTableName, " from ", tableName,
+			" where 1 = 0");
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -287,15 +287,6 @@ public abstract class BaseDB implements DB {
 	}
 
 	@Override
-	public String getCopyTableStructureSQL(
-		String tableName, String newTableName) {
-
-		return StringBundler.concat(
-			"create table ", newTableName, " as select * from ", tableName,
-			" where 1 = 0");
-	}
-
-	@Override
 	public DBType getDBType() {
 		return _dbType;
 	}
@@ -854,6 +845,14 @@ public abstract class BaseDB implements DB {
 		}
 
 		return validIndexNames;
+	}
+
+	protected String getCopyTableStructureSQL(
+		String tableName, String newTableName) {
+
+		return StringBundler.concat(
+			"create table ", newTableName, " as select * from ", tableName,
+			" where 1 = 0");
 	}
 
 	protected List<IndexMetadata> getIndexes(

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -968,6 +968,10 @@ public abstract class BaseDB implements DB {
 
 	protected abstract String[] getTemplate();
 
+	protected boolean isSupportsDuplicatedIndexName() {
+		return _SUPPORTS_DUPLICATED_INDEX_NAME;
+	}
+
 	protected String limitColumnLength(String column, int length) {
 		return StringBundler.concat(column, "\\(", length, "\\)");
 	}
@@ -1159,6 +1163,8 @@ public abstract class BaseDB implements DB {
 	private static final boolean _SUPPORTS_ALTER_COLUMN_NAME = true;
 
 	private static final boolean _SUPPORTS_ALTER_COLUMN_TYPE = true;
+
+	private static final boolean _SUPPORTS_DUPLICATED_INDEX_NAME = true;
 
 	private static final boolean _SUPPORTS_INLINE_DISTINCT = true;
 

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -246,8 +246,7 @@ public abstract class BaseDB implements DB {
 
 	@Override
 	public void copyTableStructure(
-			Connection connection, String tableName, String newTableName,
-			String indexNamePrefix)
+			Connection connection, String tableName, String newTableName)
 		throws Exception {
 
 		runSQL(connection, getCopyTableStructureSQL(tableName, newTableName));
@@ -257,6 +256,12 @@ public abstract class BaseDB implements DB {
 			getPrimaryKeyColumnNames(connection, tableName));
 
 		List<IndexMetadata> indexMetadatas = new ArrayList<>();
+
+		String indexNamePrefix = StringPool.BLANK;
+
+		if (!isSupportsDuplicatedIndexName()) {
+			indexNamePrefix = "TMP_";
+		}
 
 		for (IndexMetadata indexMetadata :
 				getIndexes(connection, tableName, null, false)) {

--- a/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
@@ -48,6 +48,15 @@ public class HypersonicDB extends BaseDB {
 	}
 
 	@Override
+	public String getCopyTableStructureSQL(
+		String tableName, String newTableName) {
+
+		return StringBundler.concat(
+			"create table ", newTableName, " as (select * from ", tableName,
+			") without data");
+	}
+
+	@Override
 	public String getPopulateSQL(String databaseName, String sqlContent) {
 		return StringPool.BLANK;
 	}

--- a/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
@@ -48,15 +48,6 @@ public class HypersonicDB extends BaseDB {
 	}
 
 	@Override
-	public String getCopyTableStructureSQL(
-		String tableName, String newTableName) {
-
-		return StringBundler.concat(
-			"create table ", newTableName, " as (select * from ", tableName,
-			") without data");
-	}
-
-	@Override
 	public String getPopulateSQL(String databaseName, String sqlContent) {
 		return StringPool.BLANK;
 	}
@@ -64,6 +55,14 @@ public class HypersonicDB extends BaseDB {
 	@Override
 	public String getRecreateSQL(String databaseName) {
 		return StringPool.BLANK;
+	}
+
+	protected String getCopyTableStructureSQL(
+		String tableName, String newTableName) {
+
+		return StringBundler.concat(
+			"create table ", newTableName, " as (select * from ", tableName,
+			") without data");
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
@@ -159,6 +159,10 @@ public class PostgreSQLDB extends BaseDB {
 		return _POSTGRESQL;
 	}
 
+	protected boolean isSupportsDuplicatedIndexName() {
+		return _SUPPORTS_DUPLICATED_INDEX_NAME;
+	}
+
 	@Override
 	protected String reword(String data) throws IOException {
 		try (UnsyncBufferedReader unsyncBufferedReader =
@@ -273,6 +277,8 @@ public class PostgreSQLDB extends BaseDB {
 	private static final int[] _SQL_VARCHAR_SIZES = {
 		SQL_VARCHAR_MAX_SIZE, SQL_VARCHAR_MAX_SIZE
 	};
+
+	private static final boolean _SUPPORTS_DUPLICATED_INDEX_NAME = false;
 
 	private static final boolean _SUPPORTS_QUERYING_AFTER_EXCEPTION = false;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -79,9 +79,6 @@ public interface DB {
 			Connection connection, String tableName, String columnName)
 		throws IOException, SQLException;
 
-	public String getCopyTableStructureSQL(
-		String tableName, String newTableName);
-
 	public DBType getDBType();
 
 	public List<Index> getIndexes(Connection connection) throws SQLException;

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -65,9 +65,22 @@ public interface DB {
 
 	public String buildSQL(String template) throws IOException, SQLException;
 
+	public void copyTableRows(
+			Connection connection, String sourceTableName,
+			String targetTableName)
+		throws Exception;
+
+	public void copyTableStructure(
+			Connection connection, String tableName, String newTableName,
+			String indexNamePrefix)
+		throws Exception;
+
 	public List<IndexMetadata> dropIndexes(
 			Connection connection, String tableName, String columnName)
 		throws IOException, SQLException;
+
+	public String getCopyTableStructureSQL(
+		String tableName, String newTableName);
 
 	public DBType getDBType();
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -71,8 +71,7 @@ public interface DB {
 		throws Exception;
 
 	public void copyTableStructure(
-			Connection connection, String tableName, String newTableName,
-			String indexNamePrefix)
+			Connection connection, String tableName, String newTableName)
 		throws Exception;
 
 	public List<IndexMetadata> dropIndexes(

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
@@ -1,1 +1,1 @@
-version 12.0.0
+version 12.1.0


### PR DESCRIPTION
__Ticket:__ <https://issues.liferay.com/browse/LPS-182452>
__Prev. pull request:__ <https://github.com/liferay-uniform/liferay-portal/pull/1154>

This pull request allows the DB framework to copy tables across all supported databases. I have split up the table creation and row copying into multiple methods to allow intermediate database operations (e.g. adding triggers). Also, I check to make sure duplicates are not inserted into the new table from the original table and use a prefix for the copied index names.

Let me know if I need to make changes.