### PR TITLE
LPS-180450 Create a tool that will validate and data to migrate one virtual instance to a db partition cluster

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/.gitrepo
+++ b/modules/dxp/apps/osb/osb-faro/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 64b4f23cdd7b9366ba9d9ceac9288357dac22242
+	commit = b7e75403a63fc13607fe826922be9e3d1aacb1e4
 	mergebuttonmergecommits = false
 	mode = push
-	parent = bdbb33483cea0274fcbed348e38a85b1f80b0802
+	parent = 8329c91078d2a38871b5b24e463d9a506efbf806
 	remote = git@github.com:liferay/com-liferay-osb-faro-private.git

--- a/modules/util/portal-tools-db-virtual-instance-migration/README.markdown
+++ b/modules/util/portal-tools-db-virtual-instance-migration/README.markdown
@@ -1,0 +1,12 @@
+# DB Virtual Instance Migration Tool
+This tool allows to migrate a virtual instance to a new database partition in a database partitioned environment. Before starting the migration, it validates that all the needed conditions for a successful migration are met.
+
+## Requirements:
+    - MySQL
+    - Database user with DDL privileges
+
+## Usage
+    usage: Liferay Portal DB Virtual Instance Migration
+
+## Execution example
+    java -jar com.liferay.portal.tools.db.partition.schema.validator.jar

--- a/modules/util/portal-tools-db-virtual-instance-migration/README.markdown
+++ b/modules/util/portal-tools-db-virtual-instance-migration/README.markdown
@@ -7,6 +7,14 @@ This tool allows to migrate a virtual instance to a new database partition in a 
 
 ## Usage
     usage: Liferay Portal DB Virtual Instance Migration
+    -d,--destination-jdbc-url <arg> Set the JDBC url for the destination database.
+    -dp,--destination-password <arg> Set the destination database user password.
+    -dsp,--destination-schema-prefix <arg> Set the schema prefix for nondefault databases in destination database.
+    -du,--destination-user <arg> Set the destination database user name.
+    -h,--help Print help message.
+    -s,--source-jdbc-url <arg> Set the JDBC url for the source database.
+    -sp,--source-password <arg> Set the source database user password.
+    -su,--source-user <arg> Set the source database user name.
 
 ## Execution example
-    java -jar com.liferay.portal.tools.db.partition.schema.validator.jar
+    java -jar com.liferay.portal.tools.db.virtual.instance.migration.jar -s "jdbc:mysql://localhost:3306/lpartition_xxxxx?useUnicode=true&characterEncoding=UTF-8&useFastDateParsing=false&useTimezone=true&serverTimezone=GMT" -su sourceDatabaseUser -sp sourceDatabasePassword -d "jdbc:mysql://localhost:3306/lportal?useUnicode=true&characterEncoding=UTF-8&useFastDateParsing=false&useTimezone=true&serverTimezone=GMT" -du destinationDatabaseUser -dp destinationDatabasePassword

--- a/modules/util/portal-tools-db-virtual-instance-migration/bnd.bnd
+++ b/modules/util/portal-tools-db-virtual-instance-migration/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Portal Tools DB Virtual Instance Migration
+Bundle-SymbolicName: com.liferay.portal.tools.db.virtual.instance.migration
+Bundle-Version: 1.0.0
+Main-Class: com.liferay.portal.tools.db.virtual.instance.migration.VirtualInstanceMigration

--- a/modules/util/portal-tools-db-virtual-instance-migration/build.gradle
+++ b/modules/util/portal-tools-db-virtual-instance-migration/build.gradle
@@ -1,0 +1,35 @@
+dependencies {
+}
+
+deploy {
+	from "scripts"
+}
+
+distZip {
+	filesMatching("**/*.jar") {
+		it.path = it.name
+	}
+}
+
+distributions {
+	main {
+		contents {
+			from "scripts"
+			into "/"
+		}
+	}
+}
+
+jar {
+	archiveName "$baseName" + ".jar"
+}
+
+liferayOSGi {
+	expandCompileInclude = true
+}
+
+startScripts {
+	onlyIf {
+		false
+	}
+}

--- a/modules/util/portal-tools-db-virtual-instance-migration/build.gradle
+++ b/modules/util/portal-tools-db-virtual-instance-migration/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
+	compileInclude group: "commons-cli", name: "commons-cli", version: "1.4"
+	compileInclude group: "mysql", name: "mysql-connector-java", version: "8.0.29"
 }
 
 deploy {

--- a/modules/util/portal-tools-db-virtual-instance-migration/build.gradle
+++ b/modules/util/portal-tools-db-virtual-instance-migration/build.gradle
@@ -1,6 +1,8 @@
 dependencies {
 	compileInclude group: "commons-cli", name: "commons-cli", version: "1.4"
 	compileInclude group: "mysql", name: "mysql-connector-java", version: "8.0.29"
+
+	compileOnly group: "org.mockito", name: "mockito-core", version: "4.5.1"
 }
 
 deploy {

--- a/modules/util/portal-tools-db-virtual-instance-migration/scripts/db_virtual_instance_migration.bat
+++ b/modules/util/portal-tools-db-virtual-instance-migration/scripts/db_virtual_instance_migration.bat
@@ -1,0 +1,11 @@
+@echo off
+
+pushd "%~dp0"
+
+path %PATH%;%JAVA_HOME%\bin
+
+java -jar com.liferay.portal.tools.db.virtual.instance.migration.jar %*
+
+popd
+
+@echo on

--- a/modules/util/portal-tools-db-virtual-instance-migration/scripts/db_virtual_instance_migration.sh
+++ b/modules/util/portal-tools-db-virtual-instance-migration/scripts/db_virtual_instance_migration.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#
+# Ignore SIGHUP to avoid stopping migration when terminal disconnects.
+#
+
+trap '' 1
+
+if [ -e /proc/$$/fd/255 ]
+then
+	DB_MIGRATION_PATH=`readlink /proc/$$/fd/255 2>/dev/null`
+fi
+
+if [ ! -n "${DB_MIGRATION_PATH}" ]
+then
+	DB_MIGRATION_PATH="$0"
+fi
+
+cd "$(dirname "${DB_MIGRATION_PATH}")"
+
+#
+# Run database virtual intance migration tool.
+#
+
+java -jar com.liferay.portal.tools.db.virtual.instance.migration.jar "$@"

--- a/modules/util/portal-tools-db-virtual-instance-migration/source-formatter-suppressions.xml
+++ b/modules/util/portal-tools-db-virtual-instance-migration/source-formatter-suppressions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<suppressions>
+	<checkstyle>
+		<suppress checks="CompanyIterationCheck" files="src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/util/Database\.java" />
+	</checkstyle>
+	<source-check>
+		<suppress checks="StringMethodsCheck" files="src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/util/Database\.java" />
+	</source-check>
+</suppressions>

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/VirtualInstanceMigration.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/VirtualInstanceMigration.java
@@ -107,6 +107,14 @@ public class VirtualInstanceMigration {
 							"destination-schema-prefix"));
 				}
 
+				if (!Database.isSingleVirtualInstance(_sourceConnection)) {
+					System.err.println(
+						"ERROR: Source database has several instances, that " +
+							"is not supported by the tool");
+
+					_exitWithCode(ErrorCodes.SOURCE_MULTI_INSTANCES);
+				}
+
 				if (!Database.isDefaultPartition(_destinationConnection)) {
 					System.err.println(
 						"ERROR: Destination database is not the default " +

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/VirtualInstanceMigration.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/VirtualInstanceMigration.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools.db.virtual.instance.migration;
+
+/**
+ * @author Luis Ortiz
+ */
+public class VirtualInstanceMigration {
+
+	public static void main(String[] args) {
+		System.out.println("Hello world!");
+
+		System.exit(0);
+	}
+
+}

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/VirtualInstanceMigration.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/VirtualInstanceMigration.java
@@ -119,10 +119,13 @@ public class VirtualInstanceMigration {
 					_exitWithCode(ErrorCodes.DESTINATION_NOT_DEFAULT);
 				}
 
-				if (!Validator.validateDatabases(
-						_sourceConnection, _destinationConnection)) {
+				ValidatorRecorder recorder = Validator.validateDatabases(
+					_sourceConnection, _destinationConnection);
 
-					ValidatorRecorder.printMessages();
+				if (recorder.hasRegisteredErrors() ||
+					recorder.hasRegisteredWarnings()) {
+
+					recorder.printMessages();
 					_exitWithCode(ErrorCodes.VALIDATION_ERROR);
 				}
 

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/VirtualInstanceMigration.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/VirtualInstanceMigration.java
@@ -14,15 +14,149 @@
 
 package com.liferay.portal.tools.db.virtual.instance.migration;
 
+import com.liferay.portal.tools.db.virtual.instance.migration.error.ErrorCodes;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
 /**
  * @author Luis Ortiz
  */
 public class VirtualInstanceMigration {
 
-	public static void main(String[] args) {
-		System.out.println("Hello world!");
+	public static void main(String[] args) throws Exception {
+		Options options = _getOptions();
 
-		System.exit(0);
+		if ((args.length != 0) &&
+			(args[0].equals("-h") || args[0].endsWith("help"))) {
+
+			HelpFormatter helpFormatter = new HelpFormatter();
+
+			helpFormatter.printHelp(
+				"Liferay Portal Tools DB Virtual Instance Migration", options);
+
+			return;
+		}
+
+		try {
+			CommandLineParser commandLineParser = new DefaultParser();
+
+			CommandLine commandLine = commandLineParser.parse(options, args);
+
+			String sourceJdbcUrl = commandLine.getOptionValue(
+				"source-jdbc-url");
+			String sourceUser = commandLine.getOptionValue("source-user");
+			String sourcePassword = commandLine.getOptionValue(
+				"source-password");
+
+			String destinationJdbcUrl = commandLine.getOptionValue(
+				"destination-jdbc-url");
+			String destinationUser = commandLine.getOptionValue(
+				"destination-user");
+			String destinationPassword = commandLine.getOptionValue(
+				"destination-password");
+
+			try {
+				_sourceConnection = DriverManager.getConnection(
+					sourceJdbcUrl, sourceUser, sourcePassword);
+			}
+			catch (SQLException sqlException) {
+				System.err.println(
+					"ERROR: Not possible to get source database connection " +
+						"with specified parameters:");
+				sqlException.printStackTrace();
+
+				_exitWithCode(ErrorCodes.BAD_SOURCE_PARAMETERS);
+			}
+
+			try {
+				_destinationConnection = DriverManager.getConnection(
+					destinationJdbcUrl, destinationUser, destinationPassword);
+			}
+			catch (SQLException sqlException) {
+				System.err.println(
+					"ERROR: Not possible to get destination database " +
+						"connection with specified parameters:");
+				sqlException.printStackTrace();
+
+				_exitWithCode(ErrorCodes.BAD_DESTINATION_PARAMETERS);
+			}
+
+			if (commandLine.hasOption("destination-schema-prefix")) {
+				_schemaPrefix = commandLine.getOptionValue(
+					"destination-schema-prefix");
+			}
+		}
+		catch (ParseException parseException) {
+			System.err.println(
+				"ERROR: Unable to parse command line properties: " +
+					parseException.getMessage());
+			System.err.println();
+
+			HelpFormatter helpFormatter = new HelpFormatter();
+
+			helpFormatter.printHelp(
+				"Liferay Portal Tools DB Virtual Instance Migration", options);
+
+			_exitWithCode(ErrorCodes.BAD_INPUT_ARGUMENTS);
+		}
+
+		_exitWithCode(ErrorCodes.SUCCESS);
 	}
+
+	private static void _exitWithCode(int code) throws SQLException {
+		if (_sourceConnection != null) {
+			_sourceConnection.close();
+		}
+
+		if (_destinationConnection != null) {
+			_sourceConnection.close();
+		}
+
+		if (code != ErrorCodes.SUCCESS) {
+			System.exit(code);
+		}
+	}
+
+	private static Options _getOptions() {
+		Options options = new Options();
+
+		options.addRequiredOption(
+			"s", "source-jdbc-url", true,
+			"Set the JDBC url for the source database.");
+		options.addRequiredOption(
+			"su", "source-user", true, "Set the source database user name.");
+		options.addRequiredOption(
+			"sp", "source-password", true,
+			"Set the source database user password.");
+		options.addRequiredOption(
+			"d", "destination-jdbc-url", true,
+			"Set the JDBC url for the destination database.");
+		options.addRequiredOption(
+			"du", "destination-user", true,
+			"Set the destination database user name.");
+		options.addRequiredOption(
+			"dp", "destination-password", true,
+			"Set the destination database user password.");
+		options.addOption(
+			"dsp", "destination-schema-prefix", true,
+			"Set the schema prefix for nondefault databases in destination " +
+				"database.");
+		options.addOption("h", "help", false, "Print help message.");
+
+		return options;
+	}
+
+	private static Connection _destinationConnection;
+	private static String _schemaPrefix = "lpartition_";
+	private static Connection _sourceConnection;
 
 }

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/VirtualInstanceMigration.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/VirtualInstanceMigration.java
@@ -16,16 +16,12 @@ package com.liferay.portal.tools.db.virtual.instance.migration;
 
 import com.liferay.portal.tools.db.virtual.instance.migration.error.ErrorCodes;
 import com.liferay.portal.tools.db.virtual.instance.migration.internal.util.Database;
-import com.liferay.portal.tools.db.virtual.instance.migration.internal.util.Version;
+import com.liferay.portal.tools.db.virtual.instance.migration.internal.validation.Validator;
+import com.liferay.portal.tools.db.virtual.instance.migration.internal.validation.ValidatorRecorder;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -109,7 +105,7 @@ public class VirtualInstanceMigration {
 
 				if (!Database.isSingleVirtualInstance(_sourceConnection)) {
 					System.err.println(
-						"ERROR: Source database has several instances, that " +
+						"ERROR: Source database has several instances. That " +
 							"is not supported by the tool");
 
 					_exitWithCode(ErrorCodes.SOURCE_MULTI_INSTANCES);
@@ -123,9 +119,14 @@ public class VirtualInstanceMigration {
 					_exitWithCode(ErrorCodes.DESTINATION_NOT_DEFAULT);
 				}
 
-				if (!_validate(_sourceConnection, _destinationConnection)) {
+				if (!Validator.validateDatabases(
+						_sourceConnection, _destinationConnection)) {
+
+					ValidatorRecorder.printMessages();
 					_exitWithCode(ErrorCodes.VALIDATION_ERROR);
 				}
+
+				System.out.println("All validations passed successfully");
 			}
 			catch (ParseException parseException) {
 				System.err.println(
@@ -149,68 +150,6 @@ public class VirtualInstanceMigration {
 			exception.printStackTrace();
 			_exitWithCode(ErrorCodes.UNEXPECTED_ERROR);
 		}
-	}
-
-	private static boolean _checkTables(
-			Connection sourceConnection, Connection destinationConnection)
-		throws SQLException {
-
-		boolean valid = true;
-
-		List<String> sourceTables = Database.getTables(sourceConnection);
-		List<String> destinationTables = Database.getTables(
-			destinationConnection);
-
-		for (String tableName : sourceTables) {
-			if (destinationTables.contains(tableName)) {
-				destinationTables.remove(tableName);
-
-				continue;
-			}
-
-			System.out.println(
-				"WARNING: Table " + tableName +
-					" is not present in destination database");
-			valid = false;
-		}
-
-		if (!destinationTables.isEmpty()) {
-			for (String tableName : destinationTables) {
-				System.out.println(
-					"WARNING: Table " + tableName +
-						" is not present in source database");
-			}
-
-			valid = false;
-		}
-
-		return valid;
-	}
-
-	private static boolean _checkWebIds(
-			Connection sourceConnection, Connection destinationConnection)
-		throws SQLException {
-
-		String sourceWebId = Database.getWebId(sourceConnection);
-
-		try (PreparedStatement preparedStatement =
-				destinationConnection.prepareStatement(
-					"select companyId from Company where webId = ?")) {
-
-			preparedStatement.setString(1, sourceWebId);
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				if (resultSet.next()) {
-					System.out.println(
-						"WARNING: webId " + sourceWebId +
-							" already exists in destination database");
-
-					return false;
-				}
-			}
-		}
-
-		return true;
 	}
 
 	private static void _exitWithCode(int code) {
@@ -259,175 +198,6 @@ public class VirtualInstanceMigration {
 			"su", "source-user", true, "Set the source database user name.");
 
 		return options;
-	}
-
-	private static void _printErrorMessages(
-		List<String> modules, String message) {
-
-		for (String module : modules) {
-			System.out.println("ERROR: Module " + module + message);
-		}
-	}
-
-	private static void _printWarningMessages(
-		List<String> modules, String message) {
-
-		for (String module : modules) {
-			System.out.println("WARNING: Module " + module + message);
-		}
-	}
-
-	private static boolean _validate(
-			Connection sourceConnection, Connection destinationConnection)
-		throws SQLException {
-
-		boolean valid = true;
-
-		if (!_validateReleaseTableState(sourceConnection)) {
-			System.out.println(
-				"ERROR: Source database Release_ table has records with an " +
-					"invalid state_");
-			valid = false;
-		}
-
-		if (!_validateReleaseTableState(destinationConnection)) {
-			System.out.println(
-				"ERROR: Destination database Release_ table has records with " +
-					"an invalid state_");
-			valid = false;
-		}
-
-		valid &= _validateReleaseTableModules(
-			sourceConnection, destinationConnection);
-
-		valid &= _checkTables(sourceConnection, destinationConnection);
-
-		valid &= _checkWebIds(sourceConnection, destinationConnection);
-
-		return valid;
-	}
-
-	private static boolean _validateReleaseTableModules(
-			Connection sourceConnection, Connection destinationConnection)
-		throws SQLException {
-
-		boolean valid = true;
-
-		try (PreparedStatement preparedStatement1 =
-				sourceConnection.prepareStatement(
-					"select servletContextName, schemaVersion, verified from " +
-						" Release_");
-			ResultSet resultSet1 = preparedStatement1.executeQuery()) {
-
-			List<String> missingModules = new ArrayList<>();
-			List<String> missingServiceModules = new ArrayList<>();
-			List<String> lowerVersionModules = new ArrayList<>();
-			List<String> higherVersionModules = new ArrayList<>();
-			List<String> sourceUnverifiedModules = new ArrayList<>();
-			List<String> destinationUnverifiedModules = new ArrayList<>();
-
-			while (resultSet1.next()) {
-				String sourceServletContextName = resultSet1.getString(1);
-				Version sourceVersion = Version.parseVersion(
-					resultSet1.getString(2));
-				boolean sourceVerified = resultSet1.getBoolean(3);
-
-				try (PreparedStatement preparedStatement2 =
-						destinationConnection.prepareStatement(
-							"select servletContextName, schemaVersion, " +
-								"verified from Release_ where " +
-									"servletContextName = ?")) {
-
-					preparedStatement2.setString(1, sourceServletContextName);
-
-					try (ResultSet resultSet2 =
-							preparedStatement2.executeQuery()) {
-
-						if (!resultSet2.next()) {
-							if (sourceServletContextName.endsWith(".service")) {
-								missingServiceModules.add(
-									sourceServletContextName);
-							}
-							else {
-								missingModules.add(sourceServletContextName);
-							}
-
-							continue;
-						}
-
-						Version destinationVersion = Version.parseVersion(
-							resultSet2.getString(2));
-						boolean destinationVerified = resultSet2.getBoolean(3);
-
-						if (sourceVersion.compareTo(destinationVersion) < 0) {
-							lowerVersionModules.add(sourceServletContextName);
-						}
-						else if (sourceVersion.compareTo(destinationVersion) >
-									0) {
-
-							higherVersionModules.add(sourceServletContextName);
-						}
-
-						if (sourceVerified && !destinationVerified) {
-							destinationUnverifiedModules.add(
-								sourceServletContextName);
-						}
-						else if (!sourceVerified && destinationVerified) {
-							sourceUnverifiedModules.add(
-								sourceServletContextName);
-						}
-					}
-				}
-			}
-
-			_printErrorMessages(
-				missingServiceModules,
-				" will not be available in the destination");
-			_printErrorMessages(
-				lowerVersionModules,
-				" needs to be upgraded in source database before the " +
-					"migration");
-			_printErrorMessages(
-				higherVersionModules,
-				" is in a lower version in destination database");
-			_printErrorMessages(
-				sourceUnverifiedModules,
-				" needs to be verified in the source before the migration");
-			_printErrorMessages(
-				destinationUnverifiedModules,
-				" needs to be verified in the destination before the " +
-					"migration");
-			_printWarningMessages(
-				missingModules, " will not be available in the destination");
-
-			if (!missingModules.isEmpty() || !missingServiceModules.isEmpty() ||
-				!lowerVersionModules.isEmpty() ||
-				!higherVersionModules.isEmpty() ||
-				!sourceUnverifiedModules.isEmpty() ||
-				!destinationUnverifiedModules.isEmpty()) {
-
-				valid = false;
-			}
-		}
-
-		return valid;
-	}
-
-	private static boolean _validateReleaseTableState(Connection connection)
-		throws SQLException {
-
-		boolean stateOk = true;
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				"select servletContextName from Release_ where state_ != 0;");
-			ResultSet resultSet = preparedStatement.executeQuery()) {
-
-			if (resultSet.next()) {
-				stateOk = false;
-			}
-		}
-
-		return stateOk;
 	}
 
 	private static Connection _destinationConnection;

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/VirtualInstanceMigration.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/VirtualInstanceMigration.java
@@ -179,6 +179,32 @@ public class VirtualInstanceMigration {
 		return valid;
 	}
 
+	private static boolean _checkWebIds(
+			Connection sourceConnection, Connection destinationConnection)
+		throws SQLException {
+
+		String sourceWebId = Database.getWebId(sourceConnection);
+
+		try (PreparedStatement preparedStatement =
+				destinationConnection.prepareStatement(
+					"select companyId from Company where webId = ?")) {
+
+			preparedStatement.setString(1, sourceWebId);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (resultSet.next()) {
+					System.out.println(
+						"WARNING: webId " + sourceWebId +
+							" already exists in destination database");
+
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
 	private static void _exitWithCode(int code) {
 		try {
 			if (_sourceConnection != null) {
@@ -267,6 +293,8 @@ public class VirtualInstanceMigration {
 			sourceConnection, destinationConnection);
 
 		valid &= _checkTables(sourceConnection, destinationConnection);
+
+		valid &= _checkWebIds(sourceConnection, destinationConnection);
 
 		return valid;
 	}

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/error/ErrorCodes.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/error/ErrorCodes.java
@@ -27,6 +27,8 @@ public class ErrorCodes {
 
 	public static final int DESTINATION_NOT_DEFAULT = 13;
 
+	public static final int SOURCE_MULTI_INSTANCES = 14;
+
 	public static final int SUCCESS = 0;
 
 	public static final int UNEXPECTED_ERROR = 255;

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/error/ErrorCodes.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/error/ErrorCodes.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools.db.virtual.instance.migration.error;
+
+/**
+ * @author Luis Ortiz
+ */
+public class ErrorCodes {
+
+	public static final int BAD_DESTINATION_PARAMETERS = 3;
+
+	public static final int BAD_INPUT_ARGUMENTS = 1;
+
+	public static final int BAD_SOURCE_PARAMETERS = 2;
+
+	public static final int SUCCESS = 0;
+
+}

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/error/ErrorCodes.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/error/ErrorCodes.java
@@ -31,4 +31,6 @@ public class ErrorCodes {
 
 	public static final int UNEXPECTED_ERROR = 255;
 
+	public static final int VALIDATION_ERROR = 20;
+
 }

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/error/ErrorCodes.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/error/ErrorCodes.java
@@ -19,12 +19,16 @@ package com.liferay.portal.tools.db.virtual.instance.migration.error;
  */
 public class ErrorCodes {
 
-	public static final int BAD_DESTINATION_PARAMETERS = 3;
+	public static final int BAD_DESTINATION_PARAMETERS = 12;
 
-	public static final int BAD_INPUT_ARGUMENTS = 1;
+	public static final int BAD_INPUT_ARGUMENTS = 10;
 
-	public static final int BAD_SOURCE_PARAMETERS = 2;
+	public static final int BAD_SOURCE_PARAMETERS = 11;
+
+	public static final int DESTINATION_NOT_DEFAULT = 13;
 
 	public static final int SUCCESS = 0;
+
+	public static final int UNEXPECTED_ERROR = 255;
 
 }

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/Release.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/Release.java
@@ -16,6 +16,8 @@ package com.liferay.portal.tools.db.virtual.instance.migration.internal;
 
 import com.liferay.portal.tools.db.virtual.instance.migration.internal.util.Version;
 
+import java.util.Objects;
+
 /**
  * @author Luis Ortiz
  */
@@ -29,6 +31,28 @@ public class Release {
 		_verified = verified;
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Release)) {
+			return false;
+		}
+
+		Release release = (Release)object;
+
+		if (_servletContextName.equals(release._servletContextName) &&
+			_schemaVersion.equals(release._schemaVersion) &&
+			(_verified == release._verified)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	public Version getSchemaVersion() {
 		return _schemaVersion;
 	}
@@ -39,6 +63,11 @@ public class Release {
 
 	public boolean getVerified() {
 		return _verified;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(_schemaVersion, _servletContextName, _verified);
 	}
 
 	private final Version _schemaVersion;

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/Release.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/Release.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools.db.virtual.instance.migration.internal;
+
+import com.liferay.portal.tools.db.virtual.instance.migration.internal.util.Version;
+
+/**
+ * @author Luis Ortiz
+ */
+public class Release {
+
+	public Release(
+		String servletContextName, Version schemaVersion, boolean verified) {
+
+		_servletContextName = servletContextName;
+		_schemaVersion = schemaVersion;
+		_verified = verified;
+	}
+
+	public Version getSchemaVersion() {
+		return _schemaVersion;
+	}
+
+	public String getServletContextName() {
+		return _servletContextName;
+	}
+
+	public boolean getVerified() {
+		return _verified;
+	}
+
+	private final Version _schemaVersion;
+	private final String _servletContextName;
+	private final boolean _verified;
+
+}

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/util/Database.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/util/Database.java
@@ -56,6 +56,20 @@ public class Database {
 		return tableNames;
 	}
 
+	public static String getWebId(Connection connection) throws SQLException {
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select webId from Company, CompanyInfo where " +
+					"CompanyInfo.companyId = Company.companyId");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			if (resultSet.next()) {
+				return resultSet.getString(1);
+			}
+
+			return null;
+		}
+	}
+
 	public static boolean isDefaultPartition(Connection connection)
 		throws SQLException {
 

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/util/Database.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/util/Database.java
@@ -90,6 +90,25 @@ public class Database {
 		return true;
 	}
 
+	public static boolean isSingleVirtualInstance(Connection connection)
+		throws SQLException {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select count(1) from CompanyInfo");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			if (resultSet.next()) {
+				int count = resultSet.getInt(1);
+
+				if (count > 1) {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
 	public static void setSchemaPrefix(String schemaPrefix) {
 		_schemaPrefix = schemaPrefix;
 	}

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/util/Database.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/util/Database.java
@@ -22,6 +22,7 @@ import java.sql.SQLException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -116,6 +117,10 @@ public class Database {
 	private static List<Long> _getCompanyIds(Connection connection)
 		throws SQLException {
 
+		if (_companyIds.containsKey(connection)) {
+			return _companyIds.get(connection);
+		}
+
 		List<Long> companyIds = new ArrayList<>();
 
 		long defaultCompanyId = _getDefaultCompanyIdBySQL(connection);
@@ -136,6 +141,8 @@ public class Database {
 				}
 			}
 		}
+
+		_companyIds.put(connection, companyIds);
 
 		return companyIds;
 	}
@@ -178,9 +185,9 @@ public class Database {
 			Connection connection, String tableName)
 		throws SQLException {
 
-		if ((!_isObjectTable(connection, tableName) &&
-			 _controlTableNames.contains(tableName)) ||
-			!_hasColumn(tableName, "companyId", connection)) {
+		if (!_isObjectTable(connection, tableName) &&
+			(_controlTableNames.contains(tableName) ||
+			 !_hasColumn(tableName, "companyId", connection))) {
 
 			return true;
 		}
@@ -218,6 +225,8 @@ public class Database {
 		return name;
 	}
 
+	private static final HashMap<Connection, List<Long>> _companyIds =
+		new HashMap<>();
 	private static final Set<String> _controlTableNames = new HashSet<>(
 		Arrays.asList("Company", "VirtualHost"));
 	private static String _schemaPrefix = "lpartition_";

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/util/Database.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/util/Database.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools.db.virtual.instance.migration.internal.util;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Luis Ortiz
+ */
+public class Database {
+
+	public static List<String> getTables(Connection connection)
+		throws SQLException {
+
+		DatabaseMetaData databaseMetaData = connection.getMetaData();
+
+		List<String> tableNames = new ArrayList<>();
+
+		try (ResultSet resultSet = databaseMetaData.getTables(
+				connection.getCatalog(), connection.getSchema(), null,
+				new String[] {"TABLE"})) {
+
+			while (resultSet.next()) {
+				String tableName = resultSet.getString("TABLE_NAME");
+
+				if (!_isObjectTable(connection, tableName) &&
+					!_isControlTable(connection, tableName)) {
+
+					tableNames.add(tableName);
+				}
+			}
+		}
+
+		return tableNames;
+	}
+
+	public static boolean isDefaultPartition(Connection connection)
+		throws SQLException {
+
+		DatabaseMetaData databaseMetaData = connection.getMetaData();
+
+		for (String tableName : _controlTableNames) {
+			try (ResultSet resultSet = databaseMetaData.getTables(
+					connection.getCatalog(), connection.getSchema(),
+					_normalizeName(databaseMetaData, tableName),
+					new String[] {"TABLE"})) {
+
+				if (!resultSet.next()) {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	public static void setSchemaPrefix(String schemaPrefix) {
+		_schemaPrefix = schemaPrefix;
+	}
+
+	private static List<Long> _getCompanyIds(Connection connection)
+		throws SQLException {
+
+		List<Long> companyIds = new ArrayList<>();
+
+		long defaultCompanyId = _getDefaultCompanyIdBySQL(connection);
+
+		if (defaultCompanyId != 0) {
+			companyIds.add(defaultCompanyId);
+		}
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select companyId from Company");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				long companyId = resultSet.getLong("companyId");
+
+				if (companyId != defaultCompanyId) {
+					companyIds.add(companyId);
+				}
+			}
+		}
+
+		return companyIds;
+	}
+
+	private static long _getDefaultCompanyIdBySQL(Connection connection)
+		throws SQLException {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select companyId from CompanyInfo");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			if (resultSet.next()) {
+				return resultSet.getLong(1);
+			}
+		}
+
+		return 0;
+	}
+
+	private static boolean _hasColumn(
+			String tableName, String columnName, Connection connection)
+		throws SQLException {
+
+		DatabaseMetaData databaseMetaData = connection.getMetaData();
+
+		try (ResultSet resultSet = databaseMetaData.getColumns(
+				connection.getCatalog(), connection.getSchema(),
+				_normalizeName(databaseMetaData, tableName),
+				_normalizeName(databaseMetaData, columnName))) {
+
+			if (!resultSet.next()) {
+				return false;
+			}
+
+			return true;
+		}
+	}
+
+	private static boolean _isControlTable(
+			Connection connection, String tableName)
+		throws SQLException {
+
+		if ((!_isObjectTable(connection, tableName) &&
+			 _controlTableNames.contains(tableName)) ||
+			!_hasColumn(tableName, "companyId", connection)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private static boolean _isObjectTable(
+			Connection connection, String tableName)
+		throws SQLException {
+
+		for (long companyId : _getCompanyIds(connection)) {
+			if (tableName.endsWith("_x_" + companyId) ||
+				tableName.startsWith("O_" + companyId + "_")) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static String _normalizeName(
+			DatabaseMetaData databaseMetaData, String name)
+		throws SQLException {
+
+		if (databaseMetaData.storesLowerCaseIdentifiers()) {
+			return name.toLowerCase();
+		}
+
+		if (databaseMetaData.storesUpperCaseIdentifiers()) {
+			return name.toUpperCase();
+		}
+
+		return name;
+	}
+
+	private static final Set<String> _controlTableNames = new HashSet<>(
+		Arrays.asList("Company", "VirtualHost"));
+	private static String _schemaPrefix = "lpartition_";
+
+}

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/util/Version.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/util/Version.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools.db.virtual.instance.migration.internal.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Luis Ortiz
+ */
+public class Version implements Comparable<Version> {
+
+	public static Version parseVersion(String version) {
+		if (version == null) {
+			return new Version(0, 0, 0);
+		}
+
+		version = version.trim();
+
+		if (version.isEmpty()) {
+			return new Version(0, 0, 0);
+		}
+
+		version = version.trim();
+
+		Matcher matcher = _versionPattern.matcher(version);
+
+		if (!matcher.matches()) {
+			return new Version(0, 0, 0);
+		}
+
+		int major = 0;
+		int minor = 0;
+		int micro = 0;
+		String qualifier = "";
+
+		String match;
+
+		try {
+			match = matcher.group(1);
+
+			if (match != null) {
+				major = Integer.parseInt(match.trim());
+			}
+		}
+		catch (NumberFormatException numberFormatException) {
+		}
+
+		try {
+			match = matcher.group(3);
+
+			if (match != null) {
+				minor = Integer.parseInt(match.trim());
+			}
+		}
+		catch (NumberFormatException numberFormatException) {
+		}
+
+		try {
+			match = matcher.group(5);
+
+			if (match != null) {
+				micro = Integer.parseInt(match.trim());
+			}
+		}
+		catch (NumberFormatException numberFormatException) {
+		}
+
+		match = matcher.group(7);
+
+		if (match != null) {
+			qualifier = match.trim();
+		}
+
+		return new Version(major, minor, micro, qualifier);
+	}
+
+	public Version(int major, int minor, int micro) {
+		_major = major;
+		_minor = minor;
+		_micro = micro;
+
+		_qualifier = "";
+	}
+
+	public Version(int major, int minor, int micro, String qualifier) {
+		_major = major;
+		_minor = minor;
+		_micro = micro;
+		_qualifier = qualifier;
+	}
+
+	@Override
+	public int compareTo(Version version) {
+		int result = Integer.compare(_major, version._major);
+
+		if (result != 0) {
+			return result;
+		}
+
+		result = Integer.compare(_minor, version._minor);
+
+		if (result != 0) {
+			return result;
+		}
+
+		result = Integer.compare(_micro, version._micro);
+
+		if (result != 0) {
+			return result;
+		}
+
+		String qualifier = version._qualifier;
+
+		result = _qualifier.compareTo(qualifier);
+
+		if (_qualifier.isEmpty() || qualifier.isEmpty()) {
+			return result * -1;
+		}
+
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Version)) {
+			return false;
+		}
+
+		Version version = (Version)object;
+
+		if ((_major == version._major) && (_minor == version._minor) &&
+			(_micro == version._micro) &&
+			_qualifier.equals(version._qualifier)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	public int getMajor() {
+		return _major;
+	}
+
+	public int getMicro() {
+		return _micro;
+	}
+
+	public int getMinor() {
+		return _minor;
+	}
+
+	public String getQualifier() {
+		return _qualifier;
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = _major;
+
+		hash = (hash * 11) + _minor;
+		hash = (hash * 11) + _micro;
+
+		return (hash * 11) + ((_qualifier == null) ? 0 : _qualifier.hashCode());
+	}
+
+	@Override
+	public String toString() {
+		if (getQualifier().isEmpty()) {
+			return _major + "." + _minor + "." + _micro;
+		}
+
+		return _major + "." + _minor + "." + _micro + "." + _qualifier;
+	}
+
+	private static final Pattern _versionPattern = Pattern.compile(
+		"(\\d{1,10})(\\.(\\d{1,10})(\\.(\\d{1,10})" +
+			"(\\.([-_\\da-zA-Z]+))?)?)?");
+
+	private final int _major;
+	private final int _micro;
+	private final int _minor;
+	private final String _qualifier;
+
+}

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/validation/Validator.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/validation/Validator.java
@@ -231,18 +231,16 @@ public class Validator {
 	private static boolean _validateReleaseTableState(Connection connection)
 		throws SQLException {
 
-		boolean stateOk = true;
-
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select servletContextName from Release_ where state_ != 0;");
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			if (resultSet.next()) {
-				stateOk = false;
+				return false;
 			}
 		}
 
-		return stateOk;
+		return true;
 	}
 
 }

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/validation/Validator.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/validation/Validator.java
@@ -157,21 +157,21 @@ public class Validator {
 		}
 
 		recorder.registerErrors(
-			missingServiceModules, " will not be available in the destination");
+			missingServiceModules, "will not be available in the destination");
 		recorder.registerErrors(
 			lowerVersionModules,
-			" needs to be upgraded in source database before the migration");
+			"needs to be upgraded in source database before the migration");
 		recorder.registerErrors(
 			higherVersionModules,
-			" is in a lower version in destination database");
+			"is in a lower version in destination database");
 		recorder.registerErrors(
 			sourceUnverifiedModules,
-			" needs to be verified in the source before the migration");
+			"needs to be verified in the source before the migration");
 		recorder.registerErrors(
 			destinationUnverifiedModules,
-			" needs to be verified in the destination before the migration");
+			"needs to be verified in the destination before the migration");
 		recorder.registerWarnings(
-			missingModules, " will not be available in the destination");
+			missingModules, "will not be available in the destination");
 	}
 
 	private static boolean _validateReleaseTableState(Connection connection)

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/validation/Validator.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/validation/Validator.java
@@ -1,0 +1,248 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools.db.virtual.instance.migration.internal.validation;
+
+import com.liferay.portal.tools.db.virtual.instance.migration.internal.util.Database;
+import com.liferay.portal.tools.db.virtual.instance.migration.internal.util.Version;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Luis Ortiz
+ */
+public class Validator {
+
+	public static boolean validateDatabases(
+			Connection sourceConnection, Connection destinationConnection)
+		throws SQLException {
+
+		boolean valid = true;
+
+		if (!_validateReleaseTableState(sourceConnection)) {
+			ValidatorRecorder.registerError(
+				"Source database Release_ table has records with an invalid " +
+					"state_");
+			valid = false;
+		}
+
+		if (!_validateReleaseTableState(destinationConnection)) {
+			ValidatorRecorder.registerError(
+				"Destination database Release_ table has records with an " +
+					"invalid state_");
+			valid = false;
+		}
+
+		valid &= _validateReleaseTableModules(
+			sourceConnection, destinationConnection);
+
+		valid &= _checkTables(sourceConnection, destinationConnection);
+
+		valid &= _checkWebIds(sourceConnection, destinationConnection);
+
+		return valid;
+	}
+
+	private static boolean _checkTables(
+			Connection sourceConnection, Connection destinationConnection)
+		throws SQLException {
+
+		boolean valid = true;
+
+		List<String> sourceTables = Database.getTables(sourceConnection);
+		List<String> destinationTables = Database.getTables(
+			destinationConnection);
+
+		for (String tableName : sourceTables) {
+			if (destinationTables.contains(tableName)) {
+				destinationTables.remove(tableName);
+
+				continue;
+			}
+
+			ValidatorRecorder.registerWarning(
+				"Table " + tableName +
+					" is not present in destination database");
+			valid = false;
+		}
+
+		if (!destinationTables.isEmpty()) {
+			for (String tableName : destinationTables) {
+				ValidatorRecorder.registerWarning(
+					"Table " + tableName +
+						" is not present in source database");
+			}
+
+			valid = false;
+		}
+
+		return valid;
+	}
+
+	private static boolean _checkWebIds(
+			Connection sourceConnection, Connection destinationConnection)
+		throws SQLException {
+
+		String sourceWebId = Database.getWebId(sourceConnection);
+
+		try (PreparedStatement preparedStatement =
+				destinationConnection.prepareStatement(
+					"select companyId from Company where webId = ?")) {
+
+			preparedStatement.setString(1, sourceWebId);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (resultSet.next()) {
+					ValidatorRecorder.registerWarning(
+						"webId " + sourceWebId +
+							" already exists in destination database");
+
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	private static boolean _validateReleaseTableModules(
+			Connection sourceConnection, Connection destinationConnection)
+		throws SQLException {
+
+		boolean valid = true;
+
+		try (PreparedStatement preparedStatement1 =
+				sourceConnection.prepareStatement(
+					"select servletContextName, schemaVersion, verified from " +
+						" Release_");
+			ResultSet resultSet1 = preparedStatement1.executeQuery()) {
+
+			List<String> missingModules = new ArrayList<>();
+			List<String> missingServiceModules = new ArrayList<>();
+			List<String> lowerVersionModules = new ArrayList<>();
+			List<String> higherVersionModules = new ArrayList<>();
+			List<String> sourceUnverifiedModules = new ArrayList<>();
+			List<String> destinationUnverifiedModules = new ArrayList<>();
+
+			while (resultSet1.next()) {
+				String sourceServletContextName = resultSet1.getString(1);
+				Version sourceVersion = Version.parseVersion(
+					resultSet1.getString(2));
+				boolean sourceVerified = resultSet1.getBoolean(3);
+
+				try (PreparedStatement preparedStatement2 =
+						destinationConnection.prepareStatement(
+							"select servletContextName, schemaVersion, " +
+								"verified from Release_ where " +
+									"servletContextName = ?")) {
+
+					preparedStatement2.setString(1, sourceServletContextName);
+
+					try (ResultSet resultSet2 =
+							preparedStatement2.executeQuery()) {
+
+						if (!resultSet2.next()) {
+							if (sourceServletContextName.endsWith(".service")) {
+								missingServiceModules.add(
+									sourceServletContextName);
+							}
+							else {
+								missingModules.add(sourceServletContextName);
+							}
+
+							continue;
+						}
+
+						Version destinationVersion = Version.parseVersion(
+							resultSet2.getString(2));
+						boolean destinationVerified = resultSet2.getBoolean(3);
+
+						if (sourceVersion.compareTo(destinationVersion) < 0) {
+							lowerVersionModules.add(sourceServletContextName);
+						}
+						else if (sourceVersion.compareTo(destinationVersion) >
+									0) {
+
+							higherVersionModules.add(sourceServletContextName);
+						}
+
+						if (sourceVerified && !destinationVerified) {
+							destinationUnverifiedModules.add(
+								sourceServletContextName);
+						}
+						else if (!sourceVerified && destinationVerified) {
+							sourceUnverifiedModules.add(
+								sourceServletContextName);
+						}
+					}
+				}
+			}
+
+			ValidatorRecorder.registerErrors(
+				missingServiceModules,
+				" will not be available in the destination");
+			ValidatorRecorder.registerErrors(
+				lowerVersionModules,
+				" needs to be upgraded in source database before the " +
+					"migration");
+			ValidatorRecorder.registerErrors(
+				higherVersionModules,
+				" is in a lower version in destination database");
+			ValidatorRecorder.registerErrors(
+				sourceUnverifiedModules,
+				" needs to be verified in the source before the migration");
+			ValidatorRecorder.registerErrors(
+				destinationUnverifiedModules,
+				" needs to be verified in the destination before the " +
+					"migration");
+			ValidatorRecorder.registerWarnings(
+				missingModules, " will not be available in the destination");
+
+			if (!missingModules.isEmpty() || !missingServiceModules.isEmpty() ||
+				!lowerVersionModules.isEmpty() ||
+				!higherVersionModules.isEmpty() ||
+				!sourceUnverifiedModules.isEmpty() ||
+				!destinationUnverifiedModules.isEmpty()) {
+
+				valid = false;
+			}
+		}
+
+		return valid;
+	}
+
+	private static boolean _validateReleaseTableState(Connection connection)
+		throws SQLException {
+
+		boolean stateOk = true;
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select servletContextName from Release_ where state_ != 0;");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			if (resultSet.next()) {
+				stateOk = false;
+			}
+		}
+
+		return stateOk;
+	}
+
+}

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/validation/ValidatorRecorder.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/validation/ValidatorRecorder.java
@@ -53,7 +53,7 @@ public class ValidatorRecorder {
 
 	public void registerErrors(List<String> modules, String message) {
 		for (String module : modules) {
-			_errors.add("Module " + module + message);
+			_errors.add("Module " + module + " " + message);
 		}
 	}
 
@@ -63,7 +63,7 @@ public class ValidatorRecorder {
 
 	public void registerWarnings(List<String> modules, String message) {
 		for (String module : modules) {
-			_warnings.add("Module " + module + message);
+			_warnings.add("Module " + module + " " + message);
 		}
 	}
 

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/validation/ValidatorRecorder.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/validation/ValidatorRecorder.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools.db.virtual.instance.migration.internal.validation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Luis Ortiz
+ */
+public class ValidatorRecorder {
+
+	public static void printMessages() {
+		for (String error : _errors) {
+			System.out.println("ERROR: " + error);
+		}
+
+		for (String warning : _warnings) {
+			System.out.println("WARNING: " + warning);
+		}
+	}
+
+	public static void registerError(String message) {
+		_errors.add(message);
+	}
+
+	public static void registerErrors(List<String> modules, String message) {
+		for (String module : modules) {
+			_errors.add("Module " + module + message);
+		}
+	}
+
+	public static void registerWarning(String message) {
+		_warnings.add(message);
+	}
+
+	public static void registerWarnings(List<String> modules, String message) {
+		for (String module : modules) {
+			_warnings.add("Module " + module + message);
+		}
+	}
+
+	private static final ArrayList<String> _errors = new ArrayList<>();
+	private static final ArrayList<String> _warnings = new ArrayList<>();
+
+}

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/validation/ValidatorRecorder.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/main/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/validation/ValidatorRecorder.java
@@ -22,37 +22,52 @@ import java.util.List;
  */
 public class ValidatorRecorder {
 
-	public static void printMessages() {
+	public boolean hasRegisteredErrors() {
+		return !_errors.isEmpty();
+	}
+
+	public boolean hasRegisteredWarnings() {
+		return !_warnings.isEmpty();
+	}
+
+	public void printErrors() {
 		for (String error : _errors) {
 			System.out.println("ERROR: " + error);
 		}
+	}
 
+	public void printMessages() {
+		printErrors();
+		printWarnings();
+	}
+
+	public void printWarnings() {
 		for (String warning : _warnings) {
 			System.out.println("WARNING: " + warning);
 		}
 	}
 
-	public static void registerError(String message) {
+	public void registerError(String message) {
 		_errors.add(message);
 	}
 
-	public static void registerErrors(List<String> modules, String message) {
+	public void registerErrors(List<String> modules, String message) {
 		for (String module : modules) {
 			_errors.add("Module " + module + message);
 		}
 	}
 
-	public static void registerWarning(String message) {
+	public void registerWarning(String message) {
 		_warnings.add(message);
 	}
 
-	public static void registerWarnings(List<String> modules, String message) {
+	public void registerWarnings(List<String> modules, String message) {
 		for (String module : modules) {
 			_warnings.add("Module " + module + message);
 		}
 	}
 
-	private static final ArrayList<String> _errors = new ArrayList<>();
-	private static final ArrayList<String> _warnings = new ArrayList<>();
+	private final ArrayList<String> _errors = new ArrayList<>();
+	private final ArrayList<String> _warnings = new ArrayList<>();
 
 }

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/test/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/util/DatabaseTest.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/test/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/util/DatabaseTest.java
@@ -1,0 +1,576 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools.db.virtual.instance.migration.internal.util;
+
+import com.liferay.portal.tools.db.virtual.instance.migration.internal.Release;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/**
+ * @author Luis Ortiz
+ */
+public class DatabaseTest {
+
+	@Test
+	public void testGetReleaseEntries() throws SQLException {
+		Release module1Release = new Release(
+			"module1", Version.parseVersion("14.2.4"), true);
+		Release module2Release = new Release(
+			"module2", Version.parseVersion("2.0.1"), false);
+
+		Mockito.when(
+			_connection.prepareStatement(
+				"select servletContextName, schemaVersion, verified from " +
+					"Release_")
+		).thenReturn(
+			_preparedStatement
+		);
+
+		Mockito.when(
+			_preparedStatement.executeQuery()
+		).thenReturn(
+			_resultSet
+		);
+
+		Mockito.when(
+			_resultSet.next()
+		).thenReturn(
+			true
+		).thenReturn(
+			true
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			_resultSet.getString(1)
+		).thenReturn(
+			module1Release.getServletContextName()
+		).thenReturn(
+			module2Release.getServletContextName()
+		);
+
+		Version module1Version = module1Release.getSchemaVersion();
+		Version module2Version = module2Release.getSchemaVersion();
+
+		Mockito.when(
+			_resultSet.getString(2)
+		).thenReturn(
+			module1Version.toString()
+		).thenReturn(
+			module2Version.toString()
+		);
+
+		Mockito.when(
+			_resultSet.getBoolean(3)
+		).thenReturn(
+			module1Release.getVerified()
+		).thenReturn(
+			module2Release.getVerified()
+		);
+
+		List<Release> releaseEntries = Database.getReleaseEntries(_connection);
+
+		Assert.assertTrue(releaseEntries.size() == 2);
+
+		Release module1Entry = releaseEntries.get(0);
+
+		Assert.assertTrue(module1Entry.equals(module1Release));
+
+		Release module2Entry = releaseEntries.get(1);
+
+		Assert.assertTrue(module2Entry.equals(module2Release));
+	}
+
+	@Test
+	public void testGetReleaseEntryFound() throws SQLException {
+		Release testRelease = new Release(
+			"module", Version.parseVersion("14.2.4"), true);
+
+		_mockGetReleaseEntry(testRelease, true);
+
+		Release release = Database.getReleaseEntry(_connection, "module");
+
+		Assert.assertNotNull(release);
+
+		Assert.assertTrue(release.equals(testRelease));
+
+		ArgumentCaptor<String> valueCapture = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_preparedStatement
+		).setString(
+			Mockito.eq(1), valueCapture.capture()
+		);
+
+		Assert.assertEquals("module", valueCapture.getValue());
+	}
+
+	@Test
+	public void testGetReleaseEntryNotFound() throws SQLException {
+		Release testRelease = new Release(
+			"module", Version.parseVersion("14.2.4"), true);
+
+		_mockGetReleaseEntry(testRelease, false);
+
+		Release release = Database.getReleaseEntry(_connection, "module");
+
+		Assert.assertNull(release);
+
+		ArgumentCaptor<String> valueCapture = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_preparedStatement
+		).setString(
+			Mockito.eq(1), valueCapture.capture()
+		);
+
+		Assert.assertEquals("module", valueCapture.getValue());
+	}
+
+	@Test
+	public void testGetTables() throws SQLException {
+		Mockito.when(
+			_connection.getMetaData()
+		).thenReturn(
+			_databaseMetaData
+		);
+
+		Mockito.when(
+			_databaseMetaData.getTables(
+				Mockito.nullable(String.class), Mockito.nullable(String.class),
+				Mockito.nullable(String.class), Mockito.any(String[].class))
+		).thenReturn(
+			_resultSet
+		);
+
+		Mockito.when(
+			_resultSet.next()
+		).thenReturn(
+			true
+		).thenReturn(
+			true
+		).thenReturn(
+			true
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			_resultSet.getString("TABLE_NAME")
+		).thenReturn(
+			"Table1"
+		).thenReturn(
+			"Company"
+		).thenReturn(
+			"Table2"
+		).thenReturn(
+			"Object_x_25000"
+		);
+
+		PreparedStatement preparedStatement1 = Mockito.mock(
+			PreparedStatement.class);
+
+		ResultSet resultSet1 = Mockito.mock(ResultSet.class);
+
+		Mockito.when(
+			_connection.prepareStatement("select companyId from CompanyInfo")
+		).thenReturn(
+			preparedStatement1
+		);
+
+		Mockito.when(
+			preparedStatement1.executeQuery()
+		).thenReturn(
+			resultSet1
+		);
+
+		Mockito.when(
+			resultSet1.next()
+		).thenReturn(
+			false
+		);
+
+		PreparedStatement preparedStatement2 = Mockito.mock(
+			PreparedStatement.class);
+
+		ResultSet resultSet2 = Mockito.mock(ResultSet.class);
+
+		Mockito.when(
+			_connection.prepareStatement("select companyId from Company")
+		).thenReturn(
+			preparedStatement2
+		);
+
+		Mockito.when(
+			preparedStatement2.executeQuery()
+		).thenReturn(
+			resultSet2
+		);
+
+		Mockito.when(
+			resultSet2.next()
+		).thenReturn(
+			true
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			resultSet2.getLong("companyId")
+		).thenReturn(
+			25000L
+		);
+
+		ResultSet resultSet3 = Mockito.mock(ResultSet.class);
+
+		Mockito.when(
+			_databaseMetaData.getColumns(
+				Mockito.nullable(String.class), Mockito.nullable(String.class),
+				Mockito.nullable(String.class), Mockito.nullable(String.class))
+		).thenReturn(
+			resultSet3
+		);
+
+		Mockito.when(
+			resultSet3.next()
+		).thenReturn(
+			true
+		);
+
+		List<String> tables = Database.getTables(_connection);
+
+		Assert.assertTrue(tables.size() == 2);
+
+		Assert.assertTrue(tables.contains("Table1"));
+		Assert.assertTrue(tables.contains("Table2"));
+		Assert.assertFalse(tables.contains("Company"));
+		Assert.assertFalse(tables.contains("Object_x_25000"));
+	}
+
+	@Test
+	public void testHasNotWebId() throws SQLException {
+		_mockWebId(false);
+
+		Assert.assertFalse(Database.hasWebId(_connection, "portlet2"));
+
+		ArgumentCaptor<String> valueCapture = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_preparedStatement
+		).setString(
+			Mockito.eq(1), valueCapture.capture()
+		);
+		Assert.assertEquals("portlet2", valueCapture.getValue());
+	}
+
+	@Test
+	public void testHasWebId() throws SQLException {
+		_mockWebId(true);
+
+		Assert.assertTrue(Database.hasWebId(_connection, "portlet1"));
+
+		ArgumentCaptor<String> valueCapture = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_preparedStatement
+		).setString(
+			Mockito.eq(1), valueCapture.capture()
+		);
+		Assert.assertEquals("portlet1", valueCapture.getValue());
+	}
+
+	@Test
+	public void testInvalidStateServlets() throws SQLException {
+		_mockServletState(false);
+
+		List<String> releaseEntries = Database.getInvalidStateServlets(
+			_connection);
+
+		Assert.assertTrue(releaseEntries.size() == 2);
+
+		Assert.assertTrue(releaseEntries.contains("module1"));
+		Assert.assertTrue(releaseEntries.contains("module2"));
+	}
+
+	@Test
+	public void testIsDefaultPartition() throws SQLException {
+		_mockDefaultPartition(true);
+
+		Assert.assertTrue(Database.isDefaultPartition(_connection));
+
+		ArgumentCaptor<String> valueCapture = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_databaseMetaData, Mockito.times(2)
+		).getTables(
+			Mockito.nullable(String.class), Mockito.nullable(String.class),
+			valueCapture.capture(), Mockito.any(String[].class)
+		);
+
+		List<String> capturedValues = valueCapture.getAllValues();
+
+		Assert.assertTrue(capturedValues.size() == 2);
+		Assert.assertTrue(capturedValues.contains("company"));
+		Assert.assertTrue(capturedValues.contains("virtualhost"));
+	}
+
+	@Test
+	public void testIsNotDefaultPartition() throws SQLException {
+		_mockDefaultPartition(false);
+
+		Assert.assertFalse(Database.isDefaultPartition(_connection));
+
+		ArgumentCaptor<String> valueCapture = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_databaseMetaData, Mockito.times(1)
+		).getTables(
+			Mockito.nullable(String.class), Mockito.nullable(String.class),
+			valueCapture.capture(), Mockito.any(String[].class)
+		);
+
+		List<String> capturedValues = valueCapture.getAllValues();
+
+		Assert.assertTrue(capturedValues.size() == 1);
+		Assert.assertTrue(capturedValues.contains("company"));
+	}
+
+	@Test
+	public void testIsNotSingleVirtualInstance() throws SQLException {
+		_mockSingleVirtualInstance(false);
+
+		Assert.assertFalse(Database.isSingleVirtualInstance(_connection));
+	}
+
+	@Test
+	public void testIsSingleVirtualInstance() throws SQLException {
+		_mockSingleVirtualInstance(true);
+
+		Assert.assertTrue(Database.isSingleVirtualInstance(_connection));
+	}
+
+	@Test
+	public void testNoInvalidStateServlets() throws SQLException {
+		_mockServletState(true);
+
+		List<String> releaseEntries = Database.getInvalidStateServlets(
+			_connection);
+
+		Assert.assertTrue(releaseEntries.isEmpty());
+	}
+
+	private void _mockDefaultPartition(boolean defaultPartition)
+		throws SQLException {
+
+		Mockito.when(
+			_connection.getMetaData()
+		).thenReturn(
+			_databaseMetaData
+		);
+
+		Mockito.when(
+			_databaseMetaData.getTables(
+				Mockito.nullable(String.class), Mockito.nullable(String.class),
+				Mockito.anyString(), Mockito.eq(new String[] {"TABLE"}))
+		).thenReturn(
+			_resultSet
+		);
+
+		Mockito.when(
+			_databaseMetaData.storesLowerCaseIdentifiers()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_resultSet.next()
+		).thenReturn(
+			defaultPartition
+		);
+	}
+
+	private void _mockGetReleaseEntry(Release release, boolean found)
+		throws SQLException {
+
+		Mockito.when(
+			_connection.prepareStatement(
+				"select servletContextName, schemaVersion, verified from " +
+					"Release_ where servletContextName = ?")
+		).thenReturn(
+			_preparedStatement
+		);
+
+		Mockito.when(
+			_preparedStatement.executeQuery()
+		).thenReturn(
+			_resultSet
+		);
+
+		if (found) {
+			Mockito.when(
+				_resultSet.next()
+			).thenReturn(
+				true
+			).thenReturn(
+				false
+			);
+
+			Mockito.when(
+				_resultSet.getString(1)
+			).thenReturn(
+				release.getServletContextName()
+			);
+
+			Version releaseVersion = release.getSchemaVersion();
+
+			Mockito.when(
+				_resultSet.getString(2)
+			).thenReturn(
+				releaseVersion.toString()
+			);
+
+			Mockito.when(
+				_resultSet.getBoolean(3)
+			).thenReturn(
+				release.getVerified()
+			);
+		}
+		else {
+			Mockito.when(
+				_resultSet.next()
+			).thenReturn(
+				false
+			);
+		}
+	}
+
+	private void _mockServletState(boolean servletsOK) throws SQLException {
+		Mockito.when(
+			_connection.prepareStatement(
+				"select servletContextName from Release_ where state_ != 0;")
+		).thenReturn(
+			_preparedStatement
+		);
+
+		Mockito.when(
+			_preparedStatement.executeQuery()
+		).thenReturn(
+			_resultSet
+		);
+
+		if (servletsOK) {
+			Mockito.when(
+				_resultSet.next()
+			).thenReturn(
+				false
+			);
+		}
+		else {
+			Mockito.when(
+				_resultSet.next()
+			).thenReturn(
+				true
+			).thenReturn(
+				true
+			).thenReturn(
+				false
+			);
+
+			Mockito.when(
+				_resultSet.getString(1)
+			).thenReturn(
+				"module1"
+			).thenReturn(
+				"module2"
+			);
+		}
+	}
+
+	private void _mockSingleVirtualInstance(boolean singleVirtualInstance)
+		throws SQLException {
+
+		Mockito.when(
+			_connection.prepareStatement("select count(1) from CompanyInfo")
+		).thenReturn(
+			_preparedStatement
+		);
+
+		Mockito.when(
+			_preparedStatement.executeQuery()
+		).thenReturn(
+			_resultSet
+		);
+
+		Mockito.when(
+			_resultSet.getInt(1)
+		).thenReturn(
+			singleVirtualInstance ? 1 : 4
+		);
+
+		Mockito.when(
+			_resultSet.next()
+		).thenReturn(
+			true
+		);
+	}
+
+	private void _mockWebId(boolean hasWebId) throws SQLException {
+		Mockito.when(
+			_connection.prepareStatement(
+				"select companyId from Company where webId = ?")
+		).thenReturn(
+			_preparedStatement
+		);
+
+		Mockito.when(
+			_preparedStatement.executeQuery()
+		).thenReturn(
+			_resultSet
+		);
+
+		Mockito.when(
+			_resultSet.next()
+		).thenReturn(
+			hasWebId
+		);
+	}
+
+	private final Connection _connection = Mockito.mock(Connection.class);
+	private final DatabaseMetaData _databaseMetaData = Mockito.mock(
+		DatabaseMetaData.class);
+	private final PreparedStatement _preparedStatement = Mockito.mock(
+		PreparedStatement.class);
+	private final ResultSet _resultSet = Mockito.mock(ResultSet.class);
+
+}

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/test/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/util/VersionTest.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/test/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/util/VersionTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools.db.virtual.instance.migration.internal.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Luis Ortiz
+ */
+public class VersionTest {
+
+	@Test
+	public void testCompareEqualFinalVersions() {
+		Version version1 = Version.parseVersion("1.2.3");
+		Version version2 = Version.parseVersion("1.2.3");
+
+		Assert.assertTrue(version1.compareTo(version2) == 0);
+	}
+
+	@Test
+	public void testCompareEqualStepVersions() {
+		Version version1 = Version.parseVersion("1.2.3.step-3");
+		Version version2 = Version.parseVersion("1.2.3.step-3");
+
+		Assert.assertTrue(version1.compareTo(version2) == 0);
+	}
+
+	@Test
+	public void testCompareFinalToStepVersion() {
+		Version version1 = Version.parseVersion("1.2.3");
+		Version version2 = Version.parseVersion("1.2.3.step-2");
+
+		Assert.assertTrue(version1.compareTo(version2) > 0);
+	}
+
+	@Test
+	public void testCompareSteps() {
+		Version version1 = Version.parseVersion("1.2.3.step-1");
+		Version version2 = Version.parseVersion("1.2.3.step-2");
+
+		Assert.assertTrue(version1.compareTo(version2) < 0);
+	}
+
+	@Test
+	public void testCompareStepToFinalVersion() {
+		Version version1 = Version.parseVersion("1.2.3.step-2");
+		Version version2 = Version.parseVersion("1.2.3");
+
+		Assert.assertTrue(version1.compareTo(version2) < 0);
+	}
+
+	@Test
+	public void testEqualFinalVersions() {
+		Version version1 = Version.parseVersion("1.2.3");
+		Version version2 = Version.parseVersion("1.2.3");
+
+		Assert.assertTrue(version1.equals(version2));
+	}
+
+	@Test
+	public void testEqualStepVersions() {
+		Version version1 = Version.parseVersion("1.2.3.step-1");
+		Version version2 = Version.parseVersion("1.2.3.step-1");
+
+		Assert.assertTrue(version1.equals(version2));
+	}
+
+	@Test
+	public void testNotEqualVersions() {
+		Version version1 = Version.parseVersion("1.2.3");
+		Version version2 = Version.parseVersion("1.2.3.step-4");
+
+		Assert.assertTrue(!version1.equals(version2));
+	}
+
+	@Test
+	public void testParseEmptyVersion() {
+		Version version = Version.parseVersion("");
+
+		Assert.assertEquals(0, version.getMajor());
+		Assert.assertEquals(0, version.getMinor());
+		Assert.assertEquals(0, version.getMicro());
+		Assert.assertEquals("", version.getQualifier());
+	}
+
+	@Test
+	public void testParseNullVersion() {
+		Version version = Version.parseVersion(null);
+
+		Assert.assertEquals(0, version.getMajor());
+		Assert.assertEquals(0, version.getMinor());
+		Assert.assertEquals(0, version.getMicro());
+		Assert.assertEquals("", version.getQualifier());
+	}
+
+	@Test
+	public void testParseStepVersion() {
+		Version version = Version.parseVersion("1.2.3.step-4");
+
+		Assert.assertEquals(1, version.getMajor());
+		Assert.assertEquals(2, version.getMinor());
+		Assert.assertEquals(3, version.getMicro());
+		Assert.assertEquals("step-4", version.getQualifier());
+	}
+
+	@Test
+	public void testParseVersion() {
+		Version version = Version.parseVersion("1.2.3");
+
+		Assert.assertEquals(1, version.getMajor());
+		Assert.assertEquals(2, version.getMinor());
+		Assert.assertEquals(3, version.getMicro());
+		Assert.assertEquals("", version.getQualifier());
+	}
+
+	@Test
+	public void testParseWrongFormatVersion() {
+		Version version = Version.parseVersion("V1.4.3");
+
+		Assert.assertEquals(0, version.getMajor());
+		Assert.assertEquals(0, version.getMinor());
+		Assert.assertEquals(0, version.getMicro());
+		Assert.assertEquals("", version.getQualifier());
+	}
+
+	@Test
+	public void testToStringFinalVersion() {
+		Version version = Version.parseVersion("1.2.3");
+
+		Assert.assertEquals("1.2.3", version.toString());
+	}
+
+	@Test
+	public void testToStringStepVersion() {
+		Version version = Version.parseVersion("1.2.3.step-4");
+
+		Assert.assertEquals("1.2.3.step-4", version.toString());
+	}
+
+}

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/test/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/validation/ValidatorRecorderTest.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/test/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/validation/ValidatorRecorderTest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools.db.virtual.instance.migration.internal.validation;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Luis Ortiz
+ */
+public class ValidatorRecorderTest {
+
+	@Before
+	public void setUp() {
+		System.setOut(new PrintStream(_testOutByteArrayOutputStream));
+	}
+
+	@After
+	public void tearDown() {
+		System.setOut(_originalOut);
+	}
+
+	@Test
+	public void testError() {
+		ValidatorRecorder recorder = new ValidatorRecorder();
+
+		recorder.registerError("A simple message");
+
+		recorder.printMessages();
+
+		Assert.assertFalse(recorder.hasRegisteredWarnings());
+		Assert.assertTrue(recorder.hasRegisteredErrors());
+
+		Assert.assertEquals(
+			"ERROR: A simple message\n",
+			_testOutByteArrayOutputStream.toString());
+	}
+
+	@Test
+	public void testMultipleError() {
+		ValidatorRecorder recorder = new ValidatorRecorder();
+
+		List<String> modules = Arrays.asList("module1", "module2", "module3");
+
+		recorder.registerErrors(modules, "simple message");
+
+		recorder.printMessages();
+
+		Assert.assertFalse(recorder.hasRegisteredWarnings());
+		Assert.assertTrue(recorder.hasRegisteredErrors());
+
+		String outputString = _testOutByteArrayOutputStream.toString();
+
+		for (String module : modules) {
+			Assert.assertTrue(
+				outputString.contains(
+					"ERROR: Module " + module + " simple message"));
+		}
+	}
+
+	@Test
+	public void testMultipleWarning() {
+		ValidatorRecorder recorder = new ValidatorRecorder();
+
+		List<String> modules = Arrays.asList("module1", "module2", "module3");
+
+		recorder.registerWarnings(modules, "simple message");
+
+		recorder.printMessages();
+
+		Assert.assertTrue(recorder.hasRegisteredWarnings());
+		Assert.assertFalse(recorder.hasRegisteredErrors());
+
+		String outputString = _testOutByteArrayOutputStream.toString();
+
+		for (String module : modules) {
+			Assert.assertTrue(
+				outputString.contains(
+					"WARNING: Module " + module + " simple message"));
+		}
+	}
+
+	@Test
+	public void testPrintingOrder() {
+		ValidatorRecorder recorder = new ValidatorRecorder();
+
+		recorder.registerWarning("A simple warning message");
+		recorder.registerError("A simple error message");
+		recorder.printMessages();
+
+		Assert.assertTrue(recorder.hasRegisteredWarnings());
+		Assert.assertTrue(recorder.hasRegisteredErrors());
+
+		String outputString = _testOutByteArrayOutputStream.toString();
+
+		Assert.assertTrue(
+			outputString.contains("WARNING: A simple warning message"));
+		Assert.assertTrue(
+			outputString.contains("ERROR: A simple error message"));
+
+		Assert.assertTrue(
+			outputString.indexOf("ERROR:") < outputString.indexOf("WARNING:"));
+	}
+
+	@Test
+	public void testWarning() {
+		ValidatorRecorder recorder = new ValidatorRecorder();
+
+		recorder.registerWarning("A simple message");
+		recorder.printMessages();
+
+		Assert.assertTrue(recorder.hasRegisteredWarnings());
+		Assert.assertFalse(recorder.hasRegisteredErrors());
+
+		Assert.assertEquals(
+			"WARNING: A simple message\n",
+			_testOutByteArrayOutputStream.toString());
+	}
+
+	private final PrintStream _originalOut = System.out;
+	private final ByteArrayOutputStream _testOutByteArrayOutputStream =
+		new ByteArrayOutputStream();
+
+}

--- a/modules/util/portal-tools-db-virtual-instance-migration/src/test/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/validation/ValidatorTest.java
+++ b/modules/util/portal-tools-db-virtual-instance-migration/src/test/java/com/liferay/portal/tools/db/virtual/instance/migration/internal/validation/ValidatorTest.java
@@ -1,0 +1,380 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools.db.virtual.instance.migration.internal.validation;
+
+import com.liferay.portal.tools.db.virtual.instance.migration.internal.Release;
+import com.liferay.portal.tools.db.virtual.instance.migration.internal.util.Database;
+import com.liferay.portal.tools.db.virtual.instance.migration.internal.util.Version;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Luis Ortiz
+ */
+public class ValidatorTest {
+
+	@Before
+	public void setUp() {
+		System.setOut(new PrintStream(_testOutByteArrayOutputStream));
+		_databaseMockedStatic = Mockito.mockStatic(Database.class);
+
+		_sourceConnection = Mockito.mock(Connection.class);
+		_destinationConnection = Mockito.mock(Connection.class);
+	}
+
+	@After
+	public void tearDown() {
+		System.setOut(_originalOut);
+		_databaseMockedStatic.close();
+	}
+
+	@Test
+	public void testCheckWebIdNotValid() throws SQLException {
+		_mockWebIds(false);
+
+		_executeAndAssert(
+			false, true,
+			Arrays.asList(
+				"WARNING: webId " + _TEST_WEB_ID +
+					" already exists in destination database"));
+	}
+
+	@Test
+	public void testCheckWebIdValid() throws SQLException {
+		_mockWebIds(true);
+
+		_executeAndAssert(false, false, null);
+	}
+
+	@Test
+	public void testHigherVersionModule() throws SQLException {
+		_mockModuleVersion("module.2.service", "1.0.0");
+
+		_executeAndAssert(
+			true, false,
+			Arrays.asList(
+				"ERROR: Module module.2.service is in a lower version in " +
+					"destination database"));
+	}
+
+	@Test
+	public void testInvalidDestinationReleaseEntries() throws SQLException {
+		_mockInvalidReleaseEntries(
+			new ArrayList<>(), Arrays.asList("module1", "module2"));
+
+		_executeAndAssert(
+			true, false,
+			Arrays.asList(
+				"ERROR: Destination database Release_ table has records with " +
+					"an invalid state_"));
+	}
+
+	@Test
+	public void testInvalidSourceReleaseEntries() throws SQLException {
+		_mockInvalidReleaseEntries(
+			Arrays.asList("module1", "module2"), new ArrayList<>());
+
+		_executeAndAssert(
+			true, false,
+			Arrays.asList(
+				"ERROR: Source database Release_ table has records with an " +
+					"invalid state_"));
+	}
+
+	@Test
+	public void testLowerVersionModule() throws SQLException {
+		_mockModuleVersion("module.1", "10.0.0");
+
+		_executeAndAssert(
+			true, false,
+			Arrays.asList(
+				"ERROR: Module module.1 needs to be upgraded in source " +
+					"database before the migration"));
+	}
+
+	@Test
+	public void testMissingNotServiceModule() throws SQLException {
+		_mockMissingModules("module.1");
+
+		_executeAndAssert(
+			false, true,
+			Arrays.asList(
+				"WARNING: Module module.1 will not be available in the " +
+					"destination"));
+	}
+
+	@Test
+	public void testMissingServiceModule() throws SQLException {
+		_mockMissingModules("module.2.service");
+
+		_executeAndAssert(
+			true, false,
+			Arrays.asList(
+				"ERROR: Module module.2.service will not be available in the " +
+					"destination"));
+	}
+
+	@Test
+	public void testMissingTablesInBothDatabases() throws SQLException {
+		_mockMissingTables(
+			new ArrayList<>(
+				Arrays.asList("table1", "table2", "table3", "table5")),
+			new ArrayList<>(
+				Arrays.asList("table1", "table3", "table4", "table5")));
+
+		_executeAndAssert(
+			false, true,
+			Arrays.asList(
+				"WARNING: Table table4 is not present in source database",
+				"WARNING: Table table2 is not present in destination " +
+					"database"));
+	}
+
+	@Test
+	public void testMissingTablesInDestination() throws SQLException {
+		_mockMissingTables(
+			new ArrayList<>(
+				Arrays.asList(
+					"table1", "table2", "table3", "table4", "table5")),
+			new ArrayList<>(Arrays.asList("table1", "table3", "table4")));
+
+		_executeAndAssert(
+			false, true,
+			Arrays.asList(
+				"WARNING: Table table2 is not present in destination database",
+				"WARNING: Table table5 is not present in destination " +
+					"database"));
+	}
+
+	@Test
+	public void testMissingTablesInSource() throws SQLException {
+		_mockMissingTables(
+			new ArrayList<>(Arrays.asList("table1", "table3", "table4")),
+			new ArrayList<>(
+				Arrays.asList(
+					"table1", "table2", "table3", "table4", "table5")));
+
+		_executeAndAssert(
+			false, true,
+			Arrays.asList(
+				"WARNING: Table table2 is not present in source database",
+				"WARNING: Table table5 is not present in source database"));
+	}
+
+	@Test
+	public void testUnverifiedDestinationModule() throws SQLException {
+		_mockupUnverifiedModule("module.2", false);
+
+		_executeAndAssert(
+			true, false,
+			Arrays.asList(
+				"ERROR: Module module.2 needs to be verified in the " +
+					"destination before the migration"));
+	}
+
+	@Test
+	public void testUnverifiedSourceModule() throws SQLException {
+		_mockupUnverifiedModule("module.2.service", true);
+
+		_executeAndAssert(
+			true, false,
+			Arrays.asList(
+				"ERROR: Module module.2.service needs to be verified in the " +
+					"source before the migration"));
+	}
+
+	private List<Release> _createReleaseElements() {
+		return Arrays.asList(
+			new Release(
+				"module.1.service", Version.parseVersion("3.5.1"), true),
+			new Release(
+				"module.2.service", Version.parseVersion("5.0.0"), false),
+			new Release("module.1", Version.parseVersion("2.3.2"), true),
+			new Release("module.2", Version.parseVersion("5.1.0"), true));
+	}
+
+	private void _executeAndAssert(
+			boolean hasErrors, boolean hasWarnings, List<String> messages)
+		throws SQLException {
+
+		ValidatorRecorder recorder = Validator.validateDatabases(
+			_sourceConnection, _destinationConnection);
+
+		Assert.assertEquals(hasErrors, recorder.hasRegisteredErrors());
+		Assert.assertEquals(hasWarnings, recorder.hasRegisteredWarnings());
+
+		recorder.printMessages();
+
+		String output = _testOutByteArrayOutputStream.toString();
+
+		if (messages == null) {
+			Assert.assertTrue(output.isEmpty());
+		}
+		else {
+			for (String message : messages) {
+				Assert.assertTrue(output.contains(message));
+			}
+		}
+	}
+
+	private void _mockInvalidReleaseEntries(
+		List<String> sourceInvalidServlets,
+		List<String> destinationInvalidServlets) {
+
+		_databaseMockedStatic.when(
+			() -> Database.getInvalidStateServlets(_sourceConnection)
+		).thenReturn(
+			sourceInvalidServlets
+		);
+
+		_databaseMockedStatic.when(
+			() -> Database.getInvalidStateServlets(_destinationConnection)
+		).thenReturn(
+			destinationInvalidServlets
+		);
+	}
+
+	private void _mockMissingModules(String module) {
+		List<Release> releases = _createReleaseElements();
+
+		_databaseMockedStatic.when(
+			() -> Database.getReleaseEntries(_sourceConnection)
+		).thenReturn(
+			releases
+		);
+
+		for (Release release : releases) {
+			String servletContextName = release.getServletContextName();
+
+			if (!servletContextName.equals(module)) {
+				_databaseMockedStatic.when(
+					() -> Database.getReleaseEntry(
+						_destinationConnection, servletContextName)
+				).thenReturn(
+					release
+				);
+			}
+		}
+	}
+
+	private void _mockMissingTables(
+		List<String> sourceTables, List<String> destinationTables) {
+
+		_databaseMockedStatic.when(
+			() -> Database.getTables(_sourceConnection)
+		).thenReturn(
+			sourceTables
+		);
+
+		_databaseMockedStatic.when(
+			() -> Database.getTables(_destinationConnection)
+		).thenReturn(
+			destinationTables
+		);
+	}
+
+	private void _mockModuleVersion(String module, String version) {
+		List<Release> releases = _createReleaseElements();
+
+		_databaseMockedStatic.when(
+			() -> Database.getReleaseEntries(_sourceConnection)
+		).thenReturn(
+			releases
+		);
+
+		for (Release release : releases) {
+			String servletContextName = release.getServletContextName();
+
+			if (servletContextName.equals(module)) {
+				release = new Release(
+					servletContextName, Version.parseVersion(version),
+					release.getVerified());
+			}
+
+			_databaseMockedStatic.when(
+				() -> Database.getReleaseEntry(
+					_destinationConnection, servletContextName)
+			).thenReturn(
+				release
+			);
+		}
+	}
+
+	private void _mockupUnverifiedModule(String module, boolean verified) {
+		List<Release> releases = _createReleaseElements();
+
+		_databaseMockedStatic.when(
+			() -> Database.getReleaseEntries(_sourceConnection)
+		).thenReturn(
+			releases
+		);
+
+		for (Release release : releases) {
+			String servletContextName = release.getServletContextName();
+
+			if (servletContextName.equals(module)) {
+				release = new Release(
+					servletContextName, release.getSchemaVersion(), verified);
+			}
+
+			_databaseMockedStatic.when(
+				() -> Database.getReleaseEntry(
+					_destinationConnection, servletContextName)
+			).thenReturn(
+				release
+			);
+		}
+	}
+
+	private void _mockWebIds(boolean valid) {
+		_databaseMockedStatic.when(
+			() -> Database.getWebId(_sourceConnection)
+		).thenReturn(
+			_TEST_WEB_ID
+		);
+
+		_databaseMockedStatic.when(
+			() -> Database.hasWebId(_destinationConnection, _TEST_WEB_ID)
+		).thenReturn(
+			!valid
+		);
+	}
+
+	private static final String _TEST_WEB_ID = "www.able.com";
+
+	private MockedStatic<Database> _databaseMockedStatic;
+	private Connection _destinationConnection;
+	private final PrintStream _originalOut = System.out;
+	private Connection _sourceConnection;
+	private final ByteArrayOutputStream _testOutByteArrayOutputStream =
+		new ByteArrayOutputStream();
+
+}


### PR DESCRIPTION
- LPS-180450 New module for virtual instances migration tool
- LPS-180450 Adding tool input parameters and checking that connections are reachable
- LPS-180450 Improving tool exit and checking that destination database is the default one
- LPS-180450 Adding validations over the Release_ table
- LPS-180450 Adding checks over the tables in source and destination databases
- LPS-180450 Added check to avoid repeated webIds on destination table
- LPS-180450 Adding check to verify that source database does not have multiple virtual instances
- LPS-180450 Better organization of the code
- LPS-180450 No need to store value
- LPS-180450 Optimization for not going to the database so many times
- LPS-180450 All database logic in the same place
- LPS-180450 Updating README
- LPS-180450 No need to return a boolean. We can know if everything went well or not based on the error and warning messages registered
- LPS-180450 It is better to manage the space from the class than rely on users
- LPS-180450 Adding unit tests for ValidatorRecorder class
- LPS-180450 Adding implementations for equals and hashCode for the Release class
- LPS-180450 Adding unit tests for Database class
- LPS-180450 Adding tests for Validator class
- LPS-180450 Adding tests to Version class
