### PR TITLE
[TS]LPS-182175

### DIFF
--- a/modules/apps/portal/portal-db-partition-test-util/bnd.bnd
+++ b/modules/apps/portal/portal-db-partition-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Portal DB Partition Test Utilities
 Bundle-SymbolicName: com.liferay.portal.db.partition.test.util
-Bundle-Version: 1.0.4
+Bundle-Version: 1.1.0
 Export-Package: com.liferay.portal.db.partition.test.util

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
@@ -49,6 +49,7 @@ import java.sql.Statement;
 
 import javax.sql.DataSource;
 
+import com.liferay.portal.util.PropsUtil;
 import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -287,6 +288,10 @@ public abstract class BaseDBPartitionTestCase {
 			ReflectionTestUtil.setFieldValue(
 				CurrentConnectionUtil.class, "_currentConnection",
 				defaultCurrentConnection);
+
+			ReflectionTestUtil.setFieldValue(
+				DBPartitionUtil.class, "_DATABASE_PARTITION_MIGRATE_ENABLED",
+				_DEFAULT_MIGRATE_SETTING);
 		}
 	}
 
@@ -312,6 +317,10 @@ public abstract class BaseDBPartitionTestCase {
 			ReflectionTestUtil.setFieldValue(
 				CurrentConnectionUtil.class, "_currentConnection",
 				defaultCurrentConnection);
+
+			ReflectionTestUtil.setFieldValue(
+				DBPartitionUtil.class, "_DATABASE_PARTITION_MIGRATE_ENABLED",
+				_DEFAULT_MIGRATE_SETTING);
 		}
 	}
 
@@ -398,6 +407,10 @@ public abstract class BaseDBPartitionTestCase {
 		ReflectionTestUtil.getFieldValue(DBInitUtil.class, "_dataSource");
 	private static boolean _dbPartitionEnabled;
 	private static LazyConnectionDataSourceProxy _lazyConnectionDataSourceProxy;
+
+	private static final boolean _DEFAULT_MIGRATE_SETTING =
+		GetterUtil.getBoolean(
+			PropsUtil.get("database.partition.migrate.enabled"));
 
 	@Inject
 	private static Props _props;

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
@@ -264,6 +264,32 @@ public abstract class BaseDBPartitionTestCase {
 		}
 	}
 
+	protected static void removeDBPartition(long companyId, boolean migrate)
+		throws Exception {
+
+		CurrentConnection defaultCurrentConnection =
+			CurrentConnectionUtil.getCurrentConnection();
+
+		try {
+			CurrentConnection currentConnection = dataSource -> connection;
+
+			ReflectionTestUtil.setFieldValue(
+				DBPartitionUtil.class, "_DATABASE_PARTITION_MIGRATE_ENABLED",
+				migrate);
+
+			ReflectionTestUtil.setFieldValue(
+				CurrentConnectionUtil.class, "_currentConnection",
+				currentConnection);
+
+			DBPartitionUtil.removeDBPartition(companyId);
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				CurrentConnectionUtil.class, "_currentConnection",
+				defaultCurrentConnection);
+		}
+	}
+
 	protected static void removeDBPartitions(boolean migrate) throws Exception {
 		CurrentConnection defaultCurrentConnection =
 			CurrentConnectionUtil.getCurrentConnection();

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PortalInstances;
+import com.liferay.portal.util.PropsUtil;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -49,7 +50,6 @@ import java.sql.Statement;
 
 import javax.sql.DataSource;
 
-import com.liferay.portal.util.PropsUtil;
 import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -403,14 +403,14 @@ public abstract class BaseDBPartitionTestCase {
 	private static final String _DB_PARTITION_SCHEMA_NAME_PREFIX =
 		"lpartitiontest_";
 
+	private static final boolean _DEFAULT_MIGRATE_SETTING =
+		GetterUtil.getBoolean(
+			PropsUtil.get("database.partition.migrate.enabled"));
+
 	private static final DataSource _currentDataSource =
 		ReflectionTestUtil.getFieldValue(DBInitUtil.class, "_dataSource");
 	private static boolean _dbPartitionEnabled;
 	private static LazyConnectionDataSourceProxy _lazyConnectionDataSourceProxy;
-
-	private static final boolean _DEFAULT_MIGRATE_SETTING =
-		GetterUtil.getBoolean(
-			PropsUtil.get("database.partition.migrate.enabled"));
 
 	@Inject
 	private static Props _props;

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -171,15 +171,19 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 						"select schema_name from information_schema.schemata;");
 				ResultSet resultSet = preparedStatement.executeQuery()) {
 
+				String partition = null;
+
 				while (resultSet.next()) {
-					String partition = resultSet.getString(1);
+					partition = resultSet.getString(1);
 
 					if (partition.equals(orphanedPartition)) {
 						removeDBPartition(companyId, false);
 
-						Assert.fail();
+						break;
 					}
 				}
+
+				Assert.assertNotEquals(partition, orphanedPartition);
 			}
 		}
 	}

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -167,7 +167,8 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 		catch (Exception exception) {
 			try (Connection connection = DataAccess.getConnection();
 				PreparedStatement preparedStatement =
-					connection.prepareStatement("SHOW SCHEMAS;");
+					connection.prepareStatement(
+						"select schema_name from information_schema.schemata;");
 				ResultSet resultSet = preparedStatement.executeQuery()) {
 
 				while (resultSet.next()) {

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -288,7 +288,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		catch (Exception exception) {
 			safeCloseable.close();
 
-			if(newDBPartitionAdded){
+			if (newDBPartitionAdded) {
 				DBPartitionUtil.removeDBPartition(companyId);
 			}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -288,6 +288,10 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		catch (Exception exception) {
 			safeCloseable.close();
 
+			if(newDBPartitionAdded){
+				DBPartitionUtil.removeDBPartition(companyId);
+			}
+
 			throw exception;
 		}
 	}


### PR DESCRIPTION
@achaparro 
LMK if you want me to make any changes. 

Ticket:
[LPS-182175](https://issues.liferay.com/browse/LPS-182175)


If the addCompany method fails, then a partition that is created prior the creation of the company remains present in the database.  Removing it throw the catch resolves the issue.  

