### PR TITLE
LPS-182452 Fix `DB.copyTableStructure()` for Hypersonic

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -395,6 +395,10 @@ public class DBTest {
 			indexNamePrefix = "TMP_";
 		}
 
+		Assert.assertArrayEquals(
+			new String[] {_dbInspector.normalizeName("id")},
+			_db.getPrimaryKeyColumnNames(_connection, _TABLE_NAME_2));
+
 		Assert.assertTrue(
 			_dbInspector.hasIndex(
 				_TABLE_NAME_2, indexNamePrefix + _INDEX_NAME));

--- a/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
@@ -79,6 +79,10 @@ public class HypersonicDB extends BaseDB {
 		return _HYPERSONIC;
 	}
 
+	protected boolean isSupportsDuplicatedIndexName() {
+		return _SUPPORTS_DUPLICATED_INDEX_NAME;
+	}
+
 	@Override
 	protected String reword(String data) throws IOException {
 		try (UnsyncBufferedReader unsyncBufferedReader =
@@ -150,5 +154,7 @@ public class HypersonicDB extends BaseDB {
 	private static final int[] _SQL_VARCHAR_SIZES = {
 		SQL_VARCHAR_MAX_SIZE, SQL_VARCHAR_MAX_SIZE
 	};
+
+	private static final boolean _SUPPORTS_DUPLICATED_INDEX_NAME = false;
 
 }

--- a/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
@@ -61,8 +61,7 @@ public class HypersonicDB extends BaseDB {
 		String tableName, String newTableName) {
 
 		return StringBundler.concat(
-			"create table ", newTableName, " as (select * from ", tableName,
-			") without data");
+			"create table ", newTableName, " (like ", tableName, ")");
 	}
 
 	@Override


### PR DESCRIPTION
__Ticket:__ <https://issues.liferay.com/browse/LPS-182452>
__Prev. Pull Request:__ <https://github.com/liferay-uniform/liferay-portal/pull/1163>

This is a follow-up pull request for [LPS-182452](https://issues.liferay.com/browse/LPS-182452) to fix `DB.copyTableStructure()` for Hypersonic DB. There were two issues here:

1. The wrong SQL syntax and query was being used to copy the table structure. The `create table ... as ...` query does not copy over things like `NULL` constraints. Using `create table ... like ...` instead should fix this issue (see the _CREATE TABLE_ section in the following: <https://hsqldb.org/doc/2.0/guide/databaseobjects-chapt.html#dbc_tables>).
2. Hypersonic does not seem to allow duplicate index names. I've tested this manually.

These issues were not caught by `ci:test:upgrade` since the upgrade tests are not run on Hypersonic. Also, I have updated the `DBTest.testCopyTableStructure()` test to check if the primary key index is copied.