### PR TITLE
LPS-185138 Convert the Optional Dynamic Greedy reference to hard reference in class UpgradeRecorder

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -41,9 +41,6 @@ import org.apache.logging.log4j.ThreadContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Luis Ortiz
@@ -305,12 +302,8 @@ public class UpgradeRecorder {
 	private final Map<String, Map<String, Integer>> _errorMessages =
 		new ConcurrentHashMap<>();
 
-	@Reference(
-		cardinality = ReferenceCardinality.OPTIONAL,
-		policy = ReferencePolicy.DYNAMIC,
-		policyOption = ReferencePolicyOption.GREEDY
-	)
-	private volatile ReleaseManager _releaseManager;
+	@Reference
+	private ReleaseManager _releaseManager;
 
 	private String _result =
 		PropsValues.UPGRADE_DATABASE_AUTO_RUN || DBUpgrader.isUpgradeClient() ?


### PR DESCRIPTION
Hi @achaparro , I'm currently working on LPS-184625, which aims to convert the optional reference to static reference with Snapshot or hard reference. 
Since static Snapshot of `_releaseManager` causes "missing default store" [error](https://github.com/liferay-core-infra/liferay-portal/pull/4581#issuecomment-1561985174), I would like to know if converting it to hard reference affects the method usage in class `UpgradeLogAppender` ? Could you please take a look?
Thanks!