### PR TITLE
LPS-181762 Support for renaming several tables in a single transaction

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -473,11 +473,8 @@ public class DBTest {
 		}
 		catch (Exception exception) {
 			Assert.assertTrue(_dbInspector.hasTable(_TABLE_NAME_1));
-			Assert.assertTrue(_dbInspector.hasTable(_TABLE_NAME_2));
+			Assert.assertFalse(_dbInspector.hasTable(_TABLE_NAME_2));
 			Assert.assertFalse(_dbInspector.hasTable(_TABLE_NAME_3));
-
-			Assert.assertTrue(_dbInspector.hasColumn(_TABLE_NAME_1, "id"));
-			Assert.assertTrue(_dbInspector.hasColumn(_TABLE_NAME_2, "id1"));
 		}
 	}
 

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.sql.Connection;
@@ -92,6 +93,7 @@ public class DBTest {
 	public void tearDown() throws Exception {
 		_db.runSQL("DROP_TABLE_IF_EXISTS(" + _TABLE_NAME_1 + ")");
 		_db.runSQL("DROP_TABLE_IF_EXISTS(" + _TABLE_NAME_2 + ")");
+		_db.runSQL("DROP_TABLE_IF_EXISTS(" + _TABLE_NAME_3 + ")");
 	}
 
 	@Test
@@ -444,6 +446,23 @@ public class DBTest {
 	}
 
 	@Test
+	public void testRenameTables() throws Exception {
+		_db.runSQL(_SQL_CREATE_TABLE_2);
+
+		_db.renameTables(
+			_connection,
+			new ObjectValuePair<>(_TABLE_NAME_1, _TABLE_NAME_3),
+			new ObjectValuePair<>(_TABLE_NAME_2, _TABLE_NAME_1),
+			new ObjectValuePair<>(_TABLE_NAME_3, _TABLE_NAME_2));
+
+		Assert.assertTrue(_dbInspector.hasTable(_TABLE_NAME_1));
+		Assert.assertTrue(_dbInspector.hasTable(_TABLE_NAME_2));
+
+		Assert.assertTrue(_dbInspector.hasColumn(_TABLE_NAME_1, "id1"));
+		Assert.assertTrue(_dbInspector.hasColumn(_TABLE_NAME_2, "id"));
+	}
+
+	@Test
 	public void testSyncTables() throws Exception {
 		_db.runSQL(
 			StringBundler.concat(
@@ -616,6 +635,8 @@ public class DBTest {
 	private static final String _TABLE_NAME_1 = "DBTest1";
 
 	private static final String _TABLE_NAME_2 = "DBTest2";
+
+	private static final String _TABLE_NAME_3 = "DBTest3";
 
 	private static Connection _connection;
 	private static DB _db;

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -462,6 +462,26 @@ public class DBTest {
 	}
 
 	@Test
+	public void testRenameTablesRollback() throws Exception {
+		try {
+			_db.renameTables(
+				_connection,
+				new ObjectValuePair<>(_TABLE_NAME_1, _TABLE_NAME_3),
+				new ObjectValuePair<>(_TABLE_NAME_2, _TABLE_NAME_1));
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			Assert.assertTrue(_dbInspector.hasTable(_TABLE_NAME_1));
+			Assert.assertTrue(_dbInspector.hasTable(_TABLE_NAME_2));
+			Assert.assertFalse(_dbInspector.hasTable(_TABLE_NAME_3));
+
+			Assert.assertTrue(_dbInspector.hasColumn(_TABLE_NAME_1, "id"));
+			Assert.assertTrue(_dbInspector.hasColumn(_TABLE_NAME_2, "id1"));
+		}
+	}
+
+	@Test
 	public void testSyncTables() throws Exception {
 		_db.runSQL(
 			StringBundler.concat(

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -450,8 +450,7 @@ public class DBTest {
 		_db.runSQL(_SQL_CREATE_TABLE_2);
 
 		_db.renameTables(
-			_connection,
-			new ObjectValuePair<>(_TABLE_NAME_1, _TABLE_NAME_3),
+			_connection, new ObjectValuePair<>(_TABLE_NAME_1, _TABLE_NAME_3),
 			new ObjectValuePair<>(_TABLE_NAME_2, _TABLE_NAME_1),
 			new ObjectValuePair<>(_TABLE_NAME_3, _TABLE_NAME_2));
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/live/LiveUpgradeExecutorImpl.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/live/LiveUpgradeExecutorImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.upgrade.live.LiveUpgradeExecutor;
 import com.liferay.portal.upgrade.live.LiveUpgradeProcess;
@@ -72,15 +73,30 @@ public class LiveUpgradeExecutorImpl implements LiveUpgradeExecutor {
 				db.copyTableRows(
 					connection, tableName, tempTableName, resultColumnNamesMap);
 			}
+
+			db.renameTables(
+				connection,
+				new ObjectValuePair<>(
+					tableName, _getArchiveTableName(tableName)),
+				new ObjectValuePair<>(tempTableName, tableName));
 		}
 	}
 
-	private String _getTempTableName(String tableName) {
-		return _UPGRADE_LIVE_TABLE_NAME_PREFIX.concat(tableName);
+	private String _getArchiveTableName(String tableName) {
+		return _UPGRADE_LIVE_ARCHIVE_TABLE_NAME_PREFIX.concat(tableName);
 	}
 
-	private static final String _UPGRADE_LIVE_TABLE_NAME_PREFIX =
+	private String _getTempTableName(String tableName) {
+		return _UPGRADE_LIVE_TEMP_TABLE_NAME_PREFIX.concat(tableName);
+	}
+
+	private static final String _UPGRADE_LIVE_ARCHIVE_TABLE_NAME_PREFIX =
 		GetterUtil.get(
-			PropsUtil.get("upgrade.live.table.name.prefix"), "tmp_live_");
+			PropsUtil.get("upgrade.live.archive.table.name.prefix"),
+			"archive_live_");
+
+	private static final String _UPGRADE_LIVE_TEMP_TABLE_NAME_PREFIX =
+		GetterUtil.get(
+			PropsUtil.get("upgrade.live.temp.table.name.prefix"), "tmp_live_");
 
 }

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/live/LiveUpgradeExecutorImpl.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/live/LiveUpgradeExecutorImpl.java
@@ -17,6 +17,8 @@ package com.liferay.portal.upgrade.internal.live;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -80,6 +82,11 @@ public class LiveUpgradeExecutorImpl implements LiveUpgradeExecutor {
 					tableName, _getArchiveTableName(tableName)),
 				new ObjectValuePair<>(tempTableName, tableName));
 		}
+		catch (Exception exception) {
+			_log.error("Live upgrade failed", exception);
+
+			throw exception;
+		}
 	}
 
 	private String _getArchiveTableName(String tableName) {
@@ -98,5 +105,8 @@ public class LiveUpgradeExecutorImpl implements LiveUpgradeExecutor {
 	private static final String _UPGRADE_LIVE_TEMP_TABLE_NAME_PREFIX =
 		GetterUtil.get(
 			PropsUtil.get("upgrade.live.temp.table.name.prefix"), "tmp_live_");
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LiveUpgradeExecutorImpl.class);
 
 }

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -385,6 +385,14 @@ public class DB2DB extends BaseDB {
 	}
 
 	@Override
+	protected String getRenameTableSQL(
+		String oldTableName, String newTableName) {
+
+		return StringBundler.concat(
+			"rename table ", oldTableName, " to ", newTableName);
+	}
+
+	@Override
 	protected int[] getSQLTypes() {
 		return _SQL_TYPES;
 	}

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -328,7 +328,6 @@ public class OracleDB extends BaseDB {
 	}
 
 	@Override
-	@SafeVarargs
 	protected final void doRenameTables(
 			Connection connection,
 			ObjectValuePair<String, String>... tableNamePairs)

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -366,13 +366,13 @@ public class OracleDB extends BaseDB {
 							"rename ", tableNamePair.getValue(), " to ",
 							tableNamePair.getKey()));
 				}
+
+				if (_log.isInfoEnabled()) {
+					_log.info("Rollback of table renames successful");
+				}
 			}
 			catch (Exception exception2) {
 				_log.fatal("Failed to rollback table renames", exception2);
-			}
-
-			if (_log.isInfoEnabled()) {
-				_log.info("Rollback of table renames successful");
 			}
 
 			throw exception1;

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -201,61 +201,6 @@ public class OracleDB extends BaseDB {
 	}
 
 	@Override
-	public void renameTables(
-			Connection connection,
-			ObjectValuePair<String, String>... tableNamePairs)
-		throws Exception {
-
-		if (tableNamePairs.length == 0) {
-			return;
-		}
-
-		int index = 0;
-		ObjectValuePair<String, String> tableNamePair = null;
-
-		try {
-			while (index < tableNamePairs.length) {
-				tableNamePair = tableNamePairs[index];
-
-				runSQL(
-					connection,
-					StringBundler.concat(
-						"rename ", tableNamePair.getKey(), " to ",
-						tableNamePair.getValue()));
-
-				index++;
-			}
-		}
-		catch (Exception exception1) {
-			_log.error(
-				StringBundler.concat(
-					"Failed to rename table ", tableNamePair.getKey(), " to ",
-					tableNamePair.getValue(), ". Attempting to rollback."));
-
-			try {
-				while (index > 0) {
-					tableNamePair = tableNamePairs[--index];
-
-					runSQL(
-						connection,
-						StringBundler.concat(
-							"rename ", tableNamePair.getValue(), " to ",
-							tableNamePair.getKey()));
-				}
-			}
-			catch (Exception exception2) {
-				_log.fatal("Failed to rollback table renames", exception2);
-			}
-
-			if (_log.isInfoEnabled()) {
-				_log.info("Rollback of table renames successful");
-			}
-
-			throw exception1;
-		}
-	}
-
-	@Override
 	protected String[] buildColumnTypeTokens(String line) {
 		Matcher matcher = _varchar2CharPattern.matcher(line);
 
@@ -380,6 +325,58 @@ public class OracleDB extends BaseDB {
 		}
 
 		runSQL(connection, sb.toString());
+	}
+
+	@Override
+	@SafeVarargs
+	protected final void doRenameTables(
+			Connection connection,
+			ObjectValuePair<String, String>... tableNamePairs)
+		throws Exception {
+
+		int index = 0;
+		ObjectValuePair<String, String> tableNamePair = null;
+
+		try {
+			while (index < tableNamePairs.length) {
+				tableNamePair = tableNamePairs[index];
+
+				runSQL(
+					connection,
+					StringBundler.concat(
+						"rename ", tableNamePair.getKey(), " to ",
+						tableNamePair.getValue()));
+
+				index++;
+			}
+		}
+		catch (Exception exception1) {
+			_log.error(
+				StringBundler.concat(
+					"Failed to rename table ", tableNamePair.getKey(), " to ",
+					tableNamePair.getValue(), ". Attempting to rollback."));
+
+			try {
+				while (index > 0) {
+					tableNamePair = tableNamePairs[--index];
+
+					runSQL(
+						connection,
+						StringBundler.concat(
+							"rename ", tableNamePair.getValue(), " to ",
+							tableNamePair.getKey()));
+				}
+			}
+			catch (Exception exception2) {
+				_log.fatal("Failed to rollback table renames", exception2);
+			}
+
+			if (_log.isInfoEnabled()) {
+				_log.info("Rollback of table renames successful");
+			}
+
+			throw exception1;
+		}
 	}
 
 	@Override

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -386,6 +386,13 @@ public class SQLServerDB extends BaseDB {
 			" where 1 = 0");
 	}
 
+	protected String getRenameTableSQL(
+		String oldTableName, String newTableName) {
+
+		return StringBundler.concat(
+			"exec sp_rename ", oldTableName, ", ", newTableName);
+	}
+
 	@Override
 	protected int[] getSQLTypes() {
 		return _SQL_TYPES;

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -473,30 +473,14 @@ public abstract class BaseDB implements DB {
 			return;
 		}
 
-		boolean autoCommit = connection.getAutoCommit();
-
-		try {
-			connection.setAutoCommit(false);
-
-			for (ObjectValuePair<String, String> tableNamePair :
-					tableNamePairs) {
-
-				runSQL(
-					connection,
-					getRenameTableSQL(
-						tableNamePair.getKey(), tableNamePair.getValue()));
+		for (ObjectValuePair<String, String> tableNamePair : tableNamePairs) {
+			if (tableNamePair == null) {
+				throw new NullPointerException(
+					"Table name pair cannot be null");
 			}
+		}
 
-			connection.commit();
-		}
-		catch (Exception exception) {
-			connection.rollback();
-
-			throw exception;
-		}
-		finally {
-			connection.setAutoCommit(autoCommit);
-		}
+		doRenameTables(connection, tableNamePairs);
 	}
 
 	@Override
@@ -987,6 +971,37 @@ public abstract class BaseDB implements DB {
 		}
 
 		runSQL(connection, sb.toString());
+	}
+
+	protected void doRenameTables(
+			Connection connection,
+			ObjectValuePair<String, String>... tableNamePairs)
+		throws Exception {
+
+		boolean autoCommit = connection.getAutoCommit();
+
+		try {
+			connection.setAutoCommit(false);
+
+			for (ObjectValuePair<String, String> tableNamePair :
+					tableNamePairs) {
+
+				runSQL(
+					connection,
+					getRenameTableSQL(
+						tableNamePair.getKey(), tableNamePair.getValue()));
+			}
+
+			connection.commit();
+		}
+		catch (Exception exception) {
+			connection.rollback();
+
+			throw exception;
+		}
+		finally {
+			connection.setAutoCommit(autoCommit);
+		}
 	}
 
 	protected Set<String> dropIndexes(

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.io.unsync.UnsyncBufferedReader;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringReader;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.util.PropsValues;
@@ -133,6 +134,33 @@ public class MySQLDB extends BaseDB {
 	@Override
 	public boolean isSupportsUpdateWithInnerJoin() {
 		return _SUPPORTS_UPDATE_WITH_INNER_JOIN;
+	}
+
+	@Override
+	public void renameTables(
+			Connection connection,
+			ObjectValuePair<String, String>... tableNamePairs)
+		throws Exception {
+
+		if (tableNamePairs.length == 0) {
+			return;
+		}
+
+		StringBundler sb = new StringBundler((tableNamePairs.length * 4) + 1);
+
+		sb.append("rename table ");
+
+		for (int i = 0; i < tableNamePairs.length; i++) {
+			if (i > 0) {
+				sb.append(", ");
+			}
+
+			sb.append(tableNamePairs[i].getKey());
+			sb.append(" to ");
+			sb.append(tableNamePairs[i].getValue());
+		}
+
+		runSQL(connection, sb.toString());
 	}
 
 	protected MySQLDB(DBType dbType, int majorVersion, int minorVersion) {

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -141,7 +141,6 @@ public class MySQLDB extends BaseDB {
 	}
 
 	@Override
-	@SafeVarargs
 	protected final void doRenameTables(
 			Connection connection,
 			ObjectValuePair<String, String>... tableNamePairs)

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -136,15 +136,16 @@ public class MySQLDB extends BaseDB {
 		return _SUPPORTS_UPDATE_WITH_INNER_JOIN;
 	}
 
+	protected MySQLDB(DBType dbType, int majorVersion, int minorVersion) {
+		super(dbType, majorVersion, minorVersion);
+	}
+
 	@Override
-	public void renameTables(
+	@SafeVarargs
+	protected final void doRenameTables(
 			Connection connection,
 			ObjectValuePair<String, String>... tableNamePairs)
 		throws Exception {
-
-		if (tableNamePairs.length == 0) {
-			return;
-		}
 
 		StringBundler sb = new StringBundler((tableNamePairs.length * 4) + 1);
 
@@ -161,10 +162,6 @@ public class MySQLDB extends BaseDB {
 		}
 
 		runSQL(connection, sb.toString());
-	}
-
-	protected MySQLDB(DBType dbType, int majorVersion, int minorVersion) {
-		super(dbType, majorVersion, minorVersion);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.kernel.dao.db;
 
 import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.portal.kernel.util.ObjectValuePair;
 
 import java.io.IOException;
 
@@ -138,6 +139,11 @@ public interface DB {
 		throws Exception;
 
 	public void removePrimaryKey(Connection connection, String tableName)
+		throws Exception;
+
+	public void renameTables(
+			Connection connection,
+			ObjectValuePair<String, String>... tableNamePairs)
 		throws Exception;
 
 	public default void runSQL(

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
@@ -1,1 +1,1 @@
-version 13.0.0
+version 13.1.0


### PR DESCRIPTION
__Ticket:__ <https://liferay.atlassian.net/browse/LPS-181762>

This pull request implements renaming of multiple tables within a single transaction. I leverage the `java.sql.Connection` connection itself for the transactions since each SQL statement execution is always handled in a transaction with the JDBC (see commit 2c448be12496bac67463c495ebce0411540e6d7f). Let me know if this approach is okay. In addition, I applied the rename table operation to the Live Upgrade framework and updated the relevant tests accordingly. Now, the Live Upgrade framework is somewhat complete 🙂.

Also, I added a new property called `upgrade.live.archive.table.name.prefix`, which will be used to name the original table after the live upgrade (see commit b0f8c0b19406dccd40405036db7e9031a3b9dd66). I felt that this was a good idea to simplify the table renaming step in the Live Upgrade. If we did not have this, we would have to do 3 renames to do a table swap and will require having an intermediate table. Also, if there is somehow an issue with rollback, then we at least have some reference on the names of the auxiliary tables created during the live upgrade. Let me know if you prefer the table swap instead between the original table and the temp one.

*Note: From what I researched, MySQL seems to be the only DB vendor that provides a dedicated statement for renaming multiple tables atomically.

Let me know if I need to change anything or if I missed something.