### PR TITLE
LPS-190043 Create statement within concurrentProcess call

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v5_2_1/JournalArticleLayoutClassedModelUsageUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v5_2_1/JournalArticleLayoutClassedModelUsageUpgradeProcess.java
@@ -31,13 +31,7 @@ public class JournalArticleLayoutClassedModelUsageUpgradeProcess
 	@Override
 	protected void doUpgrade() throws Exception {
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			PreparedStatement preparedStatement1 = connection.prepareStatement(
-				StringBundler.concat(
-					"select 1 from LayoutClassedModelUsage where classNameId ",
-					"= ? and classPK = ? and containerKey = ? and ",
-					"containerType = ? and plid = ?"));
-
-			String sql = StringBundler.concat(
+			String sql1 = StringBundler.concat(
 				"select distinct ",
 				"LayoutClassedModelUsage.layoutClassedModelUsageId, ",
 				"LayoutClassedModelUsage.classNameId, ",
@@ -48,8 +42,13 @@ public class JournalArticleLayoutClassedModelUsageUpgradeProcess
 				"LayoutRevision.layoutRevisionId = ",
 				"LayoutClassedModelUsage.plid");
 
+			String sql2 = StringBundler.concat(
+				"select 1 from LayoutClassedModelUsage where classNameId = ? ",
+				"and classPK = ? and containerKey = ? and containerType = ? ",
+				"and plid = ?");
+
 			processConcurrently(
-				sql,
+				sql1,
 				"update LayoutClassedModelUsage set plid = ? where " +
 					"layoutClassedModelUsageId = ?",
 				resultSet -> new Object[] {
@@ -68,6 +67,9 @@ public class JournalArticleLayoutClassedModelUsageUpgradeProcess
 					String containerKey = (String)values[3];
 					long containerType = (Long)values[4];
 					long plid = (Long)values[5];
+
+					PreparedStatement preparedStatement1 =
+						connection.prepareStatement(sql2);
 
 					preparedStatement1.setLong(1, classNameId);
 					preparedStatement1.setLong(2, classPK);


### PR DESCRIPTION
Notes from @javalosjr96:
> Ticket: [LPS-190043](https://liferay.atlassian.net/browse/LPS-190043)
> 
> Description:
> When there is a data set affect by [LPS-181691](https://liferay.atlassian.net/browse/LPS-181691), then the nested Resultset will end up closing due to the capabilities of the Database type.   
> e.g This occured once for me on MySQL 5.7, but none after.  
> 
> On Oracle19c this occurs frequently.
> 
> Solution:
> Move the prepared statement so that a new one is created rather than reassigning parameters to the old one.


