### PR TITLE
LPS-181762 Generalize `DB.renameTables()` for databases that do not support DDL rollback

### DIFF
--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -406,6 +406,10 @@ public class OracleDB extends BaseDB {
 		}
 	}
 
+	protected boolean isSupportsDDLRollback() {
+		return _SUPPORTS_DDL_ROLLBACK;
+	}
+
 	@Override
 	protected boolean isSupportsDuplicatedIndexName() {
 		return _SUPPORTS_DUPLICATED_INDEX_NAME;
@@ -526,6 +530,8 @@ public class OracleDB extends BaseDB {
 	private static final int[] _SQL_VARCHAR_SIZES = {
 		_SQL_STRING_SIZE, SQL_SIZE_NONE
 	};
+
+	private static final boolean _SUPPORTS_DDL_ROLLBACK = false;
 
 	private static final boolean _SUPPORTS_DUPLICATED_INDEX_NAME = false;
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -328,57 +327,11 @@ public class OracleDB extends BaseDB {
 	}
 
 	@Override
-	protected final void doRenameTables(
-			Connection connection,
-			ObjectValuePair<String, String>... tableNameObjectValuePairs)
-		throws Exception {
+	protected String getRenameTableSQL(
+		String oldTableName, String newTableName) {
 
-		int index = 0;
-		ObjectValuePair<String, String> tableNameObjectValuePair = null;
-
-		try {
-			while (index < tableNameObjectValuePairs.length) {
-				tableNameObjectValuePair = tableNameObjectValuePairs[index];
-
-				runSQL(
-					connection,
-					StringBundler.concat(
-						"rename ", tableNameObjectValuePair.getKey(), " to ",
-						tableNameObjectValuePair.getValue()));
-
-				index++;
-			}
-		}
-		catch (Exception exception1) {
-			_log.error(
-				StringBundler.concat(
-					"Unable to rename table ",
-					tableNameObjectValuePair.getKey(), " to ",
-					tableNameObjectValuePair.getValue(),
-					". Attempting to rollback."));
-
-			try {
-				while (index > 0) {
-					tableNameObjectValuePair =
-						tableNameObjectValuePairs[--index];
-
-					runSQL(
-						connection,
-						StringBundler.concat(
-							"rename ", tableNameObjectValuePair.getValue(),
-							" to ", tableNameObjectValuePair.getKey()));
-				}
-
-				if (_log.isInfoEnabled()) {
-					_log.info("Successfully rolled back table renames");
-				}
-			}
-			catch (Exception exception2) {
-				_log.fatal("Unable to roll back table renames", exception2);
-			}
-
-			throw exception1;
-		}
+		return StringBundler.concat(
+			"rename ", oldTableName, " to ", newTableName);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -980,30 +980,80 @@ public abstract class BaseDB implements DB {
 			ObjectValuePair<String, String>... tableNameObjectValuePairs)
 		throws Exception {
 
-		boolean autoCommit = connection.getAutoCommit();
+		if (isSupportsDDLRollback()) {
+			boolean autoCommit = connection.getAutoCommit();
 
-		try {
-			connection.setAutoCommit(false);
+			try {
+				connection.setAutoCommit(false);
 
-			for (ObjectValuePair<String, String> tableNameObjectValuePair :
-					tableNameObjectValuePairs) {
+				for (ObjectValuePair<String, String> tableNameObjectValuePair :
+						tableNameObjectValuePairs) {
 
-				runSQL(
-					connection,
-					getRenameTableSQL(
-						tableNameObjectValuePair.getKey(),
-						tableNameObjectValuePair.getValue()));
+					runSQL(
+						connection,
+						getRenameTableSQL(
+							tableNameObjectValuePair.getKey(),
+							tableNameObjectValuePair.getValue()));
+				}
+
+				connection.commit();
 			}
+			catch (Exception exception) {
+				connection.rollback();
 
-			connection.commit();
+				throw exception;
+			}
+			finally {
+				connection.setAutoCommit(autoCommit);
+			}
 		}
-		catch (Exception exception) {
-			connection.rollback();
+		else {
+			int index = 0;
+			ObjectValuePair<String, String> tableNameObjectValuePair = null;
 
-			throw exception;
-		}
-		finally {
-			connection.setAutoCommit(autoCommit);
+			try {
+				while (index < tableNameObjectValuePairs.length) {
+					tableNameObjectValuePair = tableNameObjectValuePairs[index];
+
+					runSQL(
+						connection,
+						getRenameTableSQL(
+							tableNameObjectValuePair.getKey(),
+							tableNameObjectValuePair.getValue()));
+
+					index++;
+				}
+			}
+			catch (Exception exception1) {
+				_log.error(
+					StringBundler.concat(
+						"Unable to rename table ",
+						tableNameObjectValuePair.getKey(), " to ",
+						tableNameObjectValuePair.getValue(),
+						". Attempting to rollback."));
+
+				try {
+					while (index > 0) {
+						tableNameObjectValuePair =
+							tableNameObjectValuePairs[--index];
+
+						runSQL(
+							connection,
+							getRenameTableSQL(
+								tableNameObjectValuePair.getValue(),
+								tableNameObjectValuePair.getKey()));
+					}
+
+					if (_log.isInfoEnabled()) {
+						_log.info("Successfully rolled back table renames");
+					}
+				}
+				catch (Exception exception2) {
+					_log.fatal("Unable to roll back table renames", exception2);
+				}
+
+				throw exception1;
+			}
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -57,6 +57,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -479,6 +480,13 @@ public abstract class BaseDB implements DB {
 			if (tableNameObjectValuePair == null) {
 				throw new IllegalArgumentException(
 					"Table name object value pair is null");
+			}
+
+			if (Objects.isNull(tableNameObjectValuePair.getKey()) ||
+				Objects.isNull(tableNameObjectValuePair.getValue())) {
+
+				throw new IllegalArgumentException(
+					"Found null in table name object value pair");
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -1227,6 +1227,10 @@ public abstract class BaseDB implements DB {
 
 	protected abstract String[] getTemplate();
 
+	protected boolean isSupportsDDLRollback() {
+		return _SUPPORTS_DDL_ROLLBACK;
+	}
+
 	protected boolean isSupportsDuplicatedIndexName() {
 		return _SUPPORTS_DUPLICATED_INDEX_NAME;
 	}
@@ -1422,6 +1426,8 @@ public abstract class BaseDB implements DB {
 	private static final boolean _SUPPORTS_ALTER_COLUMN_NAME = true;
 
 	private static final boolean _SUPPORTS_ALTER_COLUMN_TYPE = true;
+
+	private static final boolean _SUPPORTS_DDL_ROLLBACK = true;
 
 	private static final boolean _SUPPORTS_DUPLICATED_INDEX_NAME = true;
 

--- a/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
@@ -191,6 +191,10 @@ public class HypersonicDB extends BaseDB {
 		return _HYPERSONIC;
 	}
 
+	protected boolean isSupportsDDLRollback() {
+		return _SUPPORTS_DDL_ROLLBACK;
+	}
+
 	protected boolean isSupportsDuplicatedIndexName() {
 		return _SUPPORTS_DUPLICATED_INDEX_NAME;
 	}
@@ -266,6 +270,8 @@ public class HypersonicDB extends BaseDB {
 	private static final int[] _SQL_VARCHAR_SIZES = {
 		SQL_VARCHAR_MAX_SIZE, SQL_VARCHAR_MAX_SIZE
 	};
+
+	private static final boolean _SUPPORTS_DDL_ROLLBACK = false;
 
 	private static final boolean _SUPPORTS_DUPLICATED_INDEX_NAME = false;
 


### PR DESCRIPTION
__Ticket:__ <https://liferay.atlassian.net/browse/LPS-181762>
__Previous pull request:__ <https://github.com/liferay-uniform/liferay-portal/pull/1252>

This is a follow-up pull request that fixes `DB.renameTables()` for Hypersonic as it does not support rolling back DDL operations. I moved the table renaming logic in `OracleDB` to `BaseDB` so it can be re-used for Hypersonic and future databases that do not support DDL rollback.