### PR TITLE
LPS-191724 Add support for `DEFAULT` clause for `DB.alterColumnType()`

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
@@ -94,9 +94,9 @@ public class BaseDBProcessTest extends BaseDBProcess {
 			Assert.fail();
 		}
 		catch (SQLException sqlException) {
+			Assert.assertFalse(
+				_dbInspector.hasColumn(_TABLE_NAME, "typeChanged"));
 		}
-
-		Assert.assertFalse(_dbInspector.hasColumn(_TABLE_NAME, "typeChanged"));
 	}
 
 	@Test
@@ -118,12 +118,13 @@ public class BaseDBProcessTest extends BaseDBProcess {
 			Assert.fail();
 		}
 		catch (SQLException sqlException) {
+			Assert.assertTrue(
+				_dbInspector.hasColumn(_TABLE_NAME, "typeInteger"));
+
+			Assert.assertTrue(
+				_dbInspector.hasColumnType(
+					_TABLE_NAME, "typeBoolean", "BOOLEAN"));
 		}
-
-		Assert.assertTrue(_dbInspector.hasColumn(_TABLE_NAME, "typeInteger"));
-
-		Assert.assertTrue(
-			_dbInspector.hasColumnType(_TABLE_NAME, "typeBoolean", "BOOLEAN"));
 	}
 
 	@Test
@@ -135,13 +136,13 @@ public class BaseDBProcessTest extends BaseDBProcess {
 			Assert.fail();
 		}
 		catch (SQLException sqlException) {
+			Assert.assertFalse(
+				_dbInspector.hasColumn(_TABLE_NAME, "deletedColumn"));
+
+			Assert.assertFalse(
+				_dbInspector.hasColumnType(
+					_TABLE_NAME, "typeBoolean", "VARCHAR"));
 		}
-
-		Assert.assertFalse(
-			_dbInspector.hasColumn(_TABLE_NAME, "deletedColumn"));
-
-		Assert.assertFalse(
-			_dbInspector.hasColumnType(_TABLE_NAME, "typeBoolean", "VARCHAR"));
 	}
 
 	@Test
@@ -154,12 +155,13 @@ public class BaseDBProcessTest extends BaseDBProcess {
 			Assert.fail();
 		}
 		catch (SQLException sqlException) {
+			Assert.assertTrue(
+				_dbInspector.hasColumn(_TABLE_NAME, "typeInteger"));
+
+			Assert.assertFalse(
+				_dbInspector.hasColumnType(
+					_TABLE_NAME, "typeBoolean", "VARCHAR"));
 		}
-
-		Assert.assertTrue(_dbInspector.hasColumn(_TABLE_NAME, "typeInteger"));
-
-		Assert.assertFalse(
-			_dbInspector.hasColumnType(_TABLE_NAME, "typeBoolean", "VARCHAR"));
 	}
 
 	@Test
@@ -172,10 +174,9 @@ public class BaseDBProcessTest extends BaseDBProcess {
 			Assert.fail();
 		}
 		catch (SQLException sqlException) {
+			Assert.assertFalse(
+				_dbInspector.hasColumn(_TABLE_NAME, "nonexistentColumn"));
 		}
-
-		Assert.assertFalse(
-			_dbInspector.hasColumn(_TABLE_NAME, "nonexistentColumn"));
 	}
 
 	@Test
@@ -231,11 +232,10 @@ public class BaseDBProcessTest extends BaseDBProcess {
 			Assert.fail();
 		}
 		catch (SQLException sqlException) {
+			Assert.assertFalse(
+				_dbInspector.hasColumnType(
+					_TABLE_NAME, "nilColumn", "LONG default 2 not null"));
 		}
-
-		Assert.assertFalse(
-			_dbInspector.hasColumnType(
-				_TABLE_NAME, "nilColumn", "LONG default 2 not null"));
 	}
 
 	@Test
@@ -298,11 +298,10 @@ public class BaseDBProcessTest extends BaseDBProcess {
 			Assert.fail();
 		}
 		catch (SQLException sqlException) {
+			Assert.assertFalse(
+				_dbInspector.hasColumnType(
+					_TABLE_NAME, "nonexistentColumn", "TEXT not null"));
 		}
-
-		Assert.assertFalse(
-			_dbInspector.hasColumnType(
-				_TABLE_NAME, "nonexistentColumn", "TEXT not null"));
 	}
 
 	@Test
@@ -405,9 +404,9 @@ public class BaseDBProcessTest extends BaseDBProcess {
 			Assert.fail();
 		}
 		catch (SQLException sqlException) {
+			Assert.assertFalse(
+				hasColumnType(_TABLE_NAME, "typeDouble", "VARCHAR"));
 		}
-
-		Assert.assertFalse(hasColumnType(_TABLE_NAME, "typeDouble", "VARCHAR"));
 	}
 
 	@Test

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
@@ -225,17 +225,11 @@ public class BaseDBProcessTest extends BaseDBProcess {
 
 	@Test
 	public void testAlterColumnTypeChangeToDefaultNotNull() throws Exception {
-		try {
-			alterColumnType(
-				_TABLE_NAME, "nilColumn", "LONG default 2 not null");
+		alterColumnType(_TABLE_NAME, "nilColumn", "LONG default 2 not null");
 
-			Assert.fail();
-		}
-		catch (SQLException sqlException) {
-			Assert.assertFalse(
-				_dbInspector.hasColumnType(
-					_TABLE_NAME, "nilColumn", "LONG default 2 not null"));
-		}
+		Assert.assertTrue(
+			_dbInspector.hasColumnType(
+				_TABLE_NAME, "nilColumn", "LONG default 2 not null"));
 	}
 
 	@Test

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
@@ -179,6 +179,24 @@ public class BaseDBProcessTest extends BaseDBProcess {
 	}
 
 	@Test
+	public void testAlterColumnNameNoNullableChange() throws Exception {
+		alterColumnName(
+			_TABLE_NAME, "nilColumn", "nilColumnTest VARCHAR(75) null");
+
+		Assert.assertTrue(
+			_dbInspector.hasColumnType(
+				_TABLE_NAME, "nilColumnTest", "VARCHAR(75) null"));
+
+		alterColumnName(
+			_TABLE_NAME, "notNilColumn",
+			"notNilColumnTest VARCHAR(75) not null");
+
+		Assert.assertTrue(
+			_dbInspector.hasColumnType(
+				_TABLE_NAME, "notNilColumnTest", "VARCHAR(75) not null"));
+	}
+
+	@Test
 	public void testAlterColumnNameSameColumnDifferentCase() throws Exception {
 		alterColumnName(_TABLE_NAME, "typeInteger", "TypeInteger INTEGER");
 

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
@@ -77,8 +77,10 @@ public class BaseDBProcessTest extends BaseDBProcess {
 				"key, notNilColumn VARCHAR(75) not null, nilColumn ",
 				"VARCHAR(75) null, typeBlob BLOB, typeBoolean BOOLEAN,",
 				"typeDate DATE null, typeDouble DOUBLE, typeInteger INTEGER, ",
-				"typeLong LONG null, typeSBlob SBLOB, typeString STRING null, ",
-				"typeText TEXT null, typeVarchar VARCHAR(75) null);"));
+				"typeLong LONG null, typeLongDefault LONG default 10 not null,",
+				"typeSBlob SBLOB, typeString STRING null, typeText TEXT null, ",
+				"typeVarchar VARCHAR(75) null, typeVarcharDefault VARCHAR(10) ",
+				"default 'testValue' not null);"));
 	}
 
 	@After
@@ -256,6 +258,35 @@ public class BaseDBProcessTest extends BaseDBProcess {
 
 		Assert.assertTrue(
 			_dbInspector.hasColumnType(_TABLE_NAME, "typeString", "TEXT null"));
+	}
+
+	@Test
+	public void testAlterColumnTypeChangeWithoutDefaultClause()
+		throws Exception {
+
+		_db.alterColumnType(
+			_connection, _TABLE_NAME, "typeVarcharDefault",
+			"VARCHAR(10) not null");
+
+		Assert.assertTrue(
+			_dbInspector.hasColumnType(
+				_TABLE_NAME, "typeVarcharDefault", "VARCHAR(10) not null"));
+	}
+
+	@Test
+	public void testAlterColumnTypeChangeWithoutNullClause() throws Exception {
+		_db.alterColumnType(
+			_connection, _TABLE_NAME, "notNilColumn", "VARCHAR(75)");
+
+		Assert.assertTrue(
+			_dbInspector.hasColumnType(
+				_TABLE_NAME, "notNilColumn", "VARCHAR(75) null"));
+
+		alterColumnType(_TABLE_NAME, "nilColumn", "VARCHAR(75)");
+
+		Assert.assertTrue(
+			_dbInspector.hasColumnType(
+				_TABLE_NAME, "nilColumn", "VARCHAR(75) null"));
 	}
 
 	@Test

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -88,6 +88,25 @@ public class DBTest {
 	}
 
 	@Test
+	public void testAlterColumnNameNoNullableChange() throws Exception {
+		_db.alterColumnName(
+			_connection, _TABLE_NAME_1, "nilColumn",
+			"nilColumnTest VARCHAR(75) null");
+
+		Assert.assertTrue(
+			_dbInspector.hasColumnType(
+				_TABLE_NAME_1, "nilColumnTest", "VARCHAR(75) null"));
+
+		_db.alterColumnName(
+			_connection, _TABLE_NAME_1, "notNilColumn",
+			"notNilColumnTest VARCHAR(75) not null");
+
+		Assert.assertTrue(
+			_dbInspector.hasColumnType(
+				_TABLE_NAME_1, "notNilColumnTest", "VARCHAR(75) not null"));
+	}
+
+	@Test
 	public void testAlterColumnTypeAlterSize() throws Exception {
 		_db.alterColumnType(
 			_connection, _TABLE_NAME_1, "notNilColumn",

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -445,8 +445,10 @@ public class DBTest {
 				"key, notNilColumn VARCHAR(75) not null, nilColumn ",
 				"VARCHAR(75) null, typeBlob BLOB, typeBoolean BOOLEAN,",
 				"typeDate DATE null, typeDouble DOUBLE, typeInteger INTEGER, ",
-				"typeLong LONG null, typeSBlob SBLOB, typeString STRING null, ",
-				"typeText TEXT null, typeVarchar VARCHAR(75) null);"));
+				"typeLong LONG null, typeLongDefault LONG default 10 not null,",
+				"typeSBlob SBLOB, typeString STRING null, typeText TEXT null, ",
+				"typeVarchar VARCHAR(75) null, typeVarcharDefault VARCHAR(10) ",
+				"default 'testValue' not null);"));
 
 		_db.runSQL(
 			StringBundler.concat(
@@ -599,8 +601,10 @@ public class DBTest {
 				"key, notNilColumn VARCHAR(75) not null, nilColumn ",
 				"VARCHAR(75) null, typeBlob BLOB, typeBoolean BOOLEAN,",
 				"typeDate DATE null, typeDouble DOUBLE, typeInteger INTEGER, ",
-				"typeLong LONG null, typeSBlob SBLOB, typeString STRING null, ",
-				"typeText TEXT null, typeVarchar VARCHAR(75) null);"));
+				"typeLong LONG null, typeLongDefault LONG default 10 not null,",
+				"typeSBlob SBLOB, typeString STRING null, typeText TEXT null, ",
+				"typeVarchar VARCHAR(75) null, typeVarcharDefault VARCHAR(10) ",
+				"default 'testValue' not null);"));
 
 		_db.runSQL(
 			StringBundler.concat(
@@ -653,8 +657,10 @@ public class DBTest {
 				"key, notNilColumn2 VARCHAR(75) not null, nilColumn2 ",
 				"VARCHAR(75) null, typeBlob2 BLOB, typeBoolean2 BOOLEAN,",
 				"typeDate2 DATE null, typeDouble2 DOUBLE, typeInteger2 ",
-				"INTEGER, typeLong2 LONG null, typeSBlob2 SBLOB, typeString2 ",
-				"STRING null, typeText2 TEXT null, typeVarchar2 VARCHAR(75) ",
+				"INTEGER, typeLong2 LONG null, typeLongDefault2 LONG default ",
+				"10 not null, typeSBlob2 SBLOB, typeString2 STRING null, ",
+				"typeText2 TEXT null, typeVarchar2 VARCHAR(75) null,",
+				"typeVarcharDefault2 VARCHAR(10) default 'testValue' not ",
 				"null);"));
 
 		_db.runSQL(

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -131,7 +131,9 @@ public class DB2DB extends BaseDB {
 
 			String tempColumnName = "temp" + columnName;
 
-			if (newColumnType.endsWith("not null")) {
+			if (newColumnType.endsWith("not null") &&
+				(dbInspector.getColumnDefaultValue(newColumnType) == null)) {
+
 				runSQL(
 					StringBundler.concat(
 						"alter table ", tableName, " add ", tempColumnName,

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -501,23 +501,36 @@ public class DB2DB extends BaseDB {
 
 					String nullable = template[template.length - 1];
 
-					if (!Validator.isBlank(nullable)) {
-						String nullableAlter;
-
-						if (nullable.equals("not null")) {
-							nullableAlter = StringUtil.replace(
+					if (nullable.equals("not null")) {
+						runSQL(
+							StringUtil.replace(
 								"alter table @table@ alter column " +
 									"@old-column@ set not null;",
-								REWORD_TEMPLATE, template);
-						}
-						else {
-							nullableAlter = StringUtil.replace(
+								REWORD_TEMPLATE, template));
+					}
+					else {
+						runSQL(
+							StringUtil.replace(
 								"alter table @table@ alter column " +
 									"@old-column@ drop not null;",
-								REWORD_TEMPLATE, template);
-						}
+								REWORD_TEMPLATE, template));
+					}
 
-						runSQL(nullableAlter);
+					String defaults = template[template.length - 2];
+
+					if (!Validator.isBlank(defaults)) {
+						runSQL(
+							StringUtil.replace(
+								"alter table @table@ alter column " +
+									"@old-column@ set default @default@;",
+								REWORD_TEMPLATE, template));
+					}
+					else {
+						runSQL(
+							StringUtil.replace(
+								"alter table @table@ alter column " +
+									"@old-column@ drop default;",
+								REWORD_TEMPLATE, template));
 					}
 				}
 				else if (line.startsWith(ALTER_TABLE_NAME)) {

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -473,6 +473,23 @@ public class OracleDB extends BaseDB {
 						REWORD_TEMPLATE, template);
 
 					line = StringUtil.replace(line, " ;", ";");
+
+					String defaults = template[template.length - 2];
+
+					if (!Validator.isBlank(defaults)) {
+						line = line.concat(
+							StringUtil.replace(
+								"alter table @table@ modify @old-column@ " +
+									"default @default@;",
+								REWORD_TEMPLATE, template));
+					}
+					else {
+						line = line.concat(
+							StringUtil.replace(
+								"alter table @table@ modify @old-column@ " +
+									"default null;",
+								REWORD_TEMPLATE, template));
+					}
 				}
 				else if (line.startsWith(ALTER_TABLE_NAME)) {
 					String[] template = buildTableNameTokens(line);

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -426,6 +426,23 @@ public class SQLServerDB extends BaseDB {
 						REWORD_TEMPLATE, template);
 
 					line = StringUtil.replace(line, " ;", ";");
+
+					line = line.concat(
+						StringUtil.replace(
+							"alter table @table@ drop constraint if exists " +
+								"@old-column@_default;",
+							REWORD_TEMPLATE, template));
+
+					String defaults = template[template.length - 2];
+
+					if (!Validator.isBlank(defaults)) {
+						line = line.concat(
+							StringUtil.replace(
+								"alter table @table@ add constraint " +
+									"@old-column@_default default @default@ " +
+										"for @old-column@;",
+								REWORD_TEMPLATE, template));
+					}
 				}
 				else if (line.startsWith(ALTER_TABLE_NAME)) {
 					String[] template = buildTableNameTokens(line);

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -63,6 +63,8 @@ public class SQLServerDB extends BaseDB {
 			removePrimaryKey(connection, tableName);
 		}
 
+		_dropDefaultConstraint(connection, tableName, columnName);
+
 		super.alterColumnType(connection, tableName, columnName, newColumnType);
 
 		if (primaryKey) {
@@ -426,12 +428,6 @@ public class SQLServerDB extends BaseDB {
 						REWORD_TEMPLATE, template);
 
 					line = StringUtil.replace(line, " ;", ";");
-
-					line = line.concat(
-						StringUtil.replace(
-							"alter table @table@ drop constraint if exists " +
-								"@old-column@_default;",
-							REWORD_TEMPLATE, template));
 
 					String defaults = template[template.length - 2];
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SybaseDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SybaseDB.java
@@ -222,6 +222,23 @@ public class SybaseDB extends BaseDB {
 						REWORD_TEMPLATE, template);
 
 					line = StringUtil.replace(line, " ;", ";");
+
+					String defaults = template[template.length - 2];
+
+					if (!Validator.isBlank(defaults)) {
+						line = line.concat(
+							StringUtil.replace(
+								"alter table @table@ modify @old-column@ " +
+									"default @default@;",
+								REWORD_TEMPLATE, template));
+					}
+					else {
+						line = line.concat(
+							StringUtil.replace(
+								"alter table @table@ modify @old-column@ " +
+									"default null;",
+								REWORD_TEMPLATE, template));
+					}
 				}
 				else if (line.startsWith(ALTER_TABLE_NAME)) {
 					String[] template = buildTableNameTokens(line);

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -822,35 +822,63 @@ public abstract class BaseDB implements DB {
 	}
 
 	protected String[] buildColumnNameTokens(String line) {
-		String[] words = StringUtil.split(line, CharPool.SPACE);
+		Matcher matcher = _alterColumnNamePattern.matcher(line);
 
-		String nullable = "";
-
-		if (words.length == 7) {
-			nullable = "not null;";
+		if (!matcher.find()) {
+			throw new IllegalArgumentException(
+				"Invalid alter column name statement");
 		}
 
-		return new String[] {words[1], words[2], words[3], words[4], nullable};
-	}
-
-	protected String[] buildColumnTypeTokens(String line) {
-		String[] words = StringUtil.split(line, CharPool.SPACE);
-
+		String defaults = matcher.group(7);
 		String nullable = "";
 
-		if (words.length == 6) {
+		if (defaults != null) {
 			nullable = "not null";
 		}
-		else if (words.length == 5) {
-			nullable = "null";
-		}
-		else if (words.length == 4) {
-			if (words[3].endsWith(";")) {
-				words[3] = words[3].substring(0, words[3].length() - 1);
+		else {
+			defaults = "";
+
+			nullable = matcher.group(8);
+
+			if (nullable == null) {
+				nullable = "";
 			}
 		}
 
-		return new String[] {words[1], words[2], "", words[3], nullable};
+		return new String[] {
+			matcher.group(1), matcher.group(2), matcher.group(3),
+			matcher.group(4), defaults, nullable
+		};
+	}
+
+	protected String[] buildColumnTypeTokens(String line) {
+		Matcher matcher = _alterColumnTypePattern.matcher(line);
+
+		if (!matcher.find()) {
+			throw new IllegalArgumentException(
+				"Invalid alter column type statement");
+		}
+
+		String defaults = matcher.group(6);
+		String nullable = "";
+
+		if (defaults != null) {
+			nullable = "not null";
+		}
+		else {
+			defaults = "";
+
+			nullable = matcher.group(7);
+
+			if (nullable == null) {
+				nullable = "";
+			}
+		}
+
+		return new String[] {
+			matcher.group(1), matcher.group(2), "", matcher.group(3), defaults,
+			nullable
+		};
 	}
 
 	protected String[] buildTableNameTokens(String line) {
@@ -1284,7 +1312,8 @@ public abstract class BaseDB implements DB {
 	};
 
 	protected static final String[] REWORD_TEMPLATE = {
-		"@table@", "@old-column@", "@new-column@", "@type@", "@nullable@"
+		"@table@", "@old-column@", "@new-column@", "@type@", "@default@",
+		"@nullable@"
 	};
 
 	protected static final int[] SQL_VARCHAR_TYPES = {
@@ -1426,6 +1455,14 @@ public abstract class BaseDB implements DB {
 
 	private static final Log _log = LogFactoryUtil.getLog(BaseDB.class);
 
+	private static final Pattern _alterColumnNamePattern = Pattern.compile(
+		"^ALTER_COLUMN_NAME (\\S+) (\\S+) (\\S+) (\\S+) ?((DEFAULT " +
+			"('?.*[^']'?) NOT NULL)|((NOT )?NULL))?$",
+		Pattern.CASE_INSENSITIVE);
+	private static final Pattern _alterColumnTypePattern = Pattern.compile(
+		"^ALTER_COLUMN_TYPE (\\S+) (\\S+) (\\S+) ?((DEFAULT ('?.*[^']'?) " +
+			"NOT NULL)|((NOT )?NULL))?$",
+		Pattern.CASE_INSENSITIVE);
 	private static final Pattern _columnLengthPattern = Pattern.compile(
 		"([^,(\\s]+)\\[\\$COLUMN_LENGTH:(\\d+)\\$\\]");
 	private static final Pattern _defaultValuePattern = Pattern.compile(

--- a/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.sql.Types;
 
+import java.util.Objects;
+
 /**
  * @author Alexander Chow
  * @author Sandeep Soni
@@ -213,11 +215,35 @@ public class HypersonicDB extends BaseDB {
 
 					String nullable = template[template.length - 1];
 
-					if (!Validator.isBlank(nullable)) {
+					if (Objects.equals(nullable, "not null")) {
 						line = line.concat(
 							StringUtil.replace(
 								"alter table @table@ alter column " +
-									"@old-column@ set @nullable@;",
+									"@old-column@ set not null;",
+								REWORD_TEMPLATE, template));
+					}
+					else {
+						line = line.concat(
+							StringUtil.replace(
+								"alter table @table@ alter column " +
+									"@old-column@ set null;",
+								REWORD_TEMPLATE, template));
+					}
+
+					String defaults = template[template.length - 2];
+
+					if (!Validator.isBlank(defaults)) {
+						line = line.concat(
+							StringUtil.replace(
+								"alter table @table@ alter column " +
+									"@old-column@ set default @default@;",
+								REWORD_TEMPLATE, template));
+					}
+					else {
+						line = line.concat(
+							StringUtil.replace(
+								"alter table @table@ alter column " +
+									"@old-column@ set default null;",
 								REWORD_TEMPLATE, template));
 					}
 				}

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -183,19 +183,33 @@ public class MySQLDB extends BaseDB {
 				else if (line.startsWith(ALTER_COLUMN_NAME)) {
 					String[] template = buildColumnNameTokens(line);
 
-					line = StringUtil.replace(
-						"alter table @table@ change column @old-column@ " +
-							"@new-column@ @type@;",
-						REWORD_TEMPLATE, template);
+					String defaults = template[template.length - 2];
+
+					if (!Validator.isBlank(defaults)) {
+						line = StringUtil.replace(
+							"alter table @table@ change column @old-column@ " +
+								"@new-column@ @type@ default @default@ " +
+									"@nullable@;",
+							REWORD_TEMPLATE, template);
+					}
+					else {
+						line = StringUtil.replace(
+							"alter table @table@ change column @old-column@ " +
+								"@new-column@ @type@ @nullable@;",
+							REWORD_TEMPLATE, template);
+					}
+
+					line = StringUtil.replace(line, " ;", ";");
 				}
 				else if (line.startsWith(ALTER_COLUMN_TYPE)) {
 					String[] template = buildColumnTypeTokens(line);
 
-					String nullable = template[template.length - 1];
+					String defaults = template[template.length - 2];
 
-					if (Validator.isBlank(nullable)) {
+					if (!Validator.isBlank(defaults)) {
 						line = StringUtil.replace(
-							"alter table @table@ modify @old-column@ @type@;",
+							"alter table @table@ modify @old-column@ @type@ " +
+								"default @default@ @nullable@;",
 							REWORD_TEMPLATE, template);
 					}
 					else {
@@ -204,6 +218,8 @@ public class MySQLDB extends BaseDB {
 								"@nullable@;",
 							REWORD_TEMPLATE, template);
 					}
+
+					line = StringUtil.replace(line, " ;", ";");
 				}
 				else if (line.startsWith(ALTER_TABLE_NAME)) {
 					String[] template = buildTableNameTokens(line);

--- a/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
@@ -24,6 +24,7 @@ import java.sql.Types;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -313,21 +314,36 @@ public class PostgreSQLDB extends BaseDB {
 
 					String nullable = template[template.length - 1];
 
-					if (!Validator.isBlank(nullable)) {
-						if (nullable.equals("not null")) {
-							line = line.concat(
-								StringUtil.replace(
-									"alter table @table@ alter column " +
-										"@old-column@ set not null;",
-									REWORD_TEMPLATE, template));
-						}
-						else {
-							line = line.concat(
-								StringUtil.replace(
-									"alter table @table@ alter column " +
-										"@old-column@ drop not null;",
-									REWORD_TEMPLATE, template));
-						}
+					if (Objects.equals(nullable, "not null")) {
+						line = line.concat(
+							StringUtil.replace(
+								"alter table @table@ alter column " +
+									"@old-column@ set not null;",
+								REWORD_TEMPLATE, template));
+					}
+					else {
+						line = line.concat(
+							StringUtil.replace(
+								"alter table @table@ alter column " +
+									"@old-column@ drop not null;",
+								REWORD_TEMPLATE, template));
+					}
+
+					String defaults = template[template.length - 2];
+
+					if (!Validator.isBlank(defaults)) {
+						line = line.concat(
+							StringUtil.replace(
+								"alter table @table@ alter column " +
+									"@old-column@ set default @default@;",
+								REWORD_TEMPLATE, template));
+					}
+					else {
+						line = line.concat(
+							StringUtil.replace(
+								"alter table @table@ alter column " +
+									"@old-column@ drop default;",
+								REWORD_TEMPLATE, template));
 					}
 				}
 				else if (line.startsWith(ALTER_TABLE_NAME)) {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -235,13 +235,6 @@ public abstract class BaseDBProcess implements DBProcess {
 			String tableName, String columnName, String newColumnType)
 		throws Exception {
 
-		String lowerCaseNewColumnType = StringUtil.lowerCase(newColumnType);
-
-		if (lowerCaseNewColumnType.contains(" default ")) {
-			throw new SQLException(
-				"Alter column type with default constraint is not allowed");
-		}
-
 		if (!hasColumn(tableName, columnName)) {
 			throw new SQLException(
 				StringBundler.concat(

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -60,6 +60,16 @@ public class DBInspector {
 		return _connection.getCatalog();
 	}
 
+	public String getColumnDefaultValue(String columnType) {
+		Matcher matcher = _columnDefaultClausePattern.matcher(columnType);
+
+		if (matcher.find()) {
+			return matcher.group(1);
+		}
+
+		return null;
+	}
+
 	public ResultSet getColumnsResultSet(String tableName) throws SQLException {
 		return _getColumnsResultSet(tableName, null);
 	}
@@ -164,7 +174,7 @@ public class DBInspector {
 
 			if (!expectedColumnNullable) {
 				return StringUtil.equals(
-					_getColumnDefaultValue(columnType),
+					getColumnDefaultValue(columnType),
 					_getColumnDefaultValue(
 						resultSet.getString("COLUMN_DEF"),
 						DB::getDefaultValue));
@@ -309,16 +319,6 @@ public class DBInspector {
 		return biFunction.apply(DBManagerUtil.getDB(), matcher.group(1));
 	}
 
-	private String _getColumnDefaultValue(String columnType) {
-		Matcher matcher = _columnDefaultClausePattern.matcher(columnType);
-
-		if (matcher.find()) {
-			return matcher.group(1);
-		}
-
-		return null;
-	}
-
 	private String _getColumnDefaultValue(
 		String columnDef, BiFunction<DB, String, String> biFunction) {
 
@@ -404,7 +404,7 @@ public class DBInspector {
 	private static final Log _log = LogFactoryUtil.getLog(DBInspector.class);
 
 	private static final Pattern _columnDefaultClausePattern = Pattern.compile(
-		".*DEFAULT '?(.*[^'])'? NOT NULL", Pattern.CASE_INSENSITIVE);
+		".*DEFAULT ('?.*[^']'?) NOT NULL", Pattern.CASE_INSENSITIVE);
 	private static final Pattern _columnSizePattern = Pattern.compile(
 		"^\\w+(?:\\((\\d+)\\))?.*", Pattern.CASE_INSENSITIVE);
 	private static final Pattern _columnTypePattern = Pattern.compile(

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -174,7 +174,7 @@ public class DBInspector {
 
 			if (!expectedColumnNullable) {
 				return StringUtil.equals(
-					getColumnDefaultValue(columnType),
+					StringUtil.unquote(getColumnDefaultValue(columnType)),
 					_getColumnDefaultValue(
 						resultSet.getString("COLUMN_DEF"),
 						DB::getDefaultValue));


### PR DESCRIPTION
__Ticket:__ <https://liferay.atlassian.net/browse/LPS-191724>

This PR does the following:

- Add support for `DEFAULT` clause for `DB.alterColumnType()` for all databases.
- Ensure that the result of `DB.alterColumnType()` is consistent across all databases.
- Fix bug in MySQL where `DB.alterColumnName()` converts `NOT NULL` columns to `NULL`.

Changes were made so that the following behaviors can be expected for all databases:

| Input                                                | Result                         |
|----------------------------------------------------------|--------------------------------|
| `column_name column_type`                                | set `NULL`, drop `DEFAULT`     |
| `column_name column_type NULL`                           | set `NULL`, drop `DEFAULT`     |
| `column_name column_type NOT NULL`                       | set `NOT NULL`, drop `DEFAULT` |
| `column_name column_type DEFAULT default_value NOT NULL` | set `NOT NULL`, add `DEFAULT`  |

Let me know if you have any questions.