### PR TITLE
LPS-194060 tests | Increase maximumPoolSize for upgrade db partition testcases 

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -11447,6 +11447,21 @@ ${update.properties}</echo>
 		<get-database-property property.name="database.url" />
 		<get-database-property property.name="database.username" />
 		<get-database-property property.name="database.version" />
+		<get-testcase-property property.name="database.partition.enabled" />
+		<get-testcase-property property.name="portal.version" />
+
+		<if>
+			<and>
+				<isset property="database.partition.enabled" />
+				<isset property="portal.version" />
+			</and>
+			<then>
+				<property name="maximumPoolSize" value="50" />
+			</then>
+			<else>
+				<property name="maximumPoolSize" value="30" />
+			</else>
+		</if>
 
 		<echo append="true" file="portal-impl/src/portal-ext.properties">
 
@@ -11461,7 +11476,7 @@ jdbc.default.password=${database.password}
 // HikariCP
 
 jdbc.default.connectionTimeout=600000
-jdbc.default.maximumPoolSize=30
+jdbc.default.maximumPoolSize=${maximumPoolSize}
 jdbc.default.minimumIdle=0
 
 enterprise.product.notification.enabled=false


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPS-194060 
- Locally passed and in CI the expected test passed from the failure related snippet we are trying to avoid([LPS-192230](https://liferay.atlassian.net/browse/LPS-192230)), later it fails due to [LPS-193273](https://liferay.atlassian.net/browse/LPS-193273).
- The change does not include continuous upgrade tests due to the non-use of specific properties, I don't think it's worth trying to adapt since these tests are unlikely to fall into this exception, since the tests will always be from the most recent update to the master and will require a small number of connections even if db partition is activated
