### PR TITLE
LPS-194194 Test Fix for UpgradeLifecycle#UpgradeProcessAndVerifyProcessOnlyRunOnFreshDB

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeLifecycle.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeLifecycle.testcase
@@ -84,10 +84,10 @@ definition {
 
 	@description = "LPS-162455: Given a user starts the portal with a database created previously. When property upgrade.database.auto.run is set to false. Then portal does not run any UpgradeProcess or VerifyProcess."
 	@priority = 4
-	test UpgradeProcessAndVerifyProcessOnlyRunOnFreshDB {
+	test UpgradeProcessAndVerifyProcessDoNotRunOnStaleDB {
 		property database.types = "db2,mariadb,mysql,oracle,postgresql";
 
-		AssertConsoleTextPresent(value1 = "UpgradeProcess");
+		AssertConsoleTextNotPresent(value1 = "UpgradeProcess");
 
 		AssertConsoleTextPresent(value1 = "VerifyProcess");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-194194

> ok, yea, so Shuyang fix what was actually a bug
> So the test should be updated to assume there is no UpgradeProcess on either startup

https://liferay.slack.com/archives/C03JAE7UMUP/p1692728864963969?thread_ts=1692724686.607649&cid=C03JAE7UMUP