### PR TITLE
LPS-192649 fix to support spaces

### DIFF
--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
@@ -186,8 +186,9 @@ public class DBUpgradeClient {
 			" -Dexternal-properties=portal-upgrade.properties " +
 				"-Dserver.detector.server.id=" +
 					_appServer.getServerDetectorServerId() +
-						" -Dliferay.shielded.container.lib.portal.dir=" +
-							_appServer.getPortalShieldedContainerLibDir());
+						" -Dliferay.shielded.container.lib.portal.dir=\"" +
+							_appServer.getPortalShieldedContainerLibDir() +
+								"\"");
 
 		System.out.println("JVM arguments: " + jvmOptsCommands);
 


### PR DESCRIPTION
Ticket:
[LPS-192649](https://liferay.atlassian.net/browse/LPS-192649)
Issue:
Using a blank space in the bundles directory can cause the process to close.

Solution:
Add quotes to included spaces.
