### PR TITLE
LPS-194060 tests | Increase maximumPoolSize for upgrade db partition testcases

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -11447,6 +11447,21 @@ ${update.properties}</echo>
 		<get-database-property property.name="database.url" />
 		<get-database-property property.name="database.username" />
 		<get-database-property property.name="database.version" />
+		<get-testcase-property property.name="database.partition.enabled" />
+		<get-testcase-property property.name="portal.version" />
+
+		<if>
+			<and>
+				<isset property="database.partition.enabled" />
+				<isset property="portal.version" />
+			</and>
+			<then>
+				<property name="database.maximum.pool.size" value="50" />
+			</then>
+			<else>
+				<property name="database.maximum.pool.size" value="30" />
+			</else>
+		</if>
 
 		<echo append="true" file="portal-impl/src/portal-ext.properties">
 
@@ -11461,7 +11476,7 @@ jdbc.default.password=${database.password}
 // HikariCP
 
 jdbc.default.connectionTimeout=600000
-jdbc.default.maximumPoolSize=30
+jdbc.default.maximumPoolSize=${database.maximum.pool.size}
 jdbc.default.minimumIdle=0
 
 enterprise.product.notification.enabled=false

--- a/build-test.xml
+++ b/build-test.xml
@@ -11442,11 +11442,6 @@ ${update.properties}</echo>
 			</then>
 		</if>
 
-		<get-database-property property.name="database.driver" />
-		<get-database-property property.name="database.password" />
-		<get-database-property property.name="database.url" />
-		<get-database-property property.name="database.username" />
-		<get-database-property property.name="database.version" />
 		<get-testcase-property property.name="database.partition.enabled" />
 		<get-testcase-property property.name="portal.version" />
 
@@ -11462,6 +11457,12 @@ ${update.properties}</echo>
 				<property name="database.max.pool.size" value="30" />
 			</else>
 		</if>
+
+		<get-database-property property.name="database.driver" />
+		<get-database-property property.name="database.password" />
+		<get-database-property property.name="database.url" />
+		<get-database-property property.name="database.username" />
+		<get-database-property property.name="database.version" />
 
 		<echo append="true" file="portal-impl/src/portal-ext.properties">
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -11456,10 +11456,10 @@ ${update.properties}</echo>
 				<isset property="portal.version" />
 			</and>
 			<then>
-				<property name="database.maximum.pool.size" value="50" />
+				<property name="database.max.pool.size" value="50" />
 			</then>
 			<else>
-				<property name="database.maximum.pool.size" value="30" />
+				<property name="database.max.pool.size" value="30" />
 			</else>
 		</if>
 
@@ -11476,7 +11476,7 @@ jdbc.default.password=${database.password}
 // HikariCP
 
 jdbc.default.connectionTimeout=600000
-jdbc.default.maximumPoolSize=${database.maximum.pool.size}
+jdbc.default.maximumPoolSize=${database.max.pool.size}
 jdbc.default.minimumIdle=0
 
 enterprise.product.notification.enabled=false


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPS-194060

Locally passed and in CI the expected test passed from the failure related snippet we are trying to avoid([LPS-192230](https://liferay.atlassian.net/browse/LPS-192230)), later it fails due to [LPS-193273](https://liferay.atlassian.net/browse/LPS-193273).
The change does not include continuous upgrade tests due to the non-use of specific properties, I don't think it's worth trying to adapt since these tests are unlikely to fall into this exception, since the tests will always be from the most recent update to the master and will require a small number of connections even if db partition is activated