### PR TITLE
LPS-193460 | Add hard refresh on db partition schedule tests to avoid cache conflicts

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
@@ -1528,12 +1528,14 @@ definition {
 		var displayDateMinute = selenium.getAttribute("//input[contains(@id,'displayDateMinute')]@value");
 
 		var displayDateMinuteFuture = ${displayDateMinute} + ${minuteIncrease};
-
+		var currentTime = "${displayDateHour}:${displayDateMinute} ${displayDateAmpm}";
 		var displayTime = "${displayDateHour}:${displayDateMinuteFuture} ${displayDateAmpm}";
 
 		WebContent.editDisplayDate(
 			displayDate = ${displayDate},
 			displayTime = ${displayTime});
+
+		echo("Web Content display time increased ${minuteIncrease} minutes from: ${currentTime} to: ${displayTime}");
 	}
 
 	macro moveArticlesToFolderCP {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
@@ -349,6 +349,8 @@ definition {
 
 		PortletEntry.publish();
 
+		TestUtils.hardRefresh();
+
 		AssertTextEquals(
 			key_webContentTitle = "Web Content Title",
 			locator1 = "WC#ENTRY_LIST_WORKFLOW_STATUS",
@@ -372,6 +374,8 @@ definition {
 		WebContent.increaseDisplayDate(minuteIncrease = 2);
 
 		PortletEntry.publish();
+
+		TestUtils.hardRefresh();
 
 		AssertTextEquals(
 			key_webContentTitle = "Web Content Title",
@@ -657,6 +661,8 @@ definition {
 
 			PortletEntry.publish();
 
+			TestUtils.hardRefresh();	
+
 			AssertTextEquals(
 				key_webContentTitle = "WC WebContent Title New Company",
 				locator1 = "WC#ENTRY_LIST_WORKFLOW_STATUS",
@@ -679,6 +685,8 @@ definition {
 			WebContent.increaseDisplayDate(minuteIncrease = 2);
 
 			PortletEntry.publish();
+
+			TestUtils.hardRefresh();
 
 			AssertTextEquals(
 				key_webContentTitle = "WC WebContent Title Default Company",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
@@ -661,7 +661,7 @@ definition {
 
 			PortletEntry.publish();
 
-			TestUtils.hardRefresh();	
+			TestUtils.hardRefresh();
 
 			AssertTextEquals(
 				key_webContentTitle = "WC WebContent Title New Company",


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPS-193460

Added an echo to display the current display time vs. after the it's changed.

![image](https://github.com/liferay-uniform/liferay-portal/assets/52680028/f00c2304-5967-4e19-92ec-a1ece099a635)

