### PR TITLE
LPS-163281 Investigate connection error on Websphere 9.0

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -9591,6 +9591,13 @@ org.apache.catalina.tribes.level = FINE]]>
 					</and>
 					<then>
 						<delete dir="${test.app.server.liferay.home}/osgi/state" />
+
+						<if>
+							<equals arg1="${app.server.type}" arg2="websphere" />
+							<then>
+								<delete dir="${test.app.server.liferay.home}/logs" />
+							</then>
+						</if>
 					</then>
 					<else>
 						<if>

--- a/build-test.xml
+++ b/build-test.xml
@@ -11250,6 +11250,17 @@ ${update.properties}</echo>
 			</then>
 		</if>
 
+		<!-- Temporarily increase tika log level until LPS-193838 -->
+
+		<var name="text.extractor.impl.log.level" value="WARN" />
+
+		<if>
+			<equals arg1="${app.server.type}" arg2="websphere" />
+			<then>
+				<var name="text.extractor.impl.log.level" value="ERROR" />
+			</then>
+		</if>
+
 		<get-testcase-property property.name="log.context.enabled" />
 
 		<if>
@@ -11329,6 +11340,8 @@ ${update.properties}</echo>
 		<Logger level="${release.local.service.impl.log.level}" name="com.liferay.portal.service.impl.ReleaseLocalServiceImpl" />
 
 		<Logger level="${dialect.detector.log.level}" name="com.liferay.portal.spring.hibernate.DialectDetector" />
+
+		<Logger level="${text.extractor.impl.log.level}" name="com.liferay.portal.tika.internal.extract.TextExtractorImpl" />
 
 		<Logger level="ERROR" name="com.zaxxer.hikari.pool.PoolBase" />
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-163281

Two issues with upgrade smoke tests on Websphere: Ex. [PortalSmokeUpgrade#ViewPortalSmokeArchive7413](https://testray.liferay.com/home/-/testray/case_results/2414373764)
1. Connection issue on startup
```
com.mysql.cj.jdbc.exceptions.CommunicationsException: Communications link failure

The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.
	at com.mysql.cj.jdbc.exceptions.SQLError.createCommunicationsException(SQLError.java:174) ~[mysql.jar:8.0.32]
```

- I was able to resolve this issue with 150f953a1949e5864c1458e1dfcf5017699629d8

----

2. null when reindexing

There is a bug ticket to fix the issue https://liferay.atlassian.net/browse/LPS-193838, but I wanted to temp ignore the error for now.

```
[beanshell] 2023-08-30 10:53:39.205 WARN  [default-26][TextExtractorImpl:102] null
[beanshell] org.apache.tika.exception.TikaException: Unexpected RuntimeException from org.apache.tika.parser.CompositeParser@cf21e772
[beanshell] 	at org.apache.tika.parser.CompositeParser.parse(CompositeParser.java:297) ~[?:?]
[beanshell] 	at org.apache.tika.parser.AutoDetectParser.parse(AutoDetectParser.java:143) ~[?:?]
[beanshell] 	at com.liferay.portal.tika.internal.extract.TextExtractorImpl._parseToString(TextExtractorImpl.java:182) ~[?:?]
[beanshell] 	at com.liferay.portal.tika.internal.extract.TextExtractorImpl.extractText(TextExtractorImpl.java:95) ~[?:?]
```

- I tried increasing the log level from WARN to ERROR in 1570118aeeaeec1d31abf12b578a144cf72e5802, but the error is still present. 
- I tried decreasing the log level from WARN to INFO, but the error is still present.

I'm thinking maybe I'm trying to modify the wrong class? I picked **com.liferay.portal.tika.internal.extract.TextExtractorImpl** because that's where the null is being thrown `WARN  [default-26][TextExtractorImpl:102]`. Also when I reverted https://github.com/liferay/liferay-portal/commit/810cea1560a1c132deb83e1267ffe35fd29c69d7 locally the issue was not present. 