### PR TITLE
LPS-189787 Improve start-app-server-tomcat-simple target to run on JDK 11

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -16502,9 +16502,16 @@ CATALINA_OPTS="$CATALINA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.managemen
 	</target>
 
 	<target name="start-app-server-tomcat-simple">
+		<get-java-jdk-bundle-version test.batch.name="${test.batch.name}" />
+
+		<get-java-jdk-bundle-type test.batch.name="${test.batch.name}" />
+
+		<get-java-jdk-home type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+
 		<trycatch property="startup.error">
 			<try>
 				<exec executable="${app.server.tomcat.bin.dir}/catalina.sh" failonerror="true" timeout="600000">
+					<env key="JAVA_HOME" value="${java.jdk.home}" />
 					<arg line="run" />
 				</exec>
 			</try>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeEnhancement.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeEnhancement.testcase
@@ -11,6 +11,8 @@ definition {
 
 	@priority = 4
 	test DecrementCoreSchemaMajorVersion {
+		property test.run.type = "single";
+
 		var script = '''
 			import com.liferay.portal.kernel.model.*;
 			import com.liferay.portal.kernel.service.ReleaseLocalServiceUtil;
@@ -47,6 +49,8 @@ definition {
 
 	@priority = 4
 	test DecrementCoreSchemaMicroVersion {
+		property test.run.type = "single";
+
 		var script = '''
 			import com.liferay.portal.kernel.model.*;
 			import com.liferay.portal.kernel.service.ReleaseLocalServiceUtil;
@@ -94,6 +98,8 @@ definition {
 
 	@priority = 3
 	test DecrementCoreSchemaMinorVersion {
+		property test.run.type = "single";
+
 		var script = '''
 			import com.liferay.portal.kernel.model.*;
 			import com.liferay.portal.kernel.service.ReleaseLocalServiceUtil;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-189787

Tests pass on JDK11: https://github.com/susanchen3/liferay-portal/pull/235#issuecomment-1709205727

**Background:** 
Tests using the `start-app-server-tomcat-simple` target did not start portal on JDK 11 because CI switches between JDK 8 and JDK 11. I believe when CI tried to run the target, it was on JDK 8, therefore not recognizing **-Xlog:gc:/tmp/tomcat-gc.log**.
```
Unrecognized option: -Xlog:gc:/tmp/tomcat-gc.log
```

**Solution:**
Pass in JDK environment variables to start up tomcat. 