### PR TITLE
LPS-195486 Have database upgrade client tests run individually in ci

### DIFF
--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
@@ -11,6 +11,7 @@ definition {
 	property portal.version = "6.2.10.21";
 	property skip.start.app.server = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testcase.url = "http://www.example.com";
 	property testray.main.component.name = "Database Upgrade Tool";
 


### PR DESCRIPTION
**Description**
A few database upgrade client tests were failing on `check-upgrade-client-*`. It looks like the test depends on some generated files from the setup phase but are cleaned up in the teardown due to grouped testing on CI. See https://liferay.atlassian.net/browse/LPS-195561 for more details of the CI/poshi change affecting most upgrade tests. 

_Proposed solution_
Run these tests individually on CI to prevent contamination from other tests' teardown phase.

**Test Plan**
- [x] [affected database upgrade client tests](https://testray.liferay.com/home/-/testray/subtasks/2419828198) are more stable and generated files can be checked correctly by respective tests. - passed in https://github.com/john-co/liferay-portal/pull/511

**JIRA Ticket**
https://liferay.atlassian.net/browse/LPS-195486