### PR TITLE
LPS-194537 Uniform QA | Point testcase.url to file system directory for tests that have custom startup

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testFunctional/tests/UpgradeManagerMbean.testcase
+++ b/modules/apps/portal/portal-upgrade-test/src/testFunctional/tests/UpgradeManagerMbean.testcase
@@ -9,6 +9,7 @@ definition {
 	property portal.upstream = "true";
 	property skip.start.app.server = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Database Upgrade Framework";
 
 	@priority = 3

--- a/modules/apps/portal/portal-upgrade-test/src/testFunctional/tests/UpgradeManagerMbean.testcase
+++ b/modules/apps/portal/portal-upgrade-test/src/testFunctional/tests/UpgradeManagerMbean.testcase
@@ -10,6 +10,7 @@ definition {
 	property skip.start.app.server = "true";
 	property test.liferay.virtual.instance = "false";
 	property test.run.type = "single";
+	property testcase.url = "file:///opt/dev/projects/github/liferay-portal/";
 	property testray.main.component.name = "Database Upgrade Framework";
 
 	@priority = 3

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
@@ -9,6 +9,7 @@ definition {
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
 	property test.run.type = "single";
+	property testcase.url = "file:///opt/dev/projects/github/liferay-portal/";
 	property testray.main.component.name = "Database Upgrade Framework";
 
 	@priority = 4
@@ -16,7 +17,6 @@ definition {
 		property database.bare.enabled = "true";
 		property skip.start.app.server = "true";
 		property test.assert.warning.exceptions = "true";
-		property testcase.url = "http://www.example.com";
 
 		var releaseBundleVersion = PropsUtil.get("test.released.release.bundle.version");
 		var releaseBundleZipURL = PropsUtil.get("test.released.test.portal.bundle.zip.url");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
@@ -8,6 +8,7 @@ definition {
 	property portal.smoke.upgrades = "false";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Database Upgrade Framework";
 
 	@priority = 4

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
@@ -15,6 +15,7 @@ definition {
 		property database.bare.enabled = "true";
 		property database.partition.enabled = "true";
 		property skip.start.app.server = "true";
+		property testcase.url = "file:///opt/dev/projects/github/liferay-portal/";
 
 		var releaseBundleVersion = PropsUtil.get("test.released.release.bundle.version");
 		var releaseBundleZipURL = PropsUtil.get("test.released.test.portal.bundle.zip.url");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
@@ -7,6 +7,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Database Upgrade Framework";
 
 	@priority = 4


### PR DESCRIPTION
**Description**
We faced errors(ERR_CONNECTION_RESET) when connecting Chrome webDriver in tests that start up portal itself

_Proposed solution_
Properly run the tests on a single instance and limit external connections setting testcase.url to a directory(liferay-portal) on the file system. 

- Tested at : https://github.com/lucasperj/liferay-portal/pull/377
 
**JIRA Ticket**
https://liferay.atlassian.net/browse/LPS-194537 | https://liferay.atlassian.net/browse/LPS-195484