### PR TITLE
LPS-195984 Automate error checking when Upgrade Tool is unable to connect to GogoShell

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -14175,6 +14175,16 @@ company.default.web.id=www.able.com</echo>
 			</then>
 		</if>
 
+		<get-testcase-property property.name="custom.upgrade.properties" />
+
+		<if>
+			<isset property="custom.upgrade.properties" />
+			<then>
+				<echo append="true" file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">
+${custom.upgrade.properties}</echo>
+			</then>
+		</if>
+
 		<get-test-app-server-lib-portal-dir />
 
 		<if>

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml
@@ -81,9 +81,7 @@
 
 		<prepare-database-upgrade-properties />
 
-		<execute dir="${db.upgrade.client.home}">
-			db_upgrade_client${file.suffix.bat} run
-		</execute>
+		<antcall inheritAll="false" target="run-upgrade-client" />
 
 		<waitfor maxwait="300" maxwaitunit="second" timeoutproperty="upgrade.not.failed">
 			<resourcecontains
@@ -306,20 +304,6 @@
 		<echo>The upgrade client printed out the exception successfully.</echo>
 	</target>
 
-	<target name="check-upgrade-client-gogoshell-failed-upgrade">
-		<get-database-upgrade-client-paths />
-
-		<sql classpath="${app.server.shielded-container-lib.portal.dir}/${jdbc.mysql.driver}" driver="${database.mysql.driver}" onerror="continue" output="output.txt" password="${database.mysql.password}" print="true" url="${database.mysql.url}" userid="${database.mysql.username}">
-			<![CDATA[
-				ALTER TABLE JournalArticle DROP type_;
-			]]>
-		</sql>
-
-		<execute dir="${db.upgrade.client.home}">
-			db_upgrade_client${file.suffix.bat} run
-		</execute>
-	</target>
-
 	<target name="check-upgrade-client-gogoshell-help-output">
 		<get-database-upgrade-client-paths />
 
@@ -499,17 +483,6 @@
 				<fail if="upgrade.failed" message="Upgrade has failed." />
 			</sequential>
 		</parallel>
-	</target>
-
-	<target name="check-upgrade-client-upgrade-core-only">
-		<get-database-upgrade-client-paths />
-
-		<echo append="true" file="${db.upgrade.client.home}/portal-upgrade-ext.properties">
-upgrade.database.auto.run=false</echo>
-
-		<execute dir="${db.upgrade.client.home}">
-			db_upgrade_client${file.suffix.bat} run
-		</execute>
 	</target>
 
 	<target name="check-upgrade-client-zip-content">
@@ -706,5 +679,13 @@ upgrade.database.auto.run=false</echo>
 			expect.file="execute-all-pending-upgrades-from-gogo-shell.expect"
 			file.suffix.bat="${file.suffix.bat}"
 		/>
+	</target>
+
+	<target name="run-upgrade-client">
+		<get-database-upgrade-client-paths />
+
+		<execute dir="${db.upgrade.client.home}">
+			db_upgrade_client${file.suffix.bat} run
+		</execute>
 	</target>
 </project>

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml
@@ -268,6 +268,44 @@
 		</fail>
 	</target>
 
+	<target name="check-upgrade-client-gogoshell-failed-connection-error">
+		<get-database-upgrade-client-paths />
+
+		<if>
+			<not>
+				<available file="${selenium.output.dir.name}" type="dir" />
+			</not>
+			<then>
+				<mkdir dir="${selenium.output.dir.name}" />
+			</then>
+		</if>
+
+		<execute dir="${db.upgrade.client.home}">
+			db_upgrade_client${file.suffix.bat} run > ${selenium.output.dir.name}/gogoshell.failed.connection.output
+		</execute>
+
+		<loadfile
+			property="upgrade.gogoshell.failed.connection.output"
+			srcFile="${selenium.output.dir.name}/gogoshell.failed.connection.output"
+		/>
+
+		<echo>${upgrade.gogoshell.failed.connection.output}</echo>
+
+		<if>
+			<not>
+				<and>
+					<contains string="${upgrade.gogoshell.failed.connection.output}" substring="Connecting to Gogo shell because the upgrade failed or is incomplete" />
+					<contains string="${upgrade.gogoshell.failed.connection.output}" substring="java.net.ConnectException: Connection refused" />
+				</and>
+			</not>
+			<then>
+				<fail message="The upgrade client failed to print out the exception." />
+			</then>
+		</if>
+
+		<echo>The upgrade client printed out the exception successfully.</echo>
+	</target>
+
 	<target name="check-upgrade-client-gogoshell-failed-upgrade">
 		<get-database-upgrade-client-paths />
 

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
@@ -60,11 +60,12 @@ definition {
 	@description = "LPS-158522: Upgrade client can connect to Gogo Shell with a failed upgrade"
 	@priority = 4
 	test CheckUpgradeClientGogoShellFailedUpgrade {
+		property custom.mysql.sql.statement = "ALTER TABLE JournalArticle DROP type_;";
 		property skip.get.testcase.database.properties = "true";
 		property skip.upgrade-legacy-database = "true";
 		property timeout.explicit.wait = "490";
 
-		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-upgrade-client-gogoshell-failed-upgrade");
+		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "run-upgrade-client");
 
 		WaitForConsoleTextPresent(value1 = "Failed upgrade process for module com.liferay.journal.service");
 
@@ -116,11 +117,12 @@ definition {
 	@description = "LPS-158522: Upgrade client only upgrades core"
 	@priority = 2
 	test CheckUpgradeClientUpgradeCoreOnly {
+		property custom.upgrade.properties = "upgrade.database.auto.run=false";
 		property skip.get.testcase.database.properties = "true";
 		property skip.upgrade-legacy-database = "true";
 		property timeout.explicit.wait = "490";
 
-		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-upgrade-client-upgrade-core-only");
+		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "run-upgrade-client");
 
 		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-unresolved-upgrade-log");
 

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
@@ -31,6 +31,20 @@ definition {
 		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-upgrade-client-custom-log");
 	}
 
+	@description = "LPS-195984:  Upgrade client throws error when Gogo Shell is unable to connect."
+	@priority = 2
+	test CheckUpgradeClientFailedGogoShellReturnsError {
+		property custom.mysql.sql.statement = "ALTER TABLE JournalArticle DROP type_;";
+		property custom.upgrade.properties = "module.framework.properties.osgi.console=80";
+		property skip.get.testcase.database.properties = "true";
+		property skip.upgrade-legacy-database = "true";
+		property timeout.explicit.wait = "490";
+
+		task ("Assert error is printed when the Gogo Shell fails to connect") {
+			AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-upgrade-client-gogoshell-failed-connection-error");
+		}
+	}
+
 	@description = "LPS-158522: Upgrade client can connect to Gogo Shell"
 	@priority = 3
 	test CheckUpgradeClientGogoShell {

--- a/test.properties
+++ b/test.properties
@@ -10302,6 +10302,7 @@
         custom.properties,\
         custom.startup.log.message,\
         custom.system.properties,\
+        custom.upgrade.properties,\
         data.archive.type,\
         database.auto.upgrade.enabled,\
         database.bare.enabled,\


### PR DESCRIPTION
**Background**
Automate [LPS-191597](https://liferay.atlassian.net/browse/LPS-191597). 

> [line 269 of DBUgradeClient](https://github.com/liferay/liferay-portal/blob/7.4.3.85-ga85/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java#L264-L269) immediately follows an ignored exception that I’d like to have seen

The exception should be printed out instead of being swallowed/ignored when the GogoShell fails to connect. 

**Test Plan**
1. Import database
2. Throw an error during upgrade process to force attempt to access GogoShell
3. Force a connection error to the GogoShell
4. Run upgrade tool 

**JIRA Ticket:**
https://liferay.atlassian.net/browse/LPS-195984