### PR TITLE
LPS-195811 Uniform QA | Fix DB Partition schedule tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/DateTimeSchedule.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DateTimeSchedule.macro
@@ -35,6 +35,13 @@ definition {
 
 		var displayDateMinuteFuture = ${displayDateMinute} + ${minuteIncreaseValue};
 
+		var minuteExceededValidator = MathUtil.isGreaterThanOrEqualTo(${displayDateMinuteFuture}, 60);
+
+		if (${minuteExceededValidator} == "true") {
+			var displayDateHour = ${displayDateHour} + 1;
+			var displayDateMinuteFuture = ${displayDateMinuteFuture} - 60;
+		}
+
 		var displayTime = "${displayDateHour}:${displayDateMinuteFuture} ${displayDateAmpm}";
 
 		return ${displayTime};

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DateTimeSchedule.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DateTimeSchedule.macro
@@ -10,12 +10,25 @@ definition {
 
 	macro getCurrentDisplayTime {
 		var displayDateHour = selenium.getAttribute("//input[contains(@id,'displayDateHour')]@value");
+
+		var displayDateHourLength = StringUtil.length(${displayDateHour});
+
+		if (${displayDateHourLength} == 1) {
+			var displayDateHour = "0${displayDateHour}";
+		}
+
 		var displayDateAmpm = selenium.getAttribute("//input[contains(@id,'displayDateAmPm')]@value");
 
 		var displayDateAmpm = StringUtil.replace(${displayDateAmpm}, 0, "AM");
 
 		var displayDateAmpm = StringUtil.replace(${displayDateAmpm}, 1, "PM");
 		var displayDateMinute = selenium.getAttribute("//input[contains(@id,'displayDateMinute')]@value");
+
+		var displayDateMinuteLength = StringUtil.length(${displayDateMinute});
+
+		if (${displayDateMinuteLength} == 1) {
+			var displayDateMinute = "0${displayDateMinute}";
+		}
 
 		var currentTime = "${displayDateHour}:${displayDateMinute} ${displayDateAmpm}";
 
@@ -40,6 +53,18 @@ definition {
 		if (${minuteExceededValidator} == "true") {
 			var displayDateHour = ${displayDateHour} + 1;
 			var displayDateMinuteFuture = ${displayDateMinuteFuture} - 60;
+		}
+
+		var displayDateHourLength = StringUtil.length(${displayDateHour});
+
+		if (${displayDateHourLength} == 1) {
+			var displayDateHour = "0${displayDateHour}";
+		}
+
+		var displayDateMinuteFutureLength = StringUtil.length(${displayDateMinuteFuture});
+
+		if (${displayDateMinuteFutureLength} == 1) {
+			var displayDateMinuteFuture = "0${displayDateMinuteFuture}";
 		}
 
 		var displayTime = "${displayDateHour}:${displayDateMinuteFuture} ${displayDateAmpm}";

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DateTimeSchedule.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DateTimeSchedule.macro
@@ -1,0 +1,43 @@
+definition {
+
+	macro getCurrentDisplayDate {
+		var displayDate = selenium.getAttribute("//input[contains(@id,'displayDate')]@value");
+
+		echo("Current display date is: ${displayDate}");
+
+		return ${displayDate};
+	}
+
+	macro getCurrentDisplayTime {
+		var displayDateHour = selenium.getAttribute("//input[contains(@id,'displayDateHour')]@value");
+		var displayDateAmpm = selenium.getAttribute("//input[contains(@id,'displayDateAmPm')]@value");
+
+		var displayDateAmpm = StringUtil.replace(${displayDateAmpm}, 0, "AM");
+
+		var displayDateAmpm = StringUtil.replace(${displayDateAmpm}, 1, "PM");
+		var displayDateMinute = selenium.getAttribute("//input[contains(@id,'displayDateMinute')]@value");
+
+		var currentTime = "${displayDateHour}:${displayDateMinute} ${displayDateAmpm}";
+
+		echo("Current display time is: ${currentTime}");
+
+		return ${currentTime};
+	}
+
+	macro increaseDisplayTime {
+		var displayDateHour = selenium.getAttribute("//input[contains(@id,'displayDateHour')]@value");
+		var displayDateAmpm = selenium.getAttribute("//input[contains(@id,'displayDateAmPm')]@value");
+
+		var displayDateAmpm = StringUtil.replace(${displayDateAmpm}, 0, "AM");
+
+		var displayDateAmpm = StringUtil.replace(${displayDateAmpm}, 1, "PM");
+		var displayDateMinute = selenium.getAttribute("//input[contains(@id,'displayDateMinute')]@value");
+
+		var displayDateMinuteFuture = ${displayDateMinute} + ${minuteIncreaseValue};
+
+		var displayTime = "${displayDateHour}:${displayDateMinuteFuture} ${displayDateAmpm}";
+
+		return ${displayTime};
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DateTimeSchedule.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DateTimeSchedule.macro
@@ -1,7 +1,9 @@
 definition {
 
 	macro getCurrentDisplayDate {
-		var displayDate = selenium.getAttribute("//input[contains(@id,'displayDate')]@value");
+		var key_field = ${field};
+
+		var displayDate = selenium.getAttribute("//input[contains(@id,'${key_field}Date')]@value");
 
 		echo("Current display date is: ${displayDate}");
 
@@ -9,7 +11,9 @@ definition {
 	}
 
 	macro getCurrentDisplayTime {
-		var displayDateHour = selenium.getAttribute("//input[contains(@id,'displayDateHour')]@value");
+		var key_field = ${field};
+
+		var displayDateHour = selenium.getAttribute("//input[contains(@id,'${key_field}DateHour')]@value");
 
 		var displayDateHourLength = StringUtil.length(${displayDateHour});
 
@@ -17,12 +21,12 @@ definition {
 			var displayDateHour = "0${displayDateHour}";
 		}
 
-		var displayDateAmpm = selenium.getAttribute("//input[contains(@id,'displayDateAmPm')]@value");
+		var displayDateAmpm = selenium.getAttribute("//input[contains(@id,'${key_field}DateAmPm')]@value");
 
 		var displayDateAmpm = StringUtil.replace(${displayDateAmpm}, 0, "AM");
 
 		var displayDateAmpm = StringUtil.replace(${displayDateAmpm}, 1, "PM");
-		var displayDateMinute = selenium.getAttribute("//input[contains(@id,'displayDateMinute')]@value");
+		var displayDateMinute = selenium.getAttribute("//input[contains(@id,'${key_field}DateMinute')]@value");
 
 		var displayDateMinuteLength = StringUtil.length(${displayDateMinute});
 
@@ -38,13 +42,15 @@ definition {
 	}
 
 	macro increaseDisplayTime {
-		var displayDateHour = selenium.getAttribute("//input[contains(@id,'displayDateHour')]@value");
-		var displayDateAmpm = selenium.getAttribute("//input[contains(@id,'displayDateAmPm')]@value");
+		var key_field = ${field};
+
+		var displayDateHour = selenium.getAttribute("//input[contains(@id,'${key_field}DateHour')]@value");
+		var displayDateAmpm = selenium.getAttribute("//input[contains(@id,'${key_field}DateAmPm')]@value");
 
 		var displayDateAmpm = StringUtil.replace(${displayDateAmpm}, 0, "AM");
 
 		var displayDateAmpm = StringUtil.replace(${displayDateAmpm}, 1, "PM");
-		var displayDateMinute = selenium.getAttribute("//input[contains(@id,'displayDateMinute')]@value");
+		var displayDateMinute = selenium.getAttribute("//input[contains(@id,'${key_field}DateMinute')]@value");
 
 		var displayDateMinuteFuture = ${displayDateMinute} + ${minuteIncreaseValue};
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
@@ -519,36 +519,9 @@ definition {
 				value1 = ${scheduleTitleName});
 		}
 
-		var displayDateHour = selenium.getAttribute("//input[contains(@id,'schedulerStartDateHour')]@value");
-		var displayDateAmpm = selenium.getAttribute("//input[contains(@id,'schedulerStartDateAmPm')]@value");
-
-		var displayDateAmpm = StringUtil.replace(${displayDateAmpm}, 0, "AM");
-
-		var displayDateAmpm = StringUtil.replace(${displayDateAmpm}, 1, "PM");
-		var displayDateMinute = selenium.getAttribute("//input[contains(@id,'schedulerStartDateMinute')]@value");
-
-		var displayDateMinuteFuture = ${displayDateMinute} + 5;
-
-		var result = MathUtil.isGreaterThan(${displayDateMinuteFuture}, 60);
-
-		if (${result} == "true") {
-			var displayDateHour = ${displayDateHour} + 1;
-			var displayDateMinuteFuture = ${displayDateMinuteFuture} - 60;
-		}
-
-		var displayDateHourLength = StringUtil.length(${displayDateHour});
-
-		if (${displayDateHourLength} == 1) {
-			var displayDateHour = "0${displayDateHour}";
-		}
-
-		var displayDateMinuteFutureLength = StringUtil.length(${displayDateMinuteFuture});
-
-		if (${displayDateMinuteFutureLength} == 1) {
-			var displayDateMinuteFuture = "0${displayDateMinuteFuture}";
-		}
-
-		var displayDate = "${displayDateHour}:${displayDateMinuteFuture} ${displayDateAmpm}";
+		var displayDate = DateTimeSchedule.increaseDisplayTime(
+			field = "start",
+			minuteIncreaseValue = 5);
 
 		Type.sendKeys(
 			locator1 = "StagingPublishToLive#DATE_SCHEDULE_TIME_INPUT",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
@@ -1541,24 +1541,17 @@ definition {
 	}
 
 	macro increaseDisplayDate {
-		var displayDate = selenium.getAttribute("//input[contains(@id,'displayDate')]@value");
-		var displayDateHour = selenium.getAttribute("//input[contains(@id,'displayDateHour')]@value");
-		var displayDateAmpm = selenium.getAttribute("//input[contains(@id,'displayDateAmPm')]@value");
+		var displayDate = DateTimeSchedule.getCurrentDisplayDate();
 
-		var displayDateAmpm = StringUtil.replace(${displayDateAmpm}, 0, "AM");
+		DateTimeSchedule.getCurrentDisplayTime();
 
-		var displayDateAmpm = StringUtil.replace(${displayDateAmpm}, 1, "PM");
-		var displayDateMinute = selenium.getAttribute("//input[contains(@id,'displayDateMinute')]@value");
-
-		var displayDateMinuteFuture = ${displayDateMinute} + ${minuteIncrease};
-		var currentTime = "${displayDateHour}:${displayDateMinute} ${displayDateAmpm}";
-		var displayTime = "${displayDateHour}:${displayDateMinuteFuture} ${displayDateAmpm}";
+		var displayTime = DateTimeSchedule.increaseDisplayTime(minuteIncreaseValue = ${minuteIncrease});
 
 		WebContent.editDisplayDate(
 			displayDate = ${displayDate},
 			displayTime = ${displayTime});
 
-		echo("Web Content display time increased ${minuteIncrease} minutes from: ${currentTime} to: ${displayTime}");
+		echo("Web Content display time increased ${minuteIncrease} minutes, changed to: ${displayTime}");
 	}
 
 	macro moveArticlesToFolderCP {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
@@ -1541,11 +1541,13 @@ definition {
 	}
 
 	macro increaseDisplayDate {
-		var displayDate = DateTimeSchedule.getCurrentDisplayDate();
+		var displayDate = DateTimeSchedule.getCurrentDisplayDate(field = "display");
 
-		DateTimeSchedule.getCurrentDisplayTime();
+		DateTimeSchedule.getCurrentDisplayTime(field = "display");
 
-		var displayTime = DateTimeSchedule.increaseDisplayTime(minuteIncreaseValue = ${minuteIncrease});
+		var displayTime = DateTimeSchedule.increaseDisplayTime(
+			field = "display",
+			minuteIncreaseValue = ${minuteIncrease});
 
 		WebContent.editDisplayDate(
 			displayDate = ${displayDate},

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
@@ -382,9 +382,9 @@ definition {
 			locator1 = "WC#ENTRY_LIST_WORKFLOW_STATUS",
 			value1 = "SCHEDULED");
 
-		// Pausing 150 seconds due to LRQA-75909
+		// Pausing 210 seconds due to LRQA-75909
 
-		Pause(locator1 = 150000);
+		Pause(locator1 = 210000);
 
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "Guest");
 
@@ -696,9 +696,9 @@ definition {
 
 		task ("View WebContent Article Publish on default Company") {
 
-			// Pausing 150 seconds due to LRQA-75909
+			// Pausing 210 seconds due to LRQA-75909
 
-			Pause(locator1 = 150000);
+			Pause(locator1 = 210000);
 
 			ProductMenu.gotoPortlet(
 				category = "Content & Data",


### PR DESCRIPTION
Description
1. These types of tests are susceptible to errors in the steps that involve changing the status of the asset in use (Web Content). 
2. Errors were also noticed when when adding the minutes (using `increaseDisplayDate` macro) it reaches the hour limit (60 minutes), and after doing the minutes append, it does not change the hour, but keeps currentHour:61/62/63 etc.
Example: [Console](https://testray.liferay.com/reports/production/logs/2023-09/test-1-26/test-portal-testsuite-upstream(master)/3359/functional-tomcat90-mysql57-jdk8/1/9/jenkins-console.txt.gz?authuser=0)
![image](https://github.com/liferay-uniform/liferay-portal/assets/52680028/1d346503-58e4-403e-9719-1b043c8684df)


Proposed solution
1. Increase the display time to avoid falling within the 60 second gap defined in checkInterval 
2. Count for cases where after the append exceeds the hour limit checking with a `for` the minute **after** the append, modifying the hour the minutes if the condition is true.

Tested at : https://github.com/lucasperj/liferay-portal/pull/382
JIRA Ticket : https://liferay.atlassian.net/browse/LPS-195811