### PR TITLE
LPS-196242 - Check that the value is not duplicated for this preference.

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradePortletPreferences.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradePortletPreferences.java
@@ -95,8 +95,15 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 		for (Preference preference : preferenceMap.values()) {
 			String[] values = preference.getValues();
 
+			outerLoop:
 			for (int i = 0; i < values.length; i++) {
 				String value = values[i];
+
+				for (int j = 0; j < i; j++) {
+					if (values[j].equals(value)) {
+						continue outerLoop;
+					}
+				}
 
 				String largeValue = null;
 				String smallValue = null;


### PR DESCRIPTION
Before upgrade, in 7.0 the customer has some entries in PortletPreferences table with the following value:

```
<preference>
<name>entryColumns</name>(...)
<value>action</value>
<value>action</value>
</preference>
```
After migration to 7.4 for each previous record in 7.0 two records are created in the PortletPreferencesValue table with the value "action" in the SMALLVALUE column.

With these changes we correct the duplication and ensure that the behavior does not recur in other cases.