### PR TITLE
LPS-195561 Run upgrade tests individually

### DIFF
--- a/modules/apps/account/account-test/src/testFunctional/tests/AccountUpgrade.testcase
+++ b/modules/apps/account/account-test/src/testFunctional/tests/AccountUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Account";
 	property testray.main.component.name = "Upgrades User and System Management";
 

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/tests/CalendarUpgrade.testcase
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/tests/CalendarUpgrade.testcase
@@ -4,6 +4,7 @@ definition {
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
 	property portal.release = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Calendar";
 	property testray.main.component.name = "Upgrades Calendar";
 

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceUpgrade.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Commerce";
 
 	setUp {

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/upgrades/wem/LocalizedWebContentUpgrade.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/upgrades/wem/LocalizedWebContentUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Data Engine";
 	property testray.main.component.name = "Upgrades Data Engine";
 

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/upgrades/wem/StructuresUpgrade.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/upgrades/wem/StructuresUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Data Engine";
 	property testray.main.component.name = "Upgrades Data Engine";
 

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotLocalStagingUpgrade.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotLocalStagingUpgrade.testcase
@@ -7,6 +7,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Depot";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/modules/apps/layout/layout-admin-web-test/src/testFunctional/tests/PageFriendlyURLUpgrade.testcase
+++ b/modules/apps/layout/layout-admin-web-test/src/testFunctional/tests/PageFriendlyURLUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Friendly URL Service";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testFunctional/tests/ContentPageReviewUpgrade.testcase
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testFunctional/tests/ContentPageReviewUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Content Page Review";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/modules/apps/layout/layout-seo-web-test/src/testFunctional/tests/CustomMetaTagsUpgrade.testcase
+++ b/modules/apps/layout/layout-seo-web-test/src/testFunctional/tests/CustomMetaTagsUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "SEO";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/modules/apps/layout/layout-seo-web-test/src/testFunctional/tests/OpenGraphUpgrade.testcase
+++ b/modules/apps/layout/layout-seo-web-test/src/testFunctional/tests/OpenGraphUpgrade.testcase
@@ -7,6 +7,7 @@ definition {
 	property test.assert.liferay.errors = "false";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "SEO";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/modules/apps/layout/layout-seo-web-test/src/testFunctional/tests/SERPPreviewUpgrade.testcase
+++ b/modules/apps/layout/layout-seo-web-test/src/testFunctional/tests/SERPPreviewUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "SEO";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectNotificationsUpgrade.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectNotificationsUpgrade.testcase
@@ -4,6 +4,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "quarantine";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Object";
 	property testray.main.component.name = "Upgrades Object";
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectUpgrade.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectUpgrade.testcase
@@ -4,6 +4,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "quarantine";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Object";
 	property testray.main.component.name = "Upgrades Object";
 

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/tests/WorkflowUpgrade.testcase
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/tests/WorkflowUpgrade.testcase
@@ -4,6 +4,7 @@ definition {
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
 	property portal.release = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Workflow";
 	property testray.main.component.name = "Upgrades Workflow";
 

--- a/modules/apps/redirect/redirect-test/src/testFunctional/tests/RedirectUpgrade.testcase
+++ b/modules/apps/redirect/redirect-test/src/testFunctional/tests/RedirectUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Redirect";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsUpgrade.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Translations Management";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-test/src/testFunctional/tests/OneDriveUpgrade.testcase
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-test/src/testFunctional/tests/OneDriveUpgrade.testcase
@@ -7,6 +7,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Online Editing";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/modules/dxp/apps/portal-rules-engine-drools/portal-rules-engine-drools-test/src/testFunctional/tests/DroolsUpgrade.testcase
+++ b/modules/dxp/apps/portal-rules-engine-drools/portal-rules-engine-drools-test/src/testFunctional/tests/DroolsUpgrade.testcase
@@ -7,6 +7,7 @@ definition {
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
 	property test.run.environment = "EE";
+	property test.run.type = "single";
 	property testray.main.component.name = "Upgrades Rules";
 
 	setUp {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/dependencies/WorkflowMetricsUpgrade.testcase
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/dependencies/WorkflowMetricsUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Workflow Metrics";
 	property testray.main.component.name = "Upgrades Workflow";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchContinuousUpgrade.testcase
@@ -11,6 +11,7 @@ definition {
 	property skip.start.app.server = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Upgrades Search";
 
 	@priority = 5

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.suite.search.engine = "elasticsearch7,solr";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Upgrades Search";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/openidconnect/OpenIDConnectUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/openidconnect/OpenIDConnectUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "OpenID Connect";
 	property testray.main.component.name = "Upgrades Security";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/upgrades/CORSUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/upgrades/CORSUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Security";
 	property testray.main.component.name = "Upgrades Security";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/upgrades/LDAPUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/upgrades/LDAPUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "LDAP";
 	property testray.main.component.name = "Upgrades Security";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/upgrades/OAuth2Upgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/upgrades/OAuth2Upgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "OAuth 2";
 	property testray.main.component.name = "Upgrades Security";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/AFSStoreUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/AFSStoreUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Database Upgrade Framework";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/AWSStoreContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/AWSStoreContinuousUpgrade.testcase
@@ -12,6 +12,7 @@ definition {
 	property skip.start.app.server = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Database Upgrade Framework";
 
 	@priority = 4

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DBStoreUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DBStoreUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Database Upgrade Framework";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
@@ -10,6 +10,7 @@ definition {
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
 	property test.run.environment = "EE";
+	property test.run.type = "single";
 	property testray.main.component.name = "Database Partitioning";
 
 	@priority = 5

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/OrganizationUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/OrganizationUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Users and Organizations";
 	property testray.main.component.name = "Upgrades User and System Management";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalConfigurationUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalConfigurationUpgrade.testcase
@@ -7,6 +7,7 @@ definition {
 	property portal.smoke.upgrades = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Portal Configuration";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalSmokeAutoUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalSmokeAutoUpgrade.testcase
@@ -11,6 +11,7 @@ definition {
 	property skip.upgrade-legacy-database = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Database Upgrade Framework";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalSmokeUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalSmokeUpgrade.testcase
@@ -7,6 +7,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Database Upgrade Framework";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortletsPermissionsUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortletsPermissionsUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Database Upgrade Framework";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeEnhancement.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeEnhancement.testcase
@@ -7,12 +7,11 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Database Upgrade Framework";
 
 	@priority = 4
 	test DecrementCoreSchemaMajorVersion {
-		property test.run.type = "single";
-
 		var script = '''
 			import com.liferay.portal.kernel.model.*;
 			import com.liferay.portal.kernel.service.ReleaseLocalServiceUtil;
@@ -49,8 +48,6 @@ definition {
 
 	@priority = 4
 	test DecrementCoreSchemaMicroVersion {
-		property test.run.type = "single";
-
 		var script = '''
 			import com.liferay.portal.kernel.model.*;
 			import com.liferay.portal.kernel.service.ReleaseLocalServiceUtil;
@@ -98,8 +95,6 @@ definition {
 
 	@priority = 3
 	test DecrementCoreSchemaMinorVersion {
-		property test.run.type = "single";
-
 		var script = '''
 			import com.liferay.portal.kernel.model.*;
 			import com.liferay.portal.kernel.service.ReleaseLocalServiceUtil;

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeLifecycle.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeLifecycle.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Database Upgrade Framework";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeLogContext.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeLogContext.testcase
@@ -10,6 +10,7 @@ definition {
 	property portal.version = "7.3.10";
 	property skip.upgrade-legacy-database = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Database Upgrade Framework";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
@@ -10,6 +10,7 @@ definition {
 	property portal.version = "7.4.13";
 	property skip.start.app.server = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testcase.url = "http://www.example.com";
 	property testray.main.component.name = "Database Upgrade Tool";
 	property upgrade.reports.enabled = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UserUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UserUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Upgrades User and System Management";
 
 	@description = "This is a use case for LPS-73277."

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/VirtualInstancesUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/VirtualInstancesUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Database Upgrade Framework";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/administration/auditing/AuditUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/administration/auditing/AuditUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.release = "false";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Audit";
 	property testray.main.component.name = "Upgrades Security";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/MultiFactorAuthenticationUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/MultiFactorAuthenticationUpgrade.testcase
@@ -9,6 +9,7 @@ definition {
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
 	property test.run.environment = "EE";
+	property test.run.type = "single";
 	property test.smtp.server.enabled = "true";
 	property testray.component.names = "Multi Factor Authentication";
 	property testray.main.component.name = "Upgrades Security";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAMLUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAMLUpgrade.testcase
@@ -8,6 +8,7 @@ definition {
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
 	property test.run.environment = "EE";
+	property test.run.type = "single";
 	property testray.component.names = "SAML";
 	property testray.main.component.name = "Upgrades Security";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/AssetsSharingUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/AssetsSharingUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Asset Sharing";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsAutoTaggingUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsAutoTaggingUpgrade.testcase
@@ -7,6 +7,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Auto Tagging";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsLocalStagingUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsLocalStagingUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Blogs";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsRemoteStagingUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsRemoteStagingUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Blogs";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Blogs";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Knowledge Base";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MessageboardsUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MessageboardsUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Message Boards";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/notifications/NotificationsUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/notifications/NotificationsUpgrade.testcase
@@ -7,6 +7,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Notifications";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Wiki";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/adaptivemedia/AdaptiveMediaUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/adaptivemedia/AdaptiveMediaUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Adaptive Media";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMLocalStagingUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMLocalStagingUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Document Management";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMRemoteStagingUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMRemoteStagingUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Document Management";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DocumentsandmediaUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DocumentsandmediaUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Document Management";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/upgrades/ExportImportUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/upgrades/ExportImportUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Upgrades Staging";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Client Extensions";
 	property testray.main.component.name = "Upgrades Remote Apps";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/PublicationsUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/PublicationsUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Upgrades Publications";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/sitetemplates/upgrades/SitetemplatesUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/sitetemplates/upgrades/SitetemplatesUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Upgrades Staging";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/upgrades/StagingUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/upgrades/StagingUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Upgrades Staging";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/upgrades/DynamicdatalistsUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/upgrades/DynamicdatalistsUpgrade.testcase
@@ -4,6 +4,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Dynamic Data Lists";
 	property testray.main.component.name = "Upgrades Data Engine";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/upgrades/FormsUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/upgrades/FormsUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Forms";
 	property testray.main.component.name = "Upgrades Forms";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/autotagging/WebContentAutoTaggingUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/autotagging/WebContentAutoTaggingUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Auto Tagging";
 	property testray.main.component.name = "Upgrades Lima";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/misc/mostviewedassets/MostViewedAssetsUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/misc/mostviewedassets/MostViewedAssetsUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Most Viewed Assets,Upgrades WEM";
 	property testray.main.component.name = "Upgrades WEM";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/assetpublisher/AssetPublisherUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/assetpublisher/AssetPublisherUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Asset Publisher,Upgrades WEM";
 	property testray.main.component.name = "Upgrades WEM";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/fragment/BannerCenterUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/fragment/BannerCenterUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Fragments,Upgrades WEM";
 	property testray.main.component.name = "Upgrades WEM";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/fragment/BasicComponentsUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/fragment/BasicComponentsUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Upgrades WEM";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/fragment/CollectionDisplayUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/fragment/CollectionDisplayUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Fragments,Upgrades WEM";
 	property testray.main.component.name = "Upgrades WEM";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/fragment/ContainerUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/fragment/ContainerUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Fragments,Upgrades WEM";
 	property testray.main.component.name = "Upgrades WEM";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/fragment/FragmentsUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/fragment/FragmentsUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Fragments,Upgrades WEM";
 	property testray.main.component.name = "Upgrades WEM";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/fragment/GridUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/fragment/GridUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Fragments,Upgrades WEM";
 	property testray.main.component.name = "Upgrades WEM";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/layout/ContentPagesWithStagingPageVersioningUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/layout/ContentPagesWithStagingPageVersioningUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Content Pages,Upgrades WEM";
 	property testray.main.component.name = "Upgrades WEM";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/layout/FragmentsAdminUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/layout/FragmentsAdminUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Upgrades WEM";
 	property testray.main.component.name = "Upgrades WEM";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/layout/MastersPageTemplatesUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/layout/MastersPageTemplatesUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Master Page Templates,Upgrades WEM";
 	property testray.main.component.name = "Upgrades WEM";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/layout/PageEditorUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/layout/PageEditorUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Upgrades WEM";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/layout/WidgetPagesUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/layout/WidgetPagesUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Page Administration,Upgrades WEM";
 	property testray.main.component.name = "Upgrades WEM";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/modernsitebuilding/MSBUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/modernsitebuilding/MSBUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.main.component.name = "Upgrades WEM";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/nestedportlets/NestedPortletsUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/nestedportlets/NestedPortletsUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Nested Portlets,Upgrades WEM";
 	property testray.main.component.name = "Upgrades WEM";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/site/SiteUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/site/SiteUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Sites Administration,Upgrades WEM";
 	property testray.main.component.name = "Upgrades WEM";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/stylebooks/StyleBooksUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/stylebooks/StyleBooksUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Style Book,Upgrades WEM";
 	property testray.main.component.name = "Upgrades WEM";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentStagingUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentStagingUpgrade.testcase
@@ -6,6 +6,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Upgrades Staging,Upgrades WEM,Web Content Administration";
 	property testray.main.component.name = "Upgrades WEM";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgradeWithWithFirstComplexStructure.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgradeWithWithFirstComplexStructure.testcase
@@ -8,6 +8,7 @@ definition {
 	property portal.upstream = "true";
 	property portal.version = "7.3.10.1";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Upgrades WEM,Web Content Administration";
 	property testray.main.component.name = "Upgrades WEM";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgradeWithWithSecondComplexStructure.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgradeWithWithSecondComplexStructure.testcase
@@ -8,6 +8,7 @@ definition {
 	property portal.upstream = "true";
 	property portal.version = "7.3.10.1";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Upgrades WEM,Web Content Administration";
 	property testray.main.component.name = "Upgrades WEM";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontentdisplay/WebContentDisplayUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontentdisplay/WebContentDisplayUpgrade.testcase
@@ -5,6 +5,7 @@ definition {
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
+	property test.run.type = "single";
 	property testray.component.names = "Web Content Display,Upgrades WEM";
 	property testray.main.component.name = "Upgrades WEM";
 


### PR DESCRIPTION
**Background**
Changes done in [LPS-192807](https://liferay.atlassian.net/browse/LPS-192807) no longer apply to have upgrade tests run individually due to [POSHI-623](https://github.com/kenjiheigel/liferay-portal/pull/1430/commits/3fa6c259a94656bca65780a3fe00d0f60043acb5).

**Test Plan**
Set `property test.run.type = "single";` for all upgrade tests.

**JIRA Ticket:**
https://liferay.atlassian.net/browse/LPS-195561