### PR TITLE
LPS-193985 Option to specify the path where upgrade reports will be stored

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -463,8 +463,7 @@ public class UpgradeReport {
 			}
 		}
 		else {
-			reportsDir = new File(
-				PropsValues.UPGRADE_REPORT_DIRECTORY);
+			reportsDir = new File(PropsValues.UPGRADE_REPORT_DIRECTORY);
 		}
 
 		if ((reportsDir != null) && !reportsDir.exists()) {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -454,11 +454,17 @@ public class UpgradeReport {
 	private File _getReportFile() {
 		File reportsDir;
 
-		if (DBUpgrader.isUpgradeClient()) {
-			reportsDir = new File(".", "reports");
+		if (PropsValues.UPGRADE_REPORT_DIRECTORY.isEmpty()) {
+			if (DBUpgrader.isUpgradeClient()) {
+				reportsDir = new File(".", "reports");
+			}
+			else {
+				reportsDir = new File(PropsValues.LIFERAY_HOME, "reports");
+			}
 		}
 		else {
-			reportsDir = new File(PropsValues.LIFERAY_HOME, "reports");
+			reportsDir = new File(
+				PropsValues.UPGRADE_REPORT_DIRECTORY);
 		}
 
 		if ((reportsDir != null) && !reportsDir.exists()) {

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -510,26 +510,30 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 
 	@Test
 	public void testUpgradeReportDirectory() throws Exception {
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "UPGRADE_REPORT_DIRECTORY",
-			"./custom_upgrade_report");
+		String originalUpgradeReportDirectory =
+			ReflectionTestUtil.getAndSetFieldValue(
+				PropsValues.class, "UPGRADE_REPORT_DIRECTORY",
+				"./custom_upgrade_report");
 
-		_upgradeReportDirectory = PropsValues.UPGRADE_REPORT_DIRECTORY;
+		try {
+			_upgradeReportDirectory = PropsValues.UPGRADE_REPORT_DIRECTORY;
 
-		_appender.start();
+			_appender.start();
 
-		Log log = LogFactoryUtil.getLog(UpgradeProcess.class);
+			Log log = LogFactoryUtil.getLog(UpgradeProcess.class);
 
-		log.warn("Upgrade report generated in " + _upgradeReportDirectory);
+			log.warn("Upgrade report generated in " + _upgradeReportDirectory);
 
-		_appender.stop();
+			_appender.stop();
 
-		String reportContent = _getReportContent();
-
-		_assertReport("Upgrade report generated in " + _upgradeReportDirectory);
-
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "UPGRADE_REPORT_DIRECTORY", "");
+			_assertReport(
+				"Upgrade report generated in " + _upgradeReportDirectory);
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				PropsValues.class, "UPGRADE_REPORT_DIRECTORY",
+				originalUpgradeReportDirectory);
+		}
 	}
 
 	protected static void setUpClass(boolean upgradeClient) throws Exception {

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -96,6 +96,8 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 
 		builder.withPattern("%level - %m%n %X");
 
+		_upgradeReportDirectory = "";
+
 		_logContextAppender = WriterAppender.createAppender(
 			builder.build(), null, _unsyncStringWriter,
 			"logContextWriterAppender", false, false);
@@ -112,7 +114,15 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 	public void tearDown() {
 		_appender.stop();
 
-		File reportsDir = new File(getFilePath(), "reports");
+		File reportsDir;
+
+		if (_upgradeReportDirectory.isEmpty()) {
+			reportsDir = new File(getFilePath(), "reports");
+		}
+		else {
+			reportsDir = new File(_upgradeReportDirectory);
+			_upgradeReportDirectory = "";
+		}
 
 		if ((reportsDir != null) && reportsDir.exists()) {
 			File reportFile = new File(reportsDir, "upgrade_report.info");
@@ -498,6 +508,30 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 				latestSchemaVersion, StringPool.NEW_LINE));
 	}
 
+	@Test
+	public void testUpgradeReportDirectory() throws Exception {
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_REPORT_DIRECTORY",
+			"./custom_upgrade_report");
+
+		_upgradeReportDirectory = PropsValues.UPGRADE_REPORT_DIRECTORY;
+
+		_appender.start();
+
+		Log log = LogFactoryUtil.getLog(UpgradeProcess.class);
+
+		log.warn("Upgrade report generated in " + _upgradeReportDirectory);
+
+		_appender.stop();
+
+		String reportContent = _getReportContent();
+
+		_assertReport("Upgrade report generated in " + _upgradeReportDirectory);
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "UPGRADE_REPORT_DIRECTORY", "");
+	}
+
 	protected static void setUpClass(boolean upgradeClient) throws Exception {
 		_db = DBManagerUtil.getDB();
 
@@ -600,7 +634,14 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 	}
 
 	private String _getReportContent() throws Exception {
-		File reportsDir = new File(getFilePath(), "reports");
+		File reportsDir;
+
+		if (_upgradeReportDirectory.isEmpty()) {
+			reportsDir = new File(getFilePath(), "reports");
+		}
+		else {
+			reportsDir = new File(_upgradeReportDirectory);
+		}
 
 		Assert.assertTrue(reportsDir.exists());
 
@@ -670,5 +711,6 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 	private String _reportContent;
 	private final UnsyncStringWriter _unsyncStringWriter =
 		new UnsyncStringWriter();
+	private String _upgradeReportDirectory;
 
 }

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -2392,6 +2392,9 @@ public class PropsValues {
 	public static final boolean UPGRADE_REPORT_ENABLED = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.UPGRADE_REPORT_ENABLED));
 
+	public static final String UPGRADE_REPORT_DIRECTORY = GetterUtil.getString(
+		PropsUtil.get(PropsKeys.UPGRADE_REPORT_DIRECTORY));
+
 	public static boolean USER_GROUPS_NAME_ALLOW_NUMERIC =
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.USER_GROUPS_NAME_ALLOW_NUMERIC));

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -2385,15 +2385,15 @@ public class PropsValues {
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.UPGRADE_LOG_CONTEXT_ENABLED));
 
+	public static final String UPGRADE_REPORT_DIRECTORY = GetterUtil.getString(
+		PropsUtil.get(PropsKeys.UPGRADE_REPORT_DIRECTORY));
+
 	public static final long UPGRADE_REPORT_DL_STORAGE_SIZE_TIMEOUT =
 		GetterUtil.getLong(
 			PropsUtil.get(PropsKeys.UPGRADE_REPORT_DL_STORAGE_SIZE_TIMEOUT));
 
 	public static final boolean UPGRADE_REPORT_ENABLED = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.UPGRADE_REPORT_ENABLED));
-
-	public static final String UPGRADE_REPORT_DIRECTORY = GetterUtil.getString(
-		PropsUtil.get(PropsKeys.UPGRADE_REPORT_DIRECTORY));
 
 	public static boolean USER_GROUPS_NAME_ALLOW_NUMERIC =
 		GetterUtil.getBoolean(

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 54.0.0
+version 54.1.0

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -184,6 +184,15 @@
     #
     upgrade.report.enabled=false
 
+    #
+    # Set the location of the upgrade report folder after the upgrade completes.
+    # If a value is not set, then the location will default to liferay.home when
+    # using the auto-upgrade tool or /reports when using the upgrade tool.
+    #
+    # Env: LIFERAY_UPGRADE_PERIOD_REPORT_PERIOD_DIRECTORY
+    #
+    upgrade.report.directory=
+
 ##
 ## Auto Deploy
 ##

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2716,14 +2716,14 @@ public interface PropsKeys {
 	public static final String UPGRADE_LOG_CONTEXT_ENABLED =
 		"upgrade.log.context.enabled";
 
+	public static final String UPGRADE_REPORT_DIRECTORY =
+		"upgrade.report.directory";
+
 	public static final String UPGRADE_REPORT_DL_STORAGE_SIZE_TIMEOUT =
 		"upgrade.report.dl.storage.size.timeout";
 
 	public static final String UPGRADE_REPORT_ENABLED =
 		"upgrade.report.enabled";
-
-	public static final String UPGRADE_REPORT_DIRECTORY =
-		"upgrade.report.directory";
 
 	public static final String USER_GROUPS_NAME_ALLOW_NUMERIC =
 		"user.groups.name.allow.numeric";

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2722,6 +2722,9 @@ public interface PropsKeys {
 	public static final String UPGRADE_REPORT_ENABLED =
 		"upgrade.report.enabled";
 
+	public static final String UPGRADE_REPORT_DIRECTORY =
+		"upgrade.report.directory";
+
 	public static final String USER_GROUPS_NAME_ALLOW_NUMERIC =
 		"user.groups.name.allow.numeric";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 65.0.0
+version 65.1.0


### PR DESCRIPTION
Hi @javalosjr96, it looks good to me, just check my last commit. For restoring the value of the property I obtain its original value first. Normally it will be empty, but if we start a portal for a test scenario with a value in the new property, we make sure it is restored back to its original value at the end of the test.
Thanks!