### PR TITLE
LPS-191843 Initial refactor of Upgrade Client tests

### DIFF
--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml
@@ -93,29 +93,6 @@
 		</sequential>
 	</macrodef>
 
-	<target name="bypass-expected-upgrade-error">
-		<get-database-upgrade-client-paths />
-
-		<prepare-database-upgrade-properties />
-
-		<antcall inheritAll="false" target="run-upgrade-client" />
-
-		<waitfor maxwait="300" maxwaitunit="second" timeoutproperty="upgrade.not.failed">
-			<resourcecontains
-				resource="${db.upgrade.client.log}"
-				substring="Connecting to Gogo shell because the upgrade failed or is incomplete"
-			/>
-		</waitfor>
-
-		<fail if="upgrade.not.failed" message="Unable to find expected upgrade failure message." />
-
-		<run-expect
-			db.upgrade.client.home="${db.upgrade.client.home}"
-			expect.file="check-upgrade-client-gogo-shell-connection.expect"
-			file.suffix.bat="${file.suffix.bat}"
-		/>
-	</target>
-
 	<target name="check-failed-gogoshell-connection">
 		<exec executable="/bin/bash" outputproperty="gogo.shell.content.out">
 			<redirector inputstring="telnet 127.0.0.1 11312 || true" />
@@ -658,6 +635,14 @@ upgrade.database.auto.run=false</echo>
 			expect.file="execute-all-pending-upgrades-from-gogo-shell.expect"
 			file.suffix.bat="${file.suffix.bat}"
 		/>
+	</target>
+
+	<target name="execute-upgrade-client-skip-gogoshell">
+		<prepare-database-upgrade-properties />
+
+		<antcall inheritAll="false" target="run-upgrade-client" />
+
+		<antcall inheritAll="false" target="check-upgrade-client-gogoshell-connection" />
 	</target>
 
 	<target name="run-upgrade-client">

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml
@@ -31,6 +31,23 @@
 		</sequential>
 	</macrodef>
 
+	<macrodef name="get-upgrade-finished-status">
+		<attribute default="success" name="upgrade.finished.status" />
+
+		<sequential>
+			<get-database-upgrade-client-paths />
+
+			<waitfor maxwait="150" maxwaitunit="second" timeoutproperty="upgrade.status">
+				<resourcecontains
+					resource="${db.upgrade.client.log}"
+					substring="upgrade finished with result @{upgrade.finished.status}"
+				/>
+			</waitfor>
+
+			<fail if="upgrade.status" message="Unable to find expected upgrade status &quot;@{upgrade.finished.status}&quot; on the log message." />
+		</sequential>
+	</macrodef>
+
 	<macrodef name="modify-script-exit-code">
 		<sequential>
 			<get-database-upgrade-client-paths />
@@ -118,56 +135,15 @@
 	</target>
 
 	<target name="check-failed-upgrade-log">
-		<get-database-upgrade-client-paths />
+		<get-upgrade-finished-status upgrade.finished.status="failure" />
 
-		<waitfor maxwait="150" maxwaitunit="second" timeoutproperty="upgrade.not.failed">
-			<resourcecontains
-				resource="${db.upgrade.client.log}"
-				substring="upgrade finished with result failure"
-			/>
-		</waitfor>
-
-		<fail if="upgrade.not.failed" message="Unable to find expected upgrade failure message." />
-
-		<waitfor maxwait="150" maxwaitunit="second" timeoutproperty="gogoshell.missing">
-			<resourcecontains
-				resource="${db.upgrade.client.log}"
-				substring="Connecting to Gogo shell because the upgrade failed or is incomplete"
-			/>
-		</waitfor>
-
-		<fail if="gogoshell.missing" message="Unable to find expected Gogo shell connection message." />
-
-		<waitfor maxwait="10" maxwaitunit="second" timeoutproperty="gogoshell.timeout">
-			<resourcecontains
-				resource="${db.upgrade.client.log}"
-				substring="Type &quot;help&quot; to get available upgrade and verify commands"
-			/>
-		</waitfor>
-
-		<fail if="gogoshell.timeout" message="The Gogo shell connection did not connect as expected." />
+		<antcall inheritAll="false" target="check-upgrade-client-gogoshell-connection" />
 	</target>
 
 	<target name="check-unresolved-upgrade-log">
-		<get-database-upgrade-client-paths />
+		<get-upgrade-finished-status upgrade.finished.status="unresolved" />
 
-		<waitfor maxwait="150" maxwaitunit="second" timeoutproperty="upgrade.not.unresolved">
-			<resourcecontains
-				resource="${db.upgrade.client.log}"
-				substring="upgrade finished with result unresolved"
-			/>
-		</waitfor>
-
-		<fail if="upgrade.not.unresolved" message="Unable to find expected upgrade unresolved message." />
-
-		<waitfor maxwait="10" maxwaitunit="second" timeoutproperty="gogoshell.timeout">
-			<resourcecontains
-				resource="${db.upgrade.client.log}"
-				substring="Type &quot;help&quot; to get available upgrade and verify commands"
-			/>
-		</waitfor>
-
-		<fail if="gogoshell.timeout" message="The Gogo shell connection did not connect as expected." />
+		<antcall inheritAll="false" target="check-upgrade-client-gogoshell-connection" />
 	</target>
 
 	<target name="check-upgrade-client-additional-settings">
@@ -235,16 +211,6 @@
 		<delete file="${db.upgrade.client.home}/logs/log_file.txt" />
 	</target>
 
-	<target name="check-upgrade-client-gogoshell">
-		<get-database-upgrade-client-paths />
-
-		<run-expect
-			db.upgrade.client.home="${db.upgrade.client.home}"
-			expect.file="check-upgrade-client-gogo-shell-connection.expect"
-			file.suffix.bat="${file.suffix.bat}"
-		/>
-	</target>
-
 	<target name="check-upgrade-client-gogoshell-command-output">
 		<get-database-upgrade-client-paths />
 
@@ -264,6 +230,28 @@
 				</not>
 			</condition>
 		</fail>
+	</target>
+
+	<target name="check-upgrade-client-gogoshell-connection">
+		<get-database-upgrade-client-paths />
+
+		<waitfor maxwait="150" maxwaitunit="second" timeoutproperty="gogoshell.missing">
+			<resourcecontains
+				resource="${db.upgrade.client.log}"
+				substring="Connecting to Gogo shell because the upgrade failed or is incomplete"
+			/>
+		</waitfor>
+
+		<fail if="gogoshell.missing" message="Unable to find expected Gogo shell connection message." />
+
+		<waitfor maxwait="10" maxwaitunit="second" timeoutproperty="gogoshell.timeout">
+			<resourcecontains
+				resource="${db.upgrade.client.log}"
+				substring="Type &quot;help&quot; to get available upgrade and verify commands"
+			/>
+		</waitfor>
+
+		<fail if="gogoshell.timeout" message="The Gogo shell connection did not connect as expected." />
 	</target>
 
 	<target name="check-upgrade-client-gogoshell-failed-connection-error">
@@ -634,16 +622,7 @@
 	</target>
 
 	<target name="check-warn-upgrade-log">
-		<get-database-upgrade-client-paths />
-
-		<waitfor maxwait="150" maxwaitunit="second" timeoutproperty="upgrade.failed">
-			<resourcecontains
-				resource="${db.upgrade.client.log}"
-				substring="upgrade finished with result warning"
-			/>
-		</waitfor>
-
-		<fail if="upgrade.failed" message="The upgrade process has timed out." />
+		<get-upgrade-finished-status upgrade.finished.status="warning" />
 	</target>
 
 	<target name="clean-database-upgrade-client">

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml
@@ -637,6 +637,16 @@ upgrade.database.auto.run=false</echo>
 		/>
 	</target>
 
+	<target name="execute-upgrade-client-gogoshell">
+		<get-database-upgrade-client-paths />
+
+		<run-expect
+			db.upgrade.client.home="${db.upgrade.client.home}"
+			expect.file="check-upgrade-client-gogo-shell-connection.expect"
+			file.suffix.bat="${file.suffix.bat}"
+		/>
+	</target>
+
 	<target name="execute-upgrade-client-skip-gogoshell">
 		<prepare-database-upgrade-properties />
 

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
@@ -48,7 +48,7 @@ definition {
 	@description = "LPS-158522: Upgrade client can connect to Gogo Shell"
 	@priority = 3
 	test CheckUpgradeClientGogoShell {
-		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-upgrade-client-gogoshell");
+		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "execute-upgrade-client-gogoshell");
 	}
 
 	@description = "LPS-158522: Upgrade client can connect to Gogo Shell and check upgrade"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/AFSStoreUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/AFSStoreUpgrade.testcase
@@ -62,7 +62,7 @@ definition {
 		property skip.upgrade-legacy-database = "true";
 		property testcase.url = "http://www.example.com";
 
-		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-upgrade-client-gogoshell");
+		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "execute-upgrade-client-gogoshell");
 
 		Log.viewUpgradeLogContentPresent(logContent = "Missing default Store");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/verifyproperties/VerifyProperties.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/verifyproperties/VerifyProperties.testcase
@@ -47,7 +47,7 @@ definition {
 		property skip.upgrade-legacy-database = "true";
 		property test.assert.warning.exceptions = "false";
 
-		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "bypass-expected-upgrade-error");
+		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "execute-upgrade-client-skip-gogoshell");
 
 		AssertConsoleTextPresent(value1 = "Detected reserved friendly URL \"/a\" Update the friendly URL for the layout with PLID");
 


### PR DESCRIPTION
Jira Ticket: https://liferay.atlassian.net/browse/LPS-191843

We need a refactor of the existing targets in build-test-db-upgrade-client.xml

- bypass-expected-upgrade-error (Change name because it does not follow any known patterns)
Action : Changed to `execute-upgrade-client-skip-gogoshell` since it executes the upgrade and skip the gogoshell after an expected upgrade error is shown.

- Steps of check-failed-upgrade-log / check-unresolved-upgrade-log / check-warn-upgrade-log  are all related and have lots of duplicate code.
Action : Cleaned the steps and split into smaller parts to reuse trought the target/tests

- check-upgrade-client-gogoshell target can express a more literal name
Action : Changed to execute-upgrade-client-gogoshell since it uses a expect file to directly connect to gogoshell  regardless of the result


