### PR TITLE
LPS 199379 Include Portal Database Validation Upgrade tests in relevant test suite

### DIFF
--- a/modules/apps/accessibility/accessibility-menu-web/src/test/java/com/liferay/accessibility/menu/web/internal/util/AccessibilitySettingsUtilTest.java
+++ b/modules/apps/accessibility/accessibility-menu-web/src/test/java/com/liferay/accessibility/menu/web/internal/util/AccessibilitySettingsUtilTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 
-/**
+/** TEST
  * @author Evan Thibodeau
  */
 public class AccessibilitySettingsUtilTest {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
@@ -14,6 +14,7 @@ definition {
 	test CompareLatest7413PartitionedUpgradedAndFreshDBSchemas {
 		property database.bare.enabled = "true";
 		property database.partition.enabled = "true";
+		property portal.smoke.upgrades = "true";
 		property skip.start.app.server = "true";
 		property testcase.url = "file:///opt/dev/projects/github/liferay-portal/";
 
@@ -260,6 +261,7 @@ definition {
 	@priority = 4
 	test CompareUpgradedAndFreshDatabaseSchemas7413 {
 		property data.archive.type = "data-archive-portal";
+		property portal.smoke.upgrades = "true";
 		property portal.version = "7.4.13";
 
 		Portlet.shutdownServer();
@@ -326,6 +328,7 @@ definition {
 	@priority = 4
 	test CompareUpgradedAndFreshDatabaseSchemas621021 {
 		property data.archive.type = "data-archive-portal";
+		property portal.smoke.upgrades = "true";
 		property portal.version = "6.2.10.21";
 
 		Portlet.shutdownServer();


### PR DESCRIPTION
**Description**
A number of real regressions were recently flagged by `Compare Database Schema` tests caused by product team commits. 
Compare database schema tests are low level tests that have been relatively stable. Proposal is to include a few of these tests in relevant suite by default to help prevent similar escaped issues.

**Test Plan**
- [ ] ci:test:relevant includes some PortalDatabseValidationUpgrade tests

**JIRA Ticket**
https://liferay.atlassian.net/browse/LPS-199379