### PR TITLE
LPS-199379 Include select Database Schema Validation Upgrade tests by default in relevant test suite

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
@@ -14,7 +14,7 @@ definition {
 	test CompareLatest7413PartitionedUpgradedAndFreshDBSchemas {
 		property database.bare.enabled = "true";
 		property database.partition.enabled = "true";
-		property portal.smoke.upgrades = "true";
+		property portal.smoke.upgrades = "false";
 		property skip.start.app.server = "true";
 		property testcase.url = "file:///opt/dev/projects/github/liferay-portal/";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
@@ -14,6 +14,7 @@ definition {
 	test CompareLatest7413PartitionedUpgradedAndFreshDBSchemas {
 		property database.bare.enabled = "true";
 		property database.partition.enabled = "true";
+		property portal.smoke.upgrades = "true";
 		property skip.start.app.server = "true";
 		property testcase.url = "file:///opt/dev/projects/github/liferay-portal/";
 
@@ -260,6 +261,7 @@ definition {
 	@priority = 4
 	test CompareUpgradedAndFreshDatabaseSchemas7413 {
 		property data.archive.type = "data-archive-portal";
+		property portal.smoke.upgrades = "true";
 		property portal.version = "7.4.13";
 
 		Portlet.shutdownServer();
@@ -326,6 +328,7 @@ definition {
 	@priority = 4
 	test CompareUpgradedAndFreshDatabaseSchemas621021 {
 		property data.archive.type = "data-archive-portal";
+		property portal.smoke.upgrades = "true";
 		property portal.version = "6.2.10.21";
 
 		Portlet.shutdownServer();

--- a/test.properties
+++ b/test.properties
@@ -7951,6 +7951,7 @@
     test.batch.run.property.query[functional-upgrade-tomcat*-mysql*-jdk8][relevant]=\
         (portal.smoke.upgrades == true) AND \
         (\
+            (database.bare.enabled == true) OR \
             (portal.version == "6.2.10.21") OR \
             (portal.version == "7.0.10.6")\
         ) AND \


### PR DESCRIPTION
**Description**
Database Schema tests have been failing occasionally and caught real issues, however were missed because they were not included in product team relevant suites.

**Proposal:**
Proposal is to include a few of these tests in relevant suite by default to help prevent similar escaped issues. Compare database schema tests are low level tests that have been relatively stable.

**Test Plan**
- [x] ci:test:relevant includes select PortalDatabseValidationUpgrade tests - see https://github.com/john-co/liferay-portal/pull/513#issuecomment-1771644923

**JIRA Ticket**
https://liferay.atlassian.net/browse/LPS-199379