### PR TITLE
LPS-198988 Test fix AutoUpgradeFromLatest7413UpdateWithDBPartitionEnabled

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
@@ -106,7 +106,7 @@ definition {
 			specificURL = "http://localhost:8080",
 			userEmailAddress = "test@liferay.com");
 
-		PortalInstances.openVirtualInstancesAdmin();
+		PortalInstances.openVirtualInstancesAdmin(baseURL = "http://localhost:8080");
 
 		PortalInstances.addCP(
 			mailDomain = "www.able.com",


### PR DESCRIPTION
**Background**
When setting the testcase.url workaround in https://github.com/brianchandotcom/liferay-portal/commit/5970a803a4cca5a9d0141af5903acef502b75e7b, it set it as the current URL, causing it to be unable to access the virtual instance portlet since the macro just appends to the current URL.

AutoUpgradeFromLatest7413UpdateWithDBPartitionEnabledAndHeadlessAPI isn't failing because it's not using the UI to create virtual instances.

**Test Plan**
Pass in baseURL to the macro when using the UI.

**Tested at:**
https://github.com/susanchen3/liferay-portal/pull/261#issuecomment-1772074963

**JIRA Ticket:**
https://liferay.atlassian.net/browse/LPS-198988

cc: @lucasperj 