### PR TITLE
LPS-198979 Ensure each persisted scheduler job can be mapped to a company

### DIFF
--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzSchedulerEngine.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzSchedulerEngine.java
@@ -619,41 +619,6 @@ public class QuartzSchedulerEngine implements SchedulerEngine {
 		}
 	}
 
-	protected void update(
-			Scheduler scheduler,
-			com.liferay.portal.kernel.scheduler.Trigger trigger,
-			StorageType storageType)
-		throws Exception {
-
-		Trigger quartzTrigger = (Trigger)trigger.getWrappedTrigger();
-
-		if (quartzTrigger == null) {
-			return;
-		}
-
-		TriggerKey triggerKey = quartzTrigger.getKey();
-
-		if (scheduler.getTrigger(triggerKey) != null) {
-			scheduler.rescheduleJob(triggerKey, quartzTrigger);
-		}
-		else {
-			JobKey jobKey = quartzTrigger.getJobKey();
-
-			JobDetail jobDetail = scheduler.getJobDetail(jobKey);
-
-			if (jobDetail == null) {
-				return;
-			}
-
-			synchronized (this) {
-				scheduler.deleteJob(jobKey);
-				scheduler.scheduleJob(jobDetail, quartzTrigger);
-			}
-
-			_updateJobState(scheduler, jobKey, TriggerState.NORMAL);
-		}
-	}
-
 	private String _fixMaxLength(
 		String argument, int maxLength, StorageType storageType) {
 

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzSchedulerEngine.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzSchedulerEngine.java
@@ -6,8 +6,10 @@
 package com.liferay.portal.scheduler.quartz.internal;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -23,6 +25,7 @@ import com.liferay.portal.kernel.scheduler.SchedulerException;
 import com.liferay.portal.kernel.scheduler.StorageType;
 import com.liferay.portal.kernel.scheduler.TriggerState;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.kernel.util.Props;
@@ -55,6 +58,7 @@ import org.quartz.ObjectAlreadyExistsException;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerContext;
 import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
 import org.quartz.TriggerKey;
 import org.quartz.TriggerUtils;
 import org.quartz.impl.StdSchedulerFactory;
@@ -108,13 +112,12 @@ public class QuartzSchedulerEngine implements SchedulerEngine {
 		try {
 			Scheduler scheduler = _getScheduler(storageType);
 
-			jobName = _fixMaxLength(jobName, _jobNameMaxLength, storageType);
+			jobName = _fixJobName(jobName, storageType);
+
 			groupName = _fixMaxLength(
 				groupName, _groupNameMaxLength, storageType);
 
-			JobKey jobKey = new JobKey(jobName, groupName);
-
-			scheduler.deleteJob(jobKey);
+			scheduler.deleteJob(new JobKey(jobName, groupName));
 		}
 		catch (Exception exception) {
 			throw new SchedulerException(
@@ -145,13 +148,12 @@ public class QuartzSchedulerEngine implements SchedulerEngine {
 		try {
 			Scheduler scheduler = _getScheduler(storageType);
 
-			jobName = _fixMaxLength(jobName, _jobNameMaxLength, storageType);
+			jobName = _fixJobName(jobName, storageType);
+
 			groupName = _fixMaxLength(
 				groupName, _groupNameMaxLength, storageType);
 
-			JobKey jobKey = new JobKey(jobName, groupName);
-
-			return getScheduledJob(scheduler, jobKey);
+			return getScheduledJob(scheduler, new JobKey(jobName, groupName));
 		}
 		catch (Exception exception) {
 			throw new SchedulerException(
@@ -236,7 +238,8 @@ public class QuartzSchedulerEngine implements SchedulerEngine {
 		try {
 			Scheduler scheduler = _getScheduler(storageType);
 
-			jobName = _fixMaxLength(jobName, _jobNameMaxLength, storageType);
+			jobName = _fixJobName(jobName, storageType);
+
 			groupName = _fixMaxLength(
 				groupName, _groupNameMaxLength, storageType);
 
@@ -263,7 +266,8 @@ public class QuartzSchedulerEngine implements SchedulerEngine {
 		try {
 			Scheduler scheduler = _getScheduler(storageType);
 
-			jobName = _fixMaxLength(jobName, _jobNameMaxLength, storageType);
+			jobName = _fixJobName(jobName, storageType);
+
 			groupName = _fixMaxLength(
 				groupName, _groupNameMaxLength, storageType);
 
@@ -316,6 +320,29 @@ public class QuartzSchedulerEngine implements SchedulerEngine {
 
 			if (quartzTrigger == null) {
 				return;
+			}
+
+			if (DBPartition.isPartitionEnabled() &&
+				(storageType == StorageType.PERSISTED)) {
+
+				long companyId = CompanyThreadLocal.getCompanyId();
+
+				if (message.contains("companyId")) {
+					companyId = message.getLong("companyId");
+				}
+
+				JobKey jobKey = quartzTrigger.getJobKey();
+
+				String jobName = _fixJobName(
+					companyId, jobKey.getName(), storageType);
+
+				TriggerBuilder<? extends Trigger> quartzTriggerBuilder =
+					quartzTrigger.getTriggerBuilder();
+
+				quartzTriggerBuilder.forJob(jobName, jobKey.getGroup());
+				quartzTriggerBuilder.withIdentity(jobName, jobKey.getGroup());
+
+				quartzTrigger = quartzTriggerBuilder.build();
 			}
 
 			Scheduler scheduler = _getScheduler(storageType);
@@ -618,6 +645,29 @@ public class QuartzSchedulerEngine implements SchedulerEngine {
 					objectAlreadyExistsException);
 			}
 		}
+	}
+
+	private String _fixJobName(
+		long companyId, String jobName, StorageType storageType) {
+
+		if ((storageType != StorageType.PERSISTED) ||
+			jobName.matches(".+@\\d+$")) {
+
+			return jobName;
+		}
+
+		jobName = _fixMaxLength(jobName, _jobNameMaxLength, storageType);
+
+		if (DBPartition.isPartitionEnabled()) {
+			jobName = jobName.concat(StringPool.AT + companyId);
+		}
+
+		return jobName;
+	}
+
+	private String _fixJobName(String jobName, StorageType storageType) {
+		return _fixJobName(
+			CompanyThreadLocal.getCompanyId(), jobName, storageType);
 	}
 
 	private String _fixMaxLength(

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzSchedulerEngine.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzSchedulerEngine.java
@@ -282,6 +282,7 @@ public class QuartzSchedulerEngine implements SchedulerEngine {
 		}
 	}
 
+	@Override
 	public void run(
 			long companyId, String jobName, String groupName,
 			StorageType storageType)
@@ -760,18 +761,22 @@ public class QuartzSchedulerEngine implements SchedulerEngine {
 
 	private class SchedulerListenerImpl extends SchedulerListenerSupport {
 
+		@Override
 		public void jobPaused(JobKey jobKey) {
 			_audit(jobKey, TriggerState.PAUSED);
 		}
 
+		@Override
 		public void jobResumed(JobKey jobKey) {
 			_audit(jobKey, TriggerState.NORMAL);
 		}
 
+		@Override
 		public void jobScheduled(Trigger trigger) {
 			_audit(trigger.getJobKey(), TriggerState.NORMAL);
 		}
 
+		@Override
 		public void triggerFinalized(Trigger trigger) {
 			JobKey jobKey = trigger.getJobKey();
 

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/registry/QuartzServiceUpgradeStepRegistrator.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/registry/QuartzServiceUpgradeStepRegistrator.java
@@ -5,11 +5,12 @@
 
 package com.liferay.portal.scheduler.quartz.internal.upgrade.registry;
 
+import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.scheduler.quartz.internal.upgrade.schema.SchemaCreationUpgradeStep;
-import com.liferay.portal.scheduler.quartz.internal.upgrade.v1_0_0.QuartzUpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Akos Thurzo
@@ -25,7 +26,18 @@ public class QuartzServiceUpgradeStepRegistrator
 		registry.registerReleaseCreationUpgradeSteps(
 			new SchemaCreationUpgradeStep());
 
-		registry.register("0.0.1", "1.0.0", new QuartzUpgradeProcess());
+		registry.register(
+			"0.0.1", "1.0.0",
+			new com.liferay.portal.scheduler.quartz.internal.upgrade.v1_0_0.
+				QuartzUpgradeProcess());
+
+		registry.register(
+			"1.0.0", "1.1.0",
+			new com.liferay.portal.scheduler.quartz.internal.upgrade.v1_1_0.
+				QuartzUpgradeProcess(_jsonFactory));
 	}
+
+	@Reference
+	private JSONFactory _jsonFactory;
 
 }

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_1_0/QuartzUpgradeProcess.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_1_0/QuartzUpgradeProcess.java
@@ -1,0 +1,130 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.scheduler.quartz.internal.upgrade.v1_1_0;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.db.partition.DBPartition;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.scheduler.SchedulerEngine;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.io.ObjectInputStream;
+
+import java.sql.Blob;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.quartz.JobDataMap;
+
+/**
+ * @author Kevin Lee
+ */
+public class QuartzUpgradeProcess extends UpgradeProcess {
+
+	public QuartzUpgradeProcess(JSONFactory jsonFactory) {
+		_jsonFactory = jsonFactory;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		Map<String, String> jobNamesMap = new HashMap<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select job_name, job_data from QUARTZ_JOB_DETAILS where " +
+					"job_name not like '%@%'");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				String jobName = resultSet.getString("job_name");
+
+				long companyId = CompanyThreadLocal.getCompanyId();
+
+				JobDataMap jobDataMap = _deserializeJobData(
+					resultSet.getBlob("job_data"));
+
+				if (jobDataMap != null) {
+					Message message = (Message)_jsonFactory.deserialize(
+						jobDataMap.getString(SchedulerEngine.MESSAGE));
+
+					if (message.contains("companyId")) {
+						companyId = message.getLong("companyId");
+					}
+				}
+
+				jobNamesMap.put(
+					jobName, jobName.concat(StringPool.AT + companyId));
+			}
+		}
+
+		if (jobNamesMap.isEmpty()) {
+			return;
+		}
+
+		_updateQuartzTables(
+			jobNamesMap, "job_name",
+			new String[] {
+				"QUARTZ_FIRED_TRIGGERS", "QUARTZ_JOB_DETAILS", "QUARTZ_TRIGGERS"
+			});
+
+		_updateQuartzTables(
+			jobNamesMap, "trigger_name",
+			new String[] {
+				"QUARTZ_BLOB_TRIGGERS", "QUARTZ_CRON_TRIGGERS",
+				"QUARTZ_FIRED_TRIGGERS", "QUARTZ_SIMPLE_TRIGGERS",
+				"QUARTZ_SIMPROP_TRIGGERS", "QUARTZ_TRIGGERS"
+			});
+	}
+
+	@Override
+	protected boolean isSkipUpgradeProcess() {
+		return !DBPartition.isPartitionEnabled();
+	}
+
+	private JobDataMap _deserializeJobData(Blob blob) throws Exception {
+		if (blob == null) {
+			return null;
+		}
+
+		ObjectInputStream objectInputStream = new ObjectInputStream(
+			blob.getBinaryStream());
+
+		return (JobDataMap)objectInputStream.readObject();
+	}
+
+	private void _updateQuartzTables(
+			Map<String, String> jobNamesMap, String columnName,
+			String[] tableNames)
+		throws Exception {
+
+		for (String tableName : tableNames) {
+			try (PreparedStatement preparedStatement =
+					AutoBatchPreparedStatementUtil.autoBatch(
+						connection,
+						StringBundler.concat(
+							"update ", tableName, " set ", columnName,
+							" = ? where ", columnName, " = ?"))) {
+
+				for (Map.Entry<String, String> entry : jobNamesMap.entrySet()) {
+					preparedStatement.setString(1, entry.getValue());
+					preparedStatement.setString(2, entry.getKey());
+					preparedStatement.addBatch();
+				}
+
+				preparedStatement.executeBatch();
+			}
+		}
+	}
+
+	private final JSONFactory _jsonFactory;
+
+}

--- a/modules/apps/portal-scheduler/source-formatter-suppressions.xml
+++ b/modules/apps/portal-scheduler/source-formatter-suppressions.xml
@@ -5,6 +5,7 @@
 		<suppress checks="MethodNameCheck" files="portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngineConfigurator\.java" />
 	</checkstyle>
 	<source-check>
+		<suppress checks="JavaDeserializationSecurityCheck" files="portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_1_0/QuartzUpgradeProcess\.java" />
 		<suppress checks="JavaVerifyUpgradeConnectionCheck" files="portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/schema/SchemaCreationUpgradeStep\.java" />
 	</source-check>
 </suppressions>


### PR DESCRIPTION
__Ticket:__ <https://liferay.atlassian.net/browse/LPS-198979>

This pull request implements the approach [here](https://liferay.atlassian.net/browse/LPS-197892?focusedCommentId=2491458) and updates the Quartz persisted scheduler so that the `companyId` is appended to the scheduler job/trigger names when DB partitioning is enabled. This is done for two main reasons:

1. To avoid collisions with the scheduler jobs and triggers when migrating a virtual instance.
2. To know which persisted scheduler jobs belongs to which company when migrating a virtual instance.

The PR keeps the `companyId` logic within `QuartzSchedulerEngine` to prevent changes to the scheduler API.