### PR TITLE
LPS-200529 Replace missing usages from POSHI-561

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/SearchAdministration.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SearchAdministration.macro
@@ -145,7 +145,7 @@ definition {
 		if (contains(${searchEngineVendor}, "Elasticsearch")) {
 			if (${waitForReindexRequest} == "true") {
 				while (!(contains(${elasticsearchTasks}, "indices:data/write/bulk")) && (${reindexStartTime} != 60)) {
-					Pause.pauseNoSPARefresh(locator1 = 1000);
+					Pause.pauseNoSPARefresh(value1 = 1000);
 
 					var reindexStartTime = ${reindexStartTime} + 1;
 
@@ -163,7 +163,7 @@ definition {
 			}
 
 			while (((contains(${elasticsearchTasks}, "indices:data/write/bulk") || (IsElementPresent.isElementPresentNoSPARefresh(locator1 = "Search#REINDEX_IN_PROGRESS_INDICATOR")) || (IsElementPresent.isElementPresentNoSPARefresh(locator1 = "//html[contains(@class,'lfr-spa-loading')]"))) && (${reindexElapsedTime} != 240)) && (maxIterations = "24")) {
-				Pause.pauseNoSPARefresh(locator1 = 10000);
+				Pause.pauseNoSPARefresh(value1 = 10000);
 
 				var reindexElapsedTime = ${reindexElapsedTime} + 10;
 
@@ -174,7 +174,7 @@ definition {
 		}
 		else if (contains(${searchEngineVendor}, "Solr")) {
 			while ((IsElementNotPresent(locator1 = "Search#REINDEX_IN_PROGRESS_INDICATOR")) && (${reindexStartTime} != 60)) {
-				Pause.pauseNoSPARefresh(locator1 = 1000);
+				Pause.pauseNoSPARefresh(value1 = 1000);
 
 				var reindexStartTime = ${reindexStartTime} + 1;
 			}
@@ -187,7 +187,7 @@ definition {
 			}
 
 			while ((((IsElementPresent.isElementPresentNoSPARefresh(locator1 = "Search#REINDEX_IN_PROGRESS_INDICATOR")) || (IsElementPresent.isElementPresentNoSPARefresh(locator1 = "//html[contains(@class,'lfr-spa-loading')]"))) && (${reindexElapsedTime} != 240)) && (maxIterations = "24")) {
-				Pause.pauseNoSPARefresh(locator1 = 10000);
+				Pause.pauseNoSPARefresh(value1 = 10000);
 
 				var reindexElapsedTime = ${reindexElapsedTime} + 10;
 			}


### PR DESCRIPTION
**Background**
Upgrade smoke tests are timing out during reindexing. Most likely due to https://liferay.atlassian.net/browse/POSHI-561.

**Test Plan**
Replace "locator1" with "value1" in missed Pause usages.

Tested at: https://github.com/susanchen3/liferay-portal/pull/269

**JIRA Ticket:**
https://liferay.atlassian.net/browse/LPS-200529