### PR TITLE
LPS-171695 Remove DDMTemplate from CTUpgradeProcess

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
@@ -316,7 +316,7 @@ public class DDMServiceUpgradeStepRegistrator
 		registry.register(
 			"3.2.9", "3.3.0",
 			new CTModelUpgradeProcess(
-				"DDMStructure", "DDMStructureVersion", "DDMTemplate",
+				"DDMStructure", "DDMStructureVersion",
 				"DDMTemplateVersion"));
 
 		registry.register(

--- a/test.properties
+++ b/test.properties
@@ -5565,24 +5565,24 @@
     test.batch.dist.app.servers[license]=tomcat
 
     test.batch.names[license]=\
-        empty-osgi-core-dir-mysql57-jdk8,\
-        functional-tomcat90-mysql57-jdk8
+        functional-upgrade-tomcat90-mysql80-jdk8
 
-    test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][license]=\
+    test.batch.run.property.query[functional-upgrade-tomcat90-mysql80-jdk8][license]=\
         (\
-            (license.required == true) AND \
-            (testray.main.component.name != "Clustering")\
-        ) OR \
+            (app.server.types == null) OR \
+            (app.server.types ~ tomcat)\
+        ) AND \
+        (data.archive.type != null) AND \
         (\
-            (\
-                (app.server.types == null) OR \
-                (app.server.types ~ tomcat)\
-            ) AND \
-            (\
-                (database.types == null) OR \
-                (database.types ~ mysql)\
-            ) AND \
-            (portal.smoke == true)\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
+        (portal.acceptance != quarantine) AND \
+        (portal.upstream == true) AND \
+        (\
+            (testray.main.component.name == "Database Partitioning") OR \
+            (testray.main.component.name == "Database Upgrade Framework") OR \
+            (testray.main.component.name == "Database Upgrade Tool")\
         )
 
     #


### PR DESCRIPTION
This test removes the DDMTemplate from the CTUpgrade Process.

The connection error occurs consistently for this process. 

We'll remove it to see if it's special.