### PR TITLE
Lps 171695 Test 2 Remove ddm template indexes

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/CTModelUpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/CTModelUpgradeProcess.java
@@ -31,6 +31,47 @@ public class CTModelUpgradeProcess extends UpgradeProcess {
 
 		DBInspector dbInspector = new DBInspector(connection);
 
+		try {
+			if (hasTable("DDMTemplate")) {
+				if ((hasIndex("DDMTemplate", "IX_40E22774"))) {
+
+					String[] indexesInDDMTemplate = {
+						"IX_13A3AC0E",
+						"IX_147A0D41",
+						"IX_17F6EC05",
+						"IX_25F23981",
+						"IX_27ACCA26",
+						"IX_2A228ED0",
+						"IX_3A6CBFF1",
+						"IX_3EE9B9D7",
+						"IX_40E22774",
+						"IX_492F3DCB",
+						"IX_8DFF58A7",
+						"IX_A967DEEF",
+						"IX_C64F367F",
+						"IX_D3180904",
+						"IX_ED2AF9E2",
+						"IX_EFDA5A3B",
+						"IX_F365A086"};
+
+					for (String index : indexesInDDMTemplate) {
+						try {
+							if (hasIndex("DDMTemplate", index)) {
+								runSQL(
+									"drop index " + index + " on DDMTemplate");
+							}
+						}
+						catch (Exception e) {
+							System.out.println(e.getMessage());
+						}
+					}
+				}
+			}
+		}
+		catch(Exception e){
+			System.out.println(e.getMessage());
+		}
+
 		for (String tableName : _tableNames) {
 			try (LoggingTimer loggingTimer = new LoggingTimer(
 					CTModelUpgradeProcess.class, tableName)) {

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/CTModelUpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/CTModelUpgradeProcess.java
@@ -107,6 +107,8 @@ public class CTModelUpgradeProcess extends UpgradeProcess {
 		}
 
 		sb.append(", ctCollectionId)");
+		
+		System.out.println(sb.toString());
 
 		runSQL(sb.toString());
 	}

--- a/test.properties
+++ b/test.properties
@@ -5565,24 +5565,24 @@
     test.batch.dist.app.servers[license]=tomcat
 
     test.batch.names[license]=\
-        empty-osgi-core-dir-mysql57-jdk8,\
-        functional-tomcat90-mysql57-jdk8
+        functional-upgrade-tomcat90-mysql80-jdk8
 
-    test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][license]=\
+    test.batch.run.property.query[functional-upgrade-tomcat90-mysql80-jdk8][license]=\
         (\
-            (license.required == true) AND \
-            (testray.main.component.name != "Clustering")\
-        ) OR \
+            (app.server.types == null) OR \
+            (app.server.types ~ tomcat)\
+        ) AND \
+        (data.archive.type != null) AND \
         (\
-            (\
-                (app.server.types == null) OR \
-                (app.server.types ~ tomcat)\
-            ) AND \
-            (\
-                (database.types == null) OR \
-                (database.types ~ mysql)\
-            ) AND \
-            (portal.smoke == true)\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
+        (portal.acceptance != quarantine) AND \
+        (portal.upstream == true) AND \
+        (\
+            (testray.main.component.name == "Database Partitioning") OR \
+            (testray.main.component.name == "Database Upgrade Framework") OR \
+            (testray.main.component.name == "Database Upgrade Tool")\
         )
 
     #


### PR DESCRIPTION
This test removes the indexes DDMTemplate has before it runs the CTModelProcess. 

This is to check to see if the number of indexes plays a role in the error.
