### PR TITLE
LPS-201250 Update properties for upgrade performance tests from changes in LPS-198308

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -11644,12 +11644,16 @@ ${update.properties}</echo>
 		</if>
 
 		<get-testcase-property property.name="database.partition.enabled" />
+		<get-testcase-property property.name="liferay.online.properties" />
 		<get-testcase-property property.name="portal.version" />
 
 		<if>
 			<and>
-				<isset property="database.partition.enabled" />
 				<isset property="portal.version" />
+				<or>
+					<isset property="database.partition.enabled" />
+					<isset property="liferay.online.properties" />
+				</or>
 			</and>
 			<then>
 				<property name="database.max.pool.size" value="50" />
@@ -11888,6 +11892,16 @@ upgrade.database.auto.run=true</echo>
 			<then>
 				<echo append="true" file="portal-impl/src/portal-ext.properties">
 database.partition.enabled=true</echo>
+			</then>
+		</if>
+
+		<get-testcase-property property.name="liferay.online.properties" />
+		<propertycopy from="liferay.online.properties[${env.CI_TEST_SUITE}]" name="liferay.online.properties" silent="true" />
+
+		<if>
+			<equals arg1="${liferay.online.properties}" arg2="true" />
+			<then>
+				<prepare-liferay-online-properties />
 
 				<get-testcase-property property.name="data.archive.type" />
 
@@ -14270,6 +14284,15 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 			<then>
 				<echo append="true" file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">
 database.partition.enabled=true</echo>
+			</then>
+		</if>
+
+		<get-testcase-property property.name="liferay.online.properties" />
+
+		<if>
+			<equals arg1="${liferay.online.properties}" arg2="true" />
+			<then>
+				<prepare-liferay-online-properties />
 
 				<get-testcase-property property.name="data.archive.type" />
 


### PR DESCRIPTION
**Background**
Upgrade performance tests are failing because **company.default.web.id** isn't being set. It was only set when it met the properties of `database.partition.enabled` and `data.archive.type`. I forgot to consider when submitting changes in https://liferay.atlassian.net/browse/LPS-198308 when changing from `database.partition.enabled` to `liferay.online.properties`.

**Tested at**
https://github.com/susanchen3/liferay-portal/pull/278#issuecomment-1803133493

**JIRA Ticket:**
https://liferay.atlassian.net/browse/LPS-201250