### PR TITLE
LPS-201250 Update properties for upgrade performance tests from changes in LPS-198308

### DIFF
--- a/build-test-local.xml
+++ b/build-test-local.xml
@@ -611,7 +611,7 @@ database.mysql.docker.image=mysql:${database.version}
 database.mysql.host=localhost_mysql
 database.mysql.password=
 database.mysql.schema=lportal
-database.mysql.url=jdbc:mysql://localhost:3307/lportal?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&serverTimezone=GMT&useFastDateParsing=false&useUnicode=true
+database.mysql.url=jdbc:mysql://localhost:3307/lportal?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&permitMysqlScheme&serverTimezone=GMT&useFastDateParsing=false&useUnicode=true
 database.mysql.username=root
 database.mysql.version=${database.version}
 database.type=mysql

--- a/build-test.xml
+++ b/build-test.xml
@@ -2931,16 +2931,7 @@ jdbc.default.url=${database.url.upgrade}
 jdbc.default.username=${database.username}
 jdbc.default.password=${database.password}</echo>
 
-			<get-testcase-property property.name="upgrade.reports.enabled" />
-
-			<if>
-				<equals arg1="${upgrade.reports.enabled}" arg2="true" />
-				<then>
-					<echo append="true" file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">${line.separator}upgrade.report.enabled=true</echo>
-				</then>
-			</if>
-
-			<echo append="true" file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">${line.separator}liferay.home=${liferay.home}</echo>
+			<prepare-upgrade-ext-properties />
 		</sequential>
 	</macrodef>
 
@@ -5179,6 +5170,75 @@ tell application "Safari" to quit
 					</antelope:repeat>
 
 					<var name="app.server.bundle.index" unset="true" />
+				</then>
+			</if>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="prepare-upgrade-ext-properties">
+		<sequential>
+			<echo append="true" file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">
+liferay.home=${liferay.home}</echo>
+
+			<get-testcase-property property.name="database.partition.enabled" />
+
+			<if>
+				<equals arg1="${database.partition.enabled}" arg2="true" />
+				<then>
+					<echo append="true" file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">
+database.partition.enabled=true</echo>
+				</then>
+			</if>
+
+			<get-testcase-property property.name="liferay.online.properties" />
+
+			<if>
+				<equals arg1="${liferay.online.properties}" arg2="true" />
+				<then>
+					<echo append="true" file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">
+include-and-override=portal-liferay-online.properties</echo>
+
+					<replace
+						file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-database.properties"
+						token="${database.mysql.driver}"
+						value="${database.mariadb.driver}"
+					/>
+
+					<get-testcase-property property.name="data.archive.type" />
+
+					<if>
+						<contains string="${data.archive.type}" substring="partition-large" />
+						<then>
+							<echo append="true" file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">
+locales=es_ES,en_US,en_GB
+locales.enabled=es_ES,en_US,en_GB
+admin.default.role.names=User
+layout.user.public.layouts.power.user.required=true
+layout.user.private.layouts.power.user.required=true
+passwords.encryption.algorithm.legacy=SHA
+company.default.web.id=www.able.com</echo>
+						</then>
+					</if>
+				</then>
+			</if>
+
+			<get-testcase-property property.name="upgrade.reports.enabled" />
+
+			<if>
+				<equals arg1="${upgrade.reports.enabled}" arg2="true" />
+				<then>
+					<echo append="true" file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">
+upgrade.report.enabled=true</echo>
+				</then>
+			</if>
+
+			<get-testcase-property property.name="custom.upgrade.properties" />
+
+			<if>
+				<isset property="custom.upgrade.properties" />
+				<then>
+					<echo append="true" file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">
+${custom.upgrade.properties}</echo>
 				</then>
 			</if>
 		</sequential>
@@ -14265,51 +14325,6 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 					src="${portal.legacy.dir}/${portal.version}/data-archive/${data.archive.type}-${database.type}.zip"
 				/>
 			</else>
-		</if>
-
-		<get-testcase-property property.name="database.partition.enabled" />
-
-		<if>
-			<equals arg1="${database.partition.enabled}" arg2="true" />
-			<then>
-				<echo append="true" file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">
-database.partition.enabled=true</echo>
-			</then>
-		</if>
-
-		<get-testcase-property property.name="liferay.online.properties" />
-
-		<if>
-			<equals arg1="${liferay.online.properties}" arg2="true" />
-			<then>
-				<prepare-liferay-online-properties />
-
-				<get-testcase-property property.name="data.archive.type" />
-
-				<if>
-					<contains string="${data.archive.type}" substring="partition-large" />
-					<then>
-						<echo append="true" file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">
-locales=es_ES,en_US,en_GB
-locales.enabled=es_ES,en_US,en_GB
-admin.default.role.names=User
-layout.user.public.layouts.power.user.required=true
-layout.user.private.layouts.power.user.required=true
-passwords.encryption.algorithm.legacy=SHA
-company.default.web.id=www.able.com</echo>
-					</then>
-				</if>
-			</then>
-		</if>
-
-		<get-testcase-property property.name="custom.upgrade.properties" />
-
-		<if>
-			<isset property="custom.upgrade.properties" />
-			<then>
-				<echo append="true" file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">
-${custom.upgrade.properties}</echo>
-			</then>
 		</if>
 
 		<get-test-app-server-lib-portal-dir />

--- a/build-test.xml
+++ b/build-test.xml
@@ -11644,12 +11644,16 @@ ${update.properties}</echo>
 		</if>
 
 		<get-testcase-property property.name="database.partition.enabled" />
+		<get-testcase-property property.name="liferay.online.properties" />
 		<get-testcase-property property.name="portal.version" />
 
 		<if>
 			<and>
-				<isset property="database.partition.enabled" />
 				<isset property="portal.version" />
+				<or>
+					<isset property="database.partition.enabled" />
+					<isset property="liferay.online.properties" />
+				</or>
 			</and>
 			<then>
 				<property name="database.max.pool.size" value="50" />
@@ -11888,6 +11892,16 @@ upgrade.database.auto.run=true</echo>
 			<then>
 				<echo append="true" file="portal-impl/src/portal-ext.properties">
 database.partition.enabled=true</echo>
+			</then>
+		</if>
+
+		<get-testcase-property property.name="liferay.online.properties" />
+		<propertycopy from="liferay.online.properties[${env.CI_TEST_SUITE}]" name="liferay.online.properties" silent="true" />
+
+		<if>
+			<equals arg1="${liferay.online.properties}" arg2="true" />
+			<then>
+				<prepare-liferay-online-properties />
 
 				<get-testcase-property property.name="data.archive.type" />
 
@@ -12019,16 +12033,6 @@ dl.store.impl=com.liferay.portal.store.gcs.GCSStore</echo>
 			<then>
 				<echo append="true" file="portal-impl/src/portal-ext.properties">
 dl.store.impl=com.liferay.portal.store.s3.IBMS3Store</echo>
-			</then>
-		</if>
-
-		<get-testcase-property property.name="liferay.online.properties" />
-		<propertycopy from="liferay.online.properties[${env.CI_TEST_SUITE}]" name="liferay.online.properties" silent="true" />
-
-		<if>
-			<equals arg1="${liferay.online.properties}" arg2="true" />
-			<then>
-				<prepare-liferay-online-properties />
 			</then>
 		</if>
 
@@ -14270,6 +14274,15 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 			<then>
 				<echo append="true" file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">
 database.partition.enabled=true</echo>
+			</then>
+		</if>
+
+		<get-testcase-property property.name="liferay.online.properties" />
+
+		<if>
+			<equals arg1="${liferay.online.properties}" arg2="true" />
+			<then>
+				<prepare-liferay-online-properties />
 
 				<get-testcase-property property.name="data.archive.type" />
 


### PR DESCRIPTION
**Background**
Upgrade performance tests are failing because **company.default.web.id** isn't being set. I forgot to consider when submitting changes in https://liferay.atlassian.net/browse/LPS-198308.

I also created a new macro to refactor how properties are prepared for `portal-upgrade-ext.properties`. 

**Tested at:** 
https://github.com/susanchen3/liferay-portal/pull/278#issuecomment-1805201933

**JIRA Ticket:**
https://liferay.atlassian.net/browse/LPS-201250