### PR TITLE
LPS-200635 Refactor Continuous upgrade tests

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -6935,6 +6935,7 @@ go</echo>
 						<equals arg1="@{liferay.portal.bundle}" arg2="7.4.13.u98" />
 						<equals arg1="@{liferay.portal.bundle}" arg2="7.4.13.u99" />
 						<equals arg1="@{liferay.portal.bundle}" arg2="7.4.13.u100" />
+						<equals arg1="@{liferay.portal.bundle}" arg2="7.4.13.u101" />
 					</or>
 					<then>
 						<var name="app.server.tomcat.version" value="9.0.80" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/Upgrade.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/Upgrade.macro
@@ -1,12 +1,30 @@
 definition {
 
-	@summary = "Restore and start original bundle with auto upgrade enabled"
+	@summary = "Restore original bundle, start it with auto upgrade enabled and reindex after"
 	macro restoreOriginalBundleAndUpgrade() {
 		Portlet.shutdownServer();
 
 		AntCommands.runCommand("build-test.xml", "prepare-upgrade-original-bundle-test-environment");
 
 		Portlet.startServer(deleteLiferayHome = "false");
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://localhost:8080",
+			userEmailAddress = "test@liferay.com");
+
+		ApplicationsMenu.gotoPortlet(
+			category = "Configuration",
+			panel = "Control Panel",
+			portlet = "Search");
+
+		Click(
+			key_navItem = "Index Actions",
+			locator1 = "NavBar#NAV_ITEM_LINK");
+
+		SearchAdministration.startReindex(action = "All Search Indexes");
+
+		SearchAdministration.waitForReindexFinished(waitForReindexRequest = "true");
 
 		Navigator.openSpecificURL(url = "http://localhost:8080");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/Upgrade.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/Upgrade.macro
@@ -1,0 +1,28 @@
+definition {
+
+	@summary = "Restore and start original bundle with auto upgrade enabled"
+	macro restoreOriginalBundleAndUpgrade() {
+		Portlet.shutdownServer();
+
+		AntCommands.runCommand("build-test.xml", "prepare-upgrade-original-bundle-test-environment");
+
+		Portlet.startServer(deleteLiferayHome = "false");
+
+		Navigator.openSpecificURL(url = "http://localhost:8080");
+	}
+
+	@summary = "Backup original bundle, configure and start latest released bundle test enviroment"
+	macro startReleasedBundle() {
+		var releaseBundleVersion = PropsUtil.get("test.released.release.bundle.version");
+		var releaseBundleZipURL = PropsUtil.get("test.released.test.portal.bundle.zip.url");
+
+		AntCommands.runCommand("build-test.xml", "prepare-upgrade-released-bundle-test-environment -Dtest.released.release.bundle.version=${releaseBundleVersion} -Dtest.released.test.portal.bundle.zip.url=${releaseBundleZipURL}");
+
+		Portlet.startServer(keepOsGiState = "true");
+
+		AntCommands.runCommand("build-test.xml", "wait-for-license-activation");
+
+		Navigator.openSpecificURL(url = "http://localhost:8080");
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/userbar/UserBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/userbar/UserBar.path
@@ -107,7 +107,7 @@
 </tr>
 <tr>
 	<td>USER_SIGN_IN</td>
-	<td>//button[contains(@class,'sign-in')]</td>
+	<td>//span[contains(@class,'sign-in')]/a/span | //button[contains(@class,'sign-in')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchContinuousUpgrade.testcase
@@ -56,26 +56,6 @@ definition {
 
 		TestUtils.hardRefresh();
 
-		User.firstLoginUI(
-			password = "test",
-			specificURL = "http://localhost:8080",
-			userEmailAddress = "test@liferay.com");
-
-		ApplicationsMenu.gotoPortlet(
-			category = "Configuration",
-			panel = "Control Panel",
-			portlet = "Search");
-
-		Click(
-			key_navItem = "Index Actions",
-			locator1 = "NavBar#NAV_ITEM_LINK");
-
-		SearchAdministration.startReindex(action = "All Search Indexes");
-
-		SearchAdministration.waitForReindexFinished(waitForReindexRequest = "true");
-
-		Navigator.openSpecificURL(url = "http://localhost:8080");
-
 		SearchPage.searchEmbedded(searchTerm = "WC Title");
 
 		Portlet.gotoPortletOptions(
@@ -377,24 +357,6 @@ definition {
 		Upgrade.restoreOriginalBundleAndUpgrade();
 
 		TestUtils.hardRefresh();
-
-		User.firstLoginUI(
-			password = "test",
-			specificURL = "http://localhost:8080",
-			userEmailAddress = "test@liferay.com");
-
-		ApplicationsMenu.gotoPortlet(
-			category = "Configuration",
-			panel = "Control Panel",
-			portlet = "Search");
-
-		Click(
-			key_navItem = "Index Actions",
-			locator1 = "NavBar#NAV_ITEM_LINK");
-
-		SearchAdministration.startReindex(action = "All Search Indexes");
-
-		SearchAdministration.waitForReindexFinished(waitForReindexRequest = "true");
 
 		ApplicationsMenu.gotoPortlet(
 			category = "Search Experiences",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchContinuousUpgrade.testcase
@@ -7,7 +7,7 @@ definition {
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
 	property minimum.slave.ram = "24";
 	property portal.release = "true";
-	property portal.upstream = "true";
+	property portal.upstream = "lucas";
 	property skip.start.app.server = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchContinuousUpgrade.testcase
@@ -15,16 +15,13 @@ definition {
 	property testcase.url = "file:///opt/dev/projects/github/liferay-portal/";
 	property testray.main.component.name = "Upgrades Search";
 
+	setUp {
+		Upgrade.startReleasedBundle();
+	}
+
 	@priority = 5
 	test ViewSearchPortletsConfiguration {
 		property portal.suite.search.engine = "elasticsearch7,solr";
-
-		var releaseBundleVersion = PropsUtil.get("test.released.release.bundle.version");
-		var releaseBundleZipURL = PropsUtil.get("test.released.test.portal.bundle.zip.url");
-
-		AntCommands.runCommand("build-test.xml", "prepare-upgrade-released-bundle-test-environment -Dtest.released.release.bundle.version=${releaseBundleVersion} -Dtest.released.test.portal.bundle.zip.url=${releaseBundleZipURL}");
-
-		Portlet.startServer(keepOsGiState = "true");
 
 		User.firstLoginUI(
 			password = "test",
@@ -55,11 +52,7 @@ definition {
 			displayFrequencies = "disable",
 			portletName = "Type Facet");
 
-		Portlet.shutdownServer();
-
-		AntCommands.runCommand("build-test.xml", "prepare-upgrade-original-bundle-test-environment");
-
-		Portlet.startServer(deleteLiferayHome = "false");
+		Upgrade.restoreOriginalBundleAndUpgrade();
 
 		TestUtils.hardRefresh();
 
@@ -130,13 +123,6 @@ definition {
 	@priority = 5
 	test ViewSXPBlueprintsAndElements {
 		property portal.suite.search.engine = "elasticsearch7";
-
-		var releaseBundleVersion = PropsUtil.get("test.released.release.bundle.version");
-		var releaseBundleZipURL = PropsUtil.get("test.released.test.portal.bundle.zip.url");
-
-		AntCommands.runCommand("build-test.xml", "prepare-upgrade-released-bundle-test-environment -Dtest.released.release.bundle.version=${releaseBundleVersion} -Dtest.released.test.portal.bundle.zip.url=${releaseBundleZipURL}");
-
-		Portlet.startServer(keepOsGiState = "true");
 
 		User.firstLoginUI(
 			password = "test",
@@ -388,13 +374,7 @@ definition {
 
 		PortletEntry.save();
 
-		Portlet.shutdownServer();
-
-		AntCommands.runCommand("build-test.xml", "prepare-upgrade-original-bundle-test-environment");
-
-		Portlet.startServer(deleteLiferayHome = "false");
-
-		Navigator.openSpecificURL(url = "http://localhost:8080");
+		Upgrade.restoreOriginalBundleAndUpgrade();
 
 		TestUtils.hardRefresh();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/AWSStoreContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/AWSStoreContinuousUpgrade.testcase
@@ -15,19 +15,12 @@ definition {
 	property test.run.type = "single";
 	property testray.main.component.name = "Database Upgrade Framework";
 
+	setUp {
+		Upgrade.startReleasedBundle();
+	}
+
 	@priority = 4
 	test AutoUpgradeFromLatest7413Update {
-		var releaseBundleVersion = PropsUtil.get("test.released.release.bundle.version");
-		var releaseBundleZipURL = PropsUtil.get("test.released.test.portal.bundle.zip.url");
-
-		AntCommands.runCommand("build-test.xml", "prepare-upgrade-released-bundle-test-environment -Dtest.released.release.bundle.version=${releaseBundleVersion} -Dtest.released.test.portal.bundle.zip.url=${releaseBundleZipURL}");
-
-		Portlet.startServer(keepOsGiState = "true");
-
-		AntCommands.runCommand("build-test.xml", "wait-for-license-activation");
-
-		Navigator.openSpecificURL(url = "http://localhost:8080");
-
 		User.firstLoginUI(
 			password = "test",
 			specificURL = "http://localhost:8080",
@@ -58,13 +51,7 @@ definition {
 			groupName = "Site Name",
 			siteURLKey = "site-name");
 
-		Portlet.shutdownServer();
-
-		AntCommands.runCommand("build-test.xml", "prepare-upgrade-original-bundle-test-environment");
-
-		Portlet.startServer(deleteLiferayHome = "false");
-
-		Navigator.openSpecificURL(url = "http://localhost:8080");
+		Upgrade.restoreOriginalBundleAndUpgrade();
 
 		User.firstLoginUI(
 			password = "test",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/AWSStoreContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/AWSStoreContinuousUpgrade.testcase
@@ -8,14 +8,13 @@ definition {
 	property minimum.slave.ram = "24";
 	property portal.release = "true";
 	property portal.smoke.upgrades = "false";
-	property portal.upstream = "true";
+	property portal.upstream = "lucas";
 	property skip.start.app.server = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
 	property test.run.type = "single";
 	property testray.main.component.name = "Database Upgrade Framework";
 
-	@ignore = "true"
 	@priority = 4
 	test AutoUpgradeFromLatest7413Update {
 		var releaseBundleVersion = PropsUtil.get("test.released.release.bundle.version");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/AWSStoreContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/AWSStoreContinuousUpgrade.testcase
@@ -53,11 +53,6 @@ definition {
 
 		Upgrade.restoreOriginalBundleAndUpgrade();
 
-		User.firstLoginUI(
-			password = "test",
-			specificURL = "http://localhost:8080",
-			userEmailAddress = "test@liferay.com");
-
 		AntCommands.runCommand("build-test-s3-store.xml", "assert-document-in-bucket -DcompanyId=${companyId} -DgroupId=${groupId} -Ds3.bucket.id=${bucketId}");
 
 		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "site-name");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
@@ -51,11 +51,6 @@ definition {
 			id = "image-square",
 			image = "tree-png");
 
-		User.firstLoginUI(
-			password = "test",
-			specificURL = "http://localhost:8080",
-			userEmailAddress = "test@liferay.com");
-
 		WebContentNavigator.openWebContentAdmin(
 			baseURL = "http://localhost:8080",
 			siteURLKey = "guest");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
@@ -2,33 +2,25 @@
 definition {
 
 	property app.server.types = "tomcat";
+	property database.bare.enabled = "true";
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver";
 	property minimum.slave.ram = "24";
 	property portal.release = "true";
 	property portal.smoke.upgrades = "false";
 	property portal.upstream = "lucas";
+	property skip.start.app.server = "true";
+	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
 	property test.run.type = "single";
 	property testcase.url = "file:///opt/dev/projects/github/liferay-portal/";
 	property testray.main.component.name = "Database Upgrade Framework";
 
+	setUp {
+		Upgrade.startReleasedBundle();
+	}
+
 	@priority = 4
 	test AutoUpgradeFromLatest7413Update {
-		property database.bare.enabled = "true";
-		property skip.start.app.server = "true";
-		property test.assert.warning.exceptions = "true";
-
-		var releaseBundleVersion = PropsUtil.get("test.released.release.bundle.version");
-		var releaseBundleZipURL = PropsUtil.get("test.released.test.portal.bundle.zip.url");
-
-		AntCommands.runCommand("build-test.xml", "prepare-upgrade-released-bundle-test-environment -Dtest.released.release.bundle.version=${releaseBundleVersion} -Dtest.released.test.portal.bundle.zip.url=${releaseBundleZipURL}");
-
-		Portlet.startServer(keepOsGiState = "true");
-
-		AntCommands.runCommand("build-test.xml", "wait-for-license-activation");
-
-		Navigator.openSpecificURL(url = "http://localhost:8080");
-
 		User.firstLoginUI(
 			password = "test",
 			specificURL = "http://localhost:8080",
@@ -50,13 +42,7 @@ definition {
 
 		WebContent.viewTitle(webContentTitle = "WC WebContent Title");
 
-		Portlet.shutdownServer();
-
-		AntCommands.runCommand("build-test.xml", "prepare-upgrade-original-bundle-test-environment");
-
-		Portlet.startServer(deleteLiferayHome = "false");
-
-		Navigator.openSpecificURL(url = "http://localhost:8080");
+		Upgrade.restoreOriginalBundleAndUpgrade();
 
 		TestUtils.hardRefresh();
 
@@ -84,11 +70,8 @@ definition {
 	@priority = 4
 	test AutoUpgradeFromLatest7413UpdateWithDBPartitionEnabled {
 		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
-		property database.bare.enabled = "true";
 		property database.types = "mysql";
 		property liferay.online.properties = "true";
-		property skip.start.app.server = "true";
-		property test.assert.warning.exceptions = "true";
 
 		var releaseBundleVersion = PropsUtil.get("test.released.release.bundle.version");
 		var releaseBundleZipURL = PropsUtil.get("test.released.test.portal.bundle.zip.url");
@@ -130,11 +113,7 @@ definition {
 			dmDocumentFile = "Document_1.doc",
 			dmDocumentTitle = "DM Document Title");
 
-		Portlet.shutdownServer();
-
-		AntCommands.runCommand("build-test.xml", "prepare-upgrade-original-bundle-test-environment");
-
-		Portlet.startServer(deleteLiferayHome = "false");
+		Upgrade.restoreOriginalBundleAndUpgrade();
 
 		User.firstLoginUI(
 			password = "test",
@@ -167,22 +146,8 @@ definition {
 
 	@priority = 4
 	test AutoUpgradeFromLatest7413UpdateWithDBPartitionEnabledAndHeadlessAPI {
-		property database.bare.enabled = "true";
 		property database.types = "mysql";
 		property liferay.online.properties = "true";
-		property skip.start.app.server = "true";
-		property test.assert.warning.exceptions = "true";
-
-		var releaseBundleVersion = PropsUtil.get("test.released.release.bundle.version");
-		var releaseBundleZipURL = PropsUtil.get("test.released.test.portal.bundle.zip.url");
-
-		AntCommands.runCommand("build-test.xml", "prepare-upgrade-released-bundle-test-environment -Dtest.released.release.bundle.version=${releaseBundleVersion} -Dtest.released.test.portal.bundle.zip.url=${releaseBundleZipURL}");
-
-		Portlet.startServer(keepOsGiState = "true");
-
-		AntCommands.runCommand("build-test.xml", "wait-for-license-activation");
-
-		Navigator.openSpecificURL(url = "http://localhost:8080");
 
 		User.firstLoginPG(
 			password = "test",
@@ -209,11 +174,7 @@ definition {
 			dmDocumentFile = "Document_1.doc",
 			dmDocumentTitle = "DM Document Title");
 
-		Portlet.shutdownServer();
-
-		AntCommands.runCommand("build-test.xml", "prepare-upgrade-original-bundle-test-environment");
-
-		Portlet.startServer(deleteLiferayHome = "false");
+		Upgrade.restoreOriginalBundleAndUpgrade();
 
 		User.firstLoginPG(
 			password = "test",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
@@ -6,7 +6,7 @@ definition {
 	property minimum.slave.ram = "24";
 	property portal.release = "true";
 	property portal.smoke.upgrades = "false";
-	property portal.upstream = "true";
+	property portal.upstream = "lucas";
 	property test.liferay.virtual.instance = "false";
 	property test.run.type = "single";
 	property testcase.url = "file:///opt/dev/projects/github/liferay-portal/";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
@@ -15,6 +15,7 @@ definition {
 		property database.bare.enabled = "true";
 		property database.partition.enabled = "true";
 		property portal.smoke.upgrades = "false";
+		property portal.upstream = "lucas";
 		property skip.start.app.server = "true";
 		property testcase.url = "file:///opt/dev/projects/github/liferay-portal/";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
@@ -19,17 +19,8 @@ definition {
 		property skip.start.app.server = "true";
 		property testcase.url = "file:///opt/dev/projects/github/liferay-portal/";
 
-		var releaseBundleVersion = PropsUtil.get("test.released.release.bundle.version");
-		var releaseBundleZipURL = PropsUtil.get("test.released.test.portal.bundle.zip.url");
-
 		task ("Given the user is using the latest 7413 portal version") {
-			AntCommands.runCommand("build-test.xml", "prepare-upgrade-released-bundle-test-environment -Dtest.released.release.bundle.version=${releaseBundleVersion} -Dtest.released.test.portal.bundle.zip.url=${releaseBundleZipURL}");
-
-			Portlet.startServer(keepOsGiState = "true");
-
-			AntCommands.runCommand("build-test.xml", "wait-for-license-activation");
-
-			Navigator.openSpecificURL(url = "http://localhost:8080");
+			Upgrade.startReleasedBundle();
 		}
 
 		task ("And a partitioned is present") {
@@ -42,11 +33,7 @@ definition {
 		}
 
 		task ("And the server is upgraded to a new version") {
-			Portlet.shutdownServer();
-
-			AntCommands.runCommand("build-test.xml", "prepare-upgrade-original-bundle-test-environment");
-
-			Portlet.startServer(deleteLiferayHome = "false");
+			Upgrade.restoreOriginalBundleAndUpgrade();
 
 			User.firstLoginPG(
 				password = "test",

--- a/test.properties
+++ b/test.properties
@@ -9471,113 +9471,11 @@
     # Upgrade
     #
 
-    test.batch.class.names.includes[upgrade]=\
-        **/portal-dao-test/**/*Test.java,\
-        **/portal-db-partition-test/**/*Test.java,\
-        **/portal-tools-db-partition*/**/*Test.java,\
-        **/src/test/**/*Upgrade*Test.java,\
-        **/src/testIntegration/**/*Upgrade*Test.java,\
-        **/src/testIntegration/**/Verify*Test.java,\
-        **/test/**/*Upgrade*Test.java,\
-        **/testIntegration/**/*Upgrade*Test.java,\
-        **/testIntegration/**/upgrade/**/Release*Test.java
-
     test.batch.dist.app.servers[upgrade]=tomcat
 
     test.batch.names[upgrade]=\
-        functional-tomcat90-db2111-jdk8,\
-        functional-tomcat90-mariadb102-jdk8,\
         functional-tomcat90-mysql57-jdk8,\
-        functional-tomcat90-mysql80-jdk8,\
-        functional-tomcat90-oracle193-jdk8,\
-        functional-tomcat90-postgresql144-jdk8,\
-        functional-tomcat90-postgresql153-jdk8,\
-        functional-upgrade-tomcat90-db2111-jdk8,\
-        functional-upgrade-tomcat90-mariadb102-jdk8,\
-        functional-upgrade-tomcat90-mysql57-jdk8,\
-        functional-upgrade-tomcat90-oracle193-jdk8,\
-        functional-upgrade-tomcat90-postgresql144-jdk8,\
-        functional-upgrade-tomcat90-postgresql153-jdk8,\
-        functional-upgrade-tomcat90-sqlserver2017-jdk8,\
-        modules-integration-db2111-jdk8,\
-        modules-integration-mariadb102-jdk8,\
-        modules-integration-mysql57-jdk8,\
-        modules-integration-oracle193-jdk8,\
-        modules-integration-postgresql144-jdk8,\
-        modules-integration-postgresql153-jdk8,\
-        modules-integration-sqlserver2017-jdk8,\
-        modules-unit-jdk8
-
-    test.batch.run.property.query[functional-tomcat90-db2111-jdk8][upgrade]=\
-        (\
-            (app.server.types == null) OR \
-            (app.server.types ~ tomcat)\
-        ) AND \
-        (data.archive.type == null) AND \
-        (\
-            (database.types == null) OR \
-            (database.types ~ db2)\
-        ) AND \
-        (portal.acceptance != quarantine) AND \
-        (portal.upstream == true) AND \
-        (testray.main.component.name == "Database Upgrade Framework")
-
-    test.batch.run.property.query[functional-tomcat90-mariadb102-jdk8][upgrade]=\
-        (\
-            (app.server.types == null) OR \
-            (app.server.types ~ tomcat)\
-        ) AND \
-        (data.archive.type == null) AND \
-        (\
-            (database.types == null) OR \
-            (database.types ~ mariadb)\
-        ) AND \
-        (portal.acceptance != quarantine) AND \
-        (portal.upstream == true) AND \
-        (testray.main.component.name == "Database Upgrade Framework")
-
-    test.batch.run.property.query[functional-tomcat90-oracle193-jdk8][upgrade]=\
-        (\
-            (app.server.types == null) OR \
-            (app.server.types ~ tomcat)\
-        ) AND \
-        (data.archive.type == null) AND \
-        (\
-            (database.types == null) OR \
-            (database.types ~ oracle)\
-        ) AND \
-        (portal.acceptance != quarantine) AND \
-        (portal.upstream == true) AND \
-        (testray.main.component.name == "Database Upgrade Framework")
-
-    test.batch.run.property.query[functional-tomcat90-postgresql*-jdk8][upgrade]=\
-        (\
-            (app.server.types == null) OR \
-            (app.server.types ~ tomcat)\
-        ) AND \
-        (data.archive.type == null) AND \
-        (\
-            (database.types == null) OR \
-            (database.types ~ postgresql)\
-        ) AND \
-        (portal.acceptance != quarantine) AND \
-        (portal.upstream == true) AND \
-        (testray.main.component.name == "Database Upgrade Framework")
-
-    test.batch.run.property.query[functional-tomcat90-mysql80-jdk8][upgrade]=\
-        (\
-            (app.server.types == null) OR \
-            (app.server.types ~ tomcat)\
-        ) AND \
-        (data.archive.type == null) AND \
-        (\
-            (database.types == null) OR \
-            (database.types ~ mysql)\
-        ) AND \
-        (database.partition.enabled == null) AND \
-        (portal.acceptance != quarantine) AND \
-        (portal.upstream == true) AND \
-        (testray.main.component.name == "Database Upgrade Framework")
+        functional-upgrade-tomcat90-mysql57-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][upgrade]=\
         (\
@@ -9590,45 +9488,10 @@
             (database.types ~ mysql)\
         ) AND \
         (portal.acceptance != quarantine) AND \
-        (portal.upstream == true) AND \
+        (portal.upstream == lucas) AND \
         (\
             (testray.main.component.name == "Database Partitioning") OR \
             (testray.main.component.name == "Database Upgrade Framework")\
-        )
-
-    test.batch.run.property.query[functional-upgrade-tomcat90-db2111-jdk8][upgrade]=\
-        (\
-            (app.server.types == null) OR \
-            (app.server.types ~ tomcat)\
-        ) AND \
-        (data.archive.type != null) AND \
-        (\
-            (database.types == null) OR \
-            (database.types ~ db2)\
-        ) AND \
-        (portal.acceptance != quarantine) AND \
-        (portal.upstream == true) AND \
-        (\
-            (testray.main.component.name == "Database Upgrade Framework") OR \
-            (testray.main.component.name == "Database Upgrade Tool") OR \
-            (testray.main.component.name == "Verify Properties")\
-        )
-
-    test.batch.run.property.query[functional-upgrade-tomcat90-mariadb102-jdk8][upgrade]=\
-        (\
-            (app.server.types == null) OR \
-            (app.server.types ~ tomcat)\
-        ) AND \
-        (data.archive.type != null) AND \
-        (\
-            (database.types == null) OR \
-            (database.types ~ mariadb)\
-        ) AND \
-        (portal.acceptance != quarantine) AND \
-        (portal.upstream == true) AND \
-        (\
-            (testray.main.component.name == "Database Upgrade Framework") OR \
-            (testray.main.component.name == "Database Upgrade Tool")\
         )
 
     test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][upgrade]=\
@@ -9642,66 +9505,12 @@
             (database.types ~ mysql)\
         ) AND \
         (portal.acceptance != quarantine) AND \
-        (portal.upstream == true) AND \
+        (portal.upstream == lucas) AND \
         (\
             (testray.main.component.name == "Database Partitioning") OR \
             (testray.main.component.name == "Database Upgrade Framework") OR \
             (testray.main.component.name == "Database Upgrade Tool") OR \
             (testray.main.component.name == "Portal Configuration") OR \
-            (testray.main.component.name == "Verify Properties")\
-        )
-
-    test.batch.run.property.query[functional-upgrade-tomcat90-oracle193-jdk8][upgrade]=\
-        (\
-            (app.server.types == null) OR \
-            (app.server.types ~ tomcat)\
-        ) AND \
-        (data.archive.type != null) AND \
-        (\
-            (database.types == null) OR \
-            (database.types ~ oracle)\
-        ) AND \
-        (portal.acceptance != quarantine) AND \
-        (portal.upstream == true) AND \
-        (\
-            (testray.main.component.name == "Database Upgrade Framework") OR \
-            (testray.main.component.name == "Database Upgrade Tool") OR \
-            (testray.main.component.name == "Verify Properties")\
-        )
-
-    test.batch.run.property.query[functional-upgrade-tomcat90-postgresql*-jdk8][upgrade]=\
-        (\
-            (app.server.types == null) OR \
-            (app.server.types ~ tomcat)\
-        ) AND \
-        (data.archive.type != null) AND \
-        (\
-            (database.types == null) OR \
-            (database.types ~ postgresql)\
-        ) AND \
-        (portal.acceptance != quarantine) AND \
-        (portal.upstream == true) AND \
-        (\
-            (testray.main.component.name == "Database Upgrade Framework") OR \
-            (testray.main.component.name == "Database Upgrade Tool") OR \
-            (testray.main.component.name == "Verify Properties")\
-        )
-
-    test.batch.run.property.query[functional-upgrade-tomcat90-sqlserver2017-jdk8][upgrade]=\
-        (\
-            (app.server.types == null) OR \
-            (app.server.types ~ tomcat)\
-        ) AND \
-        (data.archive.type != null) AND \
-        (\
-            (database.types == null) OR \
-            (database.types ~ sqlserver)\
-        ) AND \
-        (portal.acceptance != quarantine) AND \
-        (portal.upstream == true) AND \
-        (\
-            (testray.main.component.name == "Database Upgrade Framework") OR \
-            (testray.main.component.name == "Database Upgrade Tool") OR \
             (testray.main.component.name == "Verify Properties")\
         )
 


### PR DESCRIPTION
**Background**

LPS-200635 - 
1. Tests are failling because [CI is using U101](https://testray.liferay.com/home/-/testray/case_results/2457257079?redirect=https%3A%2F%2Ftestray.liferay.com%2Fhome%2F-%2Ftestray%2Fcase_results%2Findex%3FtestrayBuildId%3D2457256984%26cur%3D1%26delta%3D200%26orderByCol%3Dstatus_sortable%26orderByType%3Dasc), that it's not set to use tomcat 80 on build-test.xml, changed that at https://github.com/liferay-uniform/liferay-portal/pull/1552/commits/fe1d97d4cf29408152410369cc16f8f5b9f7e7db.
2. After that is fixed, I've noticed that there are path differences between U101 : U102 and Master, due to [LPS-198516](https://liferay.atlassian.net/browse/LPS-198516), I've sent https://github.com/liferay-uniform/liferay-portal/pull/1552/commits/fbcdbdf473c2ae6784b818a8c0eaad8f3dff451d as a temp commit to prove that on CI for now, that will also be needed if we are going to run Q3 > Master upgrades.

LPS-193399 - 
1. We have some steps that are repeated in the continuous tests, splitted then into different macros, one for the pre-upgrade(`startReleasedBundle`), and other for the upgrade/post-upgrade(`restoreOriginalBundleAndUpgrade`)
2. I've called `startReleasedBundle` on setup for the continuous tests files since it's always done in the beggining of the tests.

LPS-200612 - 
1. All upgrade tests should be Reindexing after the upgrade is completed, so I've [added](https://github.com/liferay-uniform/liferay-portal/pull/1552/commits/1f2d67c77caaf0b9cdb49e88539d18ae3b17881b) the steps to reindex after the upgrade is completed inside `restoreOriginalBundleAndUpgrade` macro. 

**JIRA Ticket:**
https://liferay.atlassian.net/browse/LPS-200635
https://liferay.atlassian.net/browse/LPS-200635
https://liferay.atlassian.net/browse/LPS-200612