### PR TITLE
LPS-201786 Increase timeout to wait for virtual instance to be created before accessing it

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
@@ -283,12 +283,10 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		PortalInstances.openVirtualInstancesAdmin();
-
-		PortalInstances.addCP(
-			mailDomain = "www.able.com",
-			virtualHost = "www.able.com",
-			webId = "www.able.com");
+		HeadlessPortalInstanceAPI.addPortalInstance(
+			domain = "www.able.com",
+			portalInstanceId = "www.able.com",
+			virtualHost = "www.able.com");
 
 		SignOut.signOut();
 
@@ -411,12 +409,10 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		PortalInstances.openVirtualInstancesAdmin();
-
-		PortalInstances.addCP(
-			mailDomain = "www.able.com",
-			virtualHost = "www.able.com",
-			webId = "www.able.com");
+		HeadlessPortalInstanceAPI.addPortalInstance(
+			domain = "www.able.com",
+			portalInstanceId = "www.able.com",
+			virtualHost = "www.able.com");
 
 		User.firstLoginUI(
 			password = "test",
@@ -462,19 +458,15 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		PortalInstances.openVirtualInstancesAdmin();
+		HeadlessPortalInstanceAPI.addPortalInstance(
+			domain = "www.able.com",
+			portalInstanceId = "www.able.com",
+			virtualHost = "www.able.com");
 
-		PortalInstances.addCP(
-			mailDomain = "www.able.com",
-			virtualHost = "www.able.com",
-			webId = "www.able.com");
-
-		PortalInstances.openVirtualInstancesAdmin();
-
-		PortalInstances.addCP(
-			mailDomain = "www.baker.com",
-			virtualHost = "www.baker.com",
-			webId = "www.baker.com");
+		HeadlessPortalInstanceAPI.addPortalInstance(
+			domain = "www.baker.com",
+			portalInstanceId = "www.baker.com",
+			virtualHost = "www.baker.com");
 
 		User.firstLoginUI(
 			password = "test",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioningCache.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioningCache.testcase
@@ -3,6 +3,7 @@ definition {
 
 	property app.server.types = "tomcat";
 	property ci.retries.disabled = "true";
+	property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
 	property database.types = "mysql";
 	property liferay.online.properties = "true";
 	property portal.release = "true";
@@ -25,12 +26,10 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		PortalInstances.openVirtualInstancesAdmin();
-
-		PortalInstances.addCP(
-			mailDomain = "www.able.com",
-			virtualHost = "www.able.com",
-			webId = "www.able.com");
+		HeadlessPortalInstanceAPI.addPortalInstance(
+			domain = "www.able.com",
+			portalInstanceId = "www.able.com",
+			virtualHost = "www.able.com");
 
 		User.firstLoginUI(
 			password = "test",
@@ -100,12 +99,10 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		PortalInstances.openVirtualInstancesAdmin();
-
-		PortalInstances.addCP(
-			mailDomain = "www.able.com",
-			virtualHost = "www.able.com",
-			webId = "www.able.com");
+		HeadlessPortalInstanceAPI.addPortalInstance(
+			domain = "www.able.com",
+			portalInstanceId = "www.able.com",
+			virtualHost = "www.able.com");
 
 		ApplicationsMenu.gotoPortlet(
 			category = "System",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
@@ -66,6 +66,7 @@ definition {
 		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
 		property database.types = "mysql";
 		property liferay.online.properties = "true";
+		property timeout.explicit.wait = "120";
 
 		User.firstLoginUI(
 			password = "test",


### PR DESCRIPTION
**Background**
Tests are occasionally trying to access [www.able.com](http://www.able.com/) before it is finished initializing.

**Test Plan:**
Increase the timeout for continuous test. Default is 60. Using API for other tests.

**JIRA Ticket:**
https://liferay.atlassian.net/browse/LPS-201786