### PR TITLE
LPS-201982 Image is no longer cached by browser, do not delete liferay home

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
@@ -619,7 +619,7 @@ definition {
 		task ("Restart server") {
 			Portlet.shutdownServer();
 
-			Portlet.startServer(keepOsGiState = "true");
+			Portlet.startServer(deleteLiferayHome = "false");
 		}
 
 		task ("Access Virtual Instance and verify that is visible in the UI") {


### PR DESCRIPTION
**Background**
[DatabasePartitioning#NewCompanyStillAccessibleAfterRestartWithCaseInsensitiveDatabase](https://testray.liferay.com/home/-/testray/case_results/2455543900) is failing because it cannot find the tree image. Due to changes in https://github.com/liferay/liferay-portal/commit/51895916ce756437c2ae1c11a734c9e640abbb05, which no longer caches the image by the browser.

**Test Plan**
Do not delete liferay home to save the image.

**JIRA Ticket:**
https://liferay.atlassian.net/browse/LPS-201982