### PR TITLE
LPS-197686  Have a more accurate upgrade status

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -216,10 +216,6 @@ public class UpgradeRecorder {
 
 			SchemaVersions schemaVersions = schemaVersionsEntry.getValue();
 
-			if (schemaVersions._getInitial() == null) {
-				continue;
-			}
-
 			Version initialVersion = Version.parseVersion(
 				schemaVersions._getInitial());
 			Version finalVersion = Version.parseVersion(
@@ -283,7 +279,7 @@ public class UpgradeRecorder {
 					servletContextName);
 
 				if (moduleSchemaVersions == null) {
-					moduleSchemaVersions = new SchemaVersions(null);
+					moduleSchemaVersions = new SchemaVersions();
 
 					_schemaVersionsMap.put(
 						servletContextName, moduleSchemaVersions);
@@ -336,10 +332,6 @@ public class UpgradeRecorder {
 
 	private class SchemaVersions {
 
-		public SchemaVersions(String initial) {
-			_initial = initial;
-		}
-
 		private String _getFinal() {
 			return _final;
 		}
@@ -354,8 +346,6 @@ public class UpgradeRecorder {
 
 		private void _setInitial(String initial) {
 			if (initial == null) {
-				_initial = "0.0.0";
-
 				return;
 			}
 
@@ -363,7 +353,7 @@ public class UpgradeRecorder {
 		}
 
 		private String _final;
-		private String _initial;
+		private String _initial = "0.0.0";
 
 	}
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -177,16 +177,12 @@ public class UpgradeRecorder {
 	}
 
 	private String _calculateResult() {
-		if (!_errorMessages.isEmpty()) {
-			return "failure";
-		}
+		String result;
 
 		try {
 			ReleaseManager releaseManager = _serviceTracker.getService();
 
-			if (!releaseManager.isUpgraded()) {
-				return "unresolved";
-			}
+			result = releaseManager.getStatus();
 		}
 		catch (Exception exception) {
 			_log.error(
@@ -194,15 +190,12 @@ public class UpgradeRecorder {
 					"Unable to check the upgrade result due to ",
 					exception.getMessage(), ". Please check manually."));
 
-			return "failure";
+			return "Failure";
 		}
 
-		if (!_warningMessages.isEmpty()) {
-			return "warning";
-		}
-
-		return "success";
+		return result;
 	}
+
 
 	private String _calculateType() {
 		_processRelease(

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -140,7 +140,7 @@ public class UpgradeRecorder {
 
 		if (_log.isInfoEnabled()) {
 			if (_type.equals("no upgrade")) {
-				if (_result.equals("success")) {
+				if (_result.equals("Success")) {
 					_log.info("No pending upgrades to run");
 				}
 				else {
@@ -153,9 +153,13 @@ public class UpgradeRecorder {
 				_log.info(
 					StringBundler.concat(
 						StringUtil.toUpperCase(_type.substring(0, 1)),
-						_type.substring(1), " upgrade finished with result ",
+						_type.substring(1), " upgrade finished with result: ",
 						_result));
 			}
+		}
+
+		if (!_errorMessages.isEmpty()) {
+			_log.info("Errors occurred during upgrade, check logs");
 		}
 
 		if (PropsValues.UPGRADE_LOG_CONTEXT_ENABLED) {
@@ -195,7 +199,6 @@ public class UpgradeRecorder {
 
 		return result;
 	}
-
 
 	private String _calculateType() {
 		_processRelease(

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.verify.VerifyException;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -93,6 +94,10 @@ public class UpgradeRecorder {
 		occurrences++;
 
 		messages.put(message, occurrences);
+
+		if (message.contains(VerifyException.class.getName())) {
+			_verifyProcessStatus = false;
+		}
 	}
 
 	public void recordUpgradeProcessMessage(String loggerName, String message) {
@@ -194,6 +199,10 @@ public class UpgradeRecorder {
 					"Unable to check the upgrade result due to ",
 					exception.getMessage(), ". Please check manually."));
 
+			return "Failure";
+		}
+
+		if (!_verifyProcessStatus) {
 			return "Failure";
 		}
 
@@ -308,6 +317,7 @@ public class UpgradeRecorder {
 	private static String _type;
 	private static final Map<String, ArrayList<String>>
 		_upgradeProcessMessages = new ConcurrentHashMap<>();
+	private static boolean _verifyProcessStatus = true;
 	private static final Map<String, Map<String, Integer>> _warningMessages =
 		new ConcurrentHashMap<>();
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
@@ -109,7 +109,7 @@ public class ReleaseManagerImpl implements ReleaseManager {
 
 		sb.append(_checkModules(showUpgradeSteps));
 
-		if (!_hasUnsatisfiedUpgradeComponents()) {
+		if (_hasUnsatisfiedUpgradeComponents()) {
 			sb.append("Unsatisfied components prevent upgrade processes to ");
 			sb.append("be registered");
 
@@ -306,7 +306,7 @@ public class ReleaseManagerImpl implements ReleaseManager {
 	private boolean _hasUnsatisfiedUpgradeComponents() {
 		String result = _systemChecker.check();
 
-		return !result.contains("UpgradeStepRegistrator");
+		return result.contains("UpgradeStepRegistrator");
 	}
 
 	private boolean _isPendingModuleUpgrades() {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
@@ -12,11 +12,13 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Release;
+import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.service.ReleaseLocalService;
 import com.liferay.portal.kernel.upgrade.ReleaseManager;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.osgi.debug.SystemChecker;
@@ -388,7 +390,9 @@ public class ReleaseManagerImpl implements ReleaseManager {
 			Release release = _releaseLocalService.fetchRelease(
 				bundleSymbolicName);
 
-			if (release == null) {
+			if ((release == null) ||
+				StringUtil.equals("0.0.0", release.getSchemaVersion())) {
+
 				try {
 					schemaCreator.create();
 
@@ -397,13 +401,19 @@ public class ReleaseManagerImpl implements ReleaseManager {
 						"0.0.0");
 
 					release.setVerified(true);
+				}
+				catch (Exception exception) {
+					release = _releaseLocalService.addRelease(
+						bundleSymbolicName, "0.0.0");
 
+					release.setState(ReleaseConstants.STATE_UPGRADE_FAILURE);
+
+					ReflectionUtil.throwException(exception);
+				}
+				finally {
 					release = _releaseLocalService.updateRelease(release);
 
 					_releasePublisher.publish(release, true);
-				}
-				catch (Exception exception) {
-					ReflectionUtil.throwException(exception);
 				}
 			}
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
@@ -119,17 +119,25 @@ public class ReleaseManagerImpl implements ReleaseManager {
 		return sb.toString();
 	}
 
-	@Override
-	public boolean isUpgraded() throws Exception {
-		try (Connection connection = DataAccess.getConnection()) {
-			if (!PortalUpgradeProcess.isInLatestSchemaVersion(connection) ||
-				_isPendingModuleUpgrades()) {
 
-				return false;
+	@Override
+	public String getStatus() throws Exception {
+		try (Connection connection = DataAccess.getConnection()) {
+			if (!PortalUpgradeProcess.isInLatestSchemaVersion(connection)) {
+
+				return "Failed";
+			}
+
+			if(_isPendingModuleUpgrades()){
+				return "Failed";
 			}
 		}
 
-		return _hasUnsatisfiedUpgradeComponents();
+		if (_hasUnsatisfiedUpgradeComponents()) {
+			return "Unresolved";
+		}
+
+		return "Success";
 	}
 
 	@Activate

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/ReleaseManager.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/ReleaseManager.java
@@ -15,6 +15,6 @@ public interface ReleaseManager {
 
 	public String getStatusMessage(boolean showUpgradeSteps);
 
-	public boolean isUpgraded() throws Exception;
+	public String getStatus() throws Exception;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
@@ -1,1 +1,1 @@
-version 21.3.0
+version 22.0.0


### PR DESCRIPTION
Issue:
Errors and Warnings during the upgrade may or may not be related to the upgrade process. If errors are thrown, we assume that the upgrade failed, however there are root causes for the error that do not stem from an upgraded process.

Solution(s):

1. Set the status of the upgrade based on the success of Core and Module Upgrades, any unresolved dependencies, as well as any failures during a Verify Process. 

2. For new services,  adding a release with an initial schema version of "0.0.0" will catch any failures if the table fails to create.



