### PR TITLE
LPS-197686 - Have a more accurate upgrade result

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -138,7 +138,8 @@ public class UpgradeRecorder {
 		_filter(_warningMessages);
 
 		_result = _calculateResult();
-		_type = _calculateType();
+
+		_type = _calculateType(_result);
 
 		if (PropsValues.UPGRADE_LOG_CONTEXT_ENABLED) {
 			ThreadContext.put("upgrade.type", _type);
@@ -146,15 +147,8 @@ public class UpgradeRecorder {
 		}
 
 		if (_log.isInfoEnabled()) {
-			if (_type.equals("no upgrade")) {
-				if (_result.equals("success")) {
-					_log.info("No pending upgrades to run");
-				}
-				else {
-					_log.info(
-						"Upgrade process failed or upgrade dependencies are " +
-							"not resolved");
-				}
+			if (_type.equals("no upgrade") && _result.equals("success")) {
+				_log.info("No pending upgrades to run");
 			}
 			else {
 				_log.info(
@@ -209,7 +203,7 @@ public class UpgradeRecorder {
 		}
 	}
 
-	private String _calculateType() {
+	private String _calculateType(String result) {
 		_processRelease(
 			(moduleSchemaVersions, schemaVersion) ->
 				moduleSchemaVersions._setFinal(schemaVersion));
@@ -249,6 +243,10 @@ public class UpgradeRecorder {
 			}
 
 			type = "micro";
+		}
+
+		if (type.equals("no upgrade") && !result.equals("success")) {
+			return "major";
 		}
 
 		return type;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -162,11 +162,13 @@ public class UpgradeRecorder {
 						StringUtil.toUpperCase(_type.substring(0, 1)),
 						_type.substring(1), " upgrade finished with result ",
 						_result));
-			}
-		}
 
-		if (!_errorMessages.isEmpty()) {
-			_log.info("Errors occurred during upgrade, check logs");
+				if (!_result.equals("failure") && !_errorMessages.isEmpty()) {
+					_log.info(
+						"Unrelated errors occur during the upgrade, please " +
+							"check the logs");
+				}
+			}
 		}
 
 		if (PropsValues.UPGRADE_LOG_CONTEXT_ENABLED) {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -177,16 +177,10 @@ public class UpgradeRecorder {
 	}
 
 	private String _calculateResult() {
-		if (!_errorMessages.isEmpty()) {
-			return "failure";
-		}
-
 		try {
 			ReleaseManager releaseManager = _serviceTracker.getService();
 
-			if (!releaseManager.isUpgraded()) {
-				return "unresolved";
-			}
+			return releaseManager.getStatus();
 		}
 		catch (Exception exception) {
 			_log.error(
@@ -196,12 +190,6 @@ public class UpgradeRecorder {
 
 			return "failure";
 		}
-
-		if (!_warningMessages.isEmpty()) {
-			return "warning";
-		}
-
-		return "success";
 	}
 
 	private String _calculateType() {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -95,8 +95,10 @@ public class UpgradeRecorder {
 
 		messages.put(message, occurrences);
 
-		if (message.contains(VerifyException.class.getName())) {
-			_verifyProcessStatus = false;
+		if (!_verifyProcessError &&
+			message.contains(VerifyException.class.getName())) {
+
+			_verifyProcessError = true;
 		}
 	}
 
@@ -163,6 +165,10 @@ public class UpgradeRecorder {
 			}
 		}
 
+		if (!_errorMessages.isEmpty()) {
+			_log.info("Errors occurred during upgrade, check logs");
+		}
+
 		if (PropsValues.UPGRADE_LOG_CONTEXT_ENABLED) {
 			ThreadContext.clearMap();
 		}
@@ -182,7 +188,7 @@ public class UpgradeRecorder {
 	}
 
 	private String _calculateResult() {
-		if (!_verifyProcessStatus) {
+		if (_verifyProcessError) {
 			return "failure";
 		}
 
@@ -313,7 +319,7 @@ public class UpgradeRecorder {
 	private static String _type;
 	private static final Map<String, ArrayList<String>>
 		_upgradeProcessMessages = new ConcurrentHashMap<>();
-	private static boolean _verifyProcessStatus;
+	private static boolean _verifyProcessError;
 	private static final Map<String, Map<String, Integer>> _warningMessages =
 		new ConcurrentHashMap<>();
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -214,7 +214,7 @@ public class UpgradeRecorder {
 			SchemaVersions schemaVersions = schemaVersionsEntry.getValue();
 
 			if (schemaVersions._getInitial() == null) {
-				continue;
+				return "major";
 			}
 
 			Version initialVersion = Version.parseVersion(

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.verify.VerifyException;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -93,6 +94,10 @@ public class UpgradeRecorder {
 		occurrences++;
 
 		messages.put(message, occurrences);
+
+		if (message.contains(VerifyException.class.getName())) {
+			_verifyProcessStatus = false;
+		}
 	}
 
 	public void recordUpgradeProcessMessage(String loggerName, String message) {
@@ -177,6 +182,10 @@ public class UpgradeRecorder {
 	}
 
 	private String _calculateResult() {
+		if (!_verifyProcessStatus) {
+			return "failure";
+		}
+
 		try {
 			ReleaseManager releaseManager = _serviceTracker.getService();
 
@@ -304,6 +313,7 @@ public class UpgradeRecorder {
 	private static String _type;
 	private static final Map<String, ArrayList<String>>
 		_upgradeProcessMessages = new ConcurrentHashMap<>();
+	private static boolean _verifyProcessStatus;
 	private static final Map<String, Map<String, Integer>> _warningMessages =
 		new ConcurrentHashMap<>();
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
@@ -109,7 +109,7 @@ public class ReleaseManagerImpl implements ReleaseManager {
 
 		sb.append(_checkModules(showUpgradeSteps));
 
-		if (!_hasUnsatisfiedUpgradeComponents()) {
+		if (_hasUnsatisfiedUpgradeComponents()) {
 			sb.append("Unsatisfied components prevent upgrade processes to ");
 			sb.append("be registered");
 
@@ -306,7 +306,7 @@ public class ReleaseManagerImpl implements ReleaseManager {
 	private boolean _hasUnsatisfiedUpgradeComponents() {
 		String result = _systemChecker.check();
 
-		return !result.contains("UpgradeStepRegistrator");
+		return result.contains("UpgradeStepRegistrator");
 	}
 
 	private boolean _isPendingModuleUpgrades() {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
@@ -12,11 +12,13 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Release;
+import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.service.ReleaseLocalService;
 import com.liferay.portal.kernel.upgrade.ReleaseManager;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.osgi.debug.SystemChecker;
@@ -388,7 +390,9 @@ public class ReleaseManagerImpl implements ReleaseManager {
 			Release release = _releaseLocalService.fetchRelease(
 				bundleSymbolicName);
 
-			if (release == null) {
+			if ((release == null) ||
+				StringUtil.equals("0.0.0", release.getSchemaVersion())) {
+
 				try {
 					schemaCreator.create();
 
@@ -397,13 +401,19 @@ public class ReleaseManagerImpl implements ReleaseManager {
 						"0.0.0");
 
 					release.setVerified(true);
+				}
+				catch (Exception exception) {
+					release = _releaseLocalService.addRelease(
+						bundleSymbolicName, "0.0.0");
 
+					release.setState(ReleaseConstants.STATE_UPGRADE_FAILURE);
+
+					ReflectionUtil.throwException(exception);
+				}
+				finally {
 					release = _releaseLocalService.updateRelease(release);
 
 					_releasePublisher.publish(release, true);
-				}
-				catch (Exception exception) {
-					ReflectionUtil.throwException(exception);
 				}
 			}
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
@@ -98,6 +98,23 @@ public class ReleaseManagerImpl implements ReleaseManager {
 	}
 
 	@Override
+	public String getStatus() throws Exception {
+		try (Connection connection = DataAccess.getConnection()) {
+			if (!PortalUpgradeProcess.isInLatestSchemaVersion(connection) ||
+				_isPendingModuleUpgrades()) {
+
+				return "failure";
+			}
+		}
+
+		if (_hasUnsatisfiedUpgradeComponents()) {
+			return "unresolved";
+		}
+
+		return "success";
+	}
+
+	@Override
 	public String getStatusMessage(boolean showUpgradeSteps) {
 		StringBundler sb = new StringBundler(6);
 
@@ -117,19 +134,6 @@ public class ReleaseManagerImpl implements ReleaseManager {
 		}
 
 		return sb.toString();
-	}
-
-	@Override
-	public boolean isUpgraded() throws Exception {
-		try (Connection connection = DataAccess.getConnection()) {
-			if (!PortalUpgradeProcess.isInLatestSchemaVersion(connection) ||
-				_isPendingModuleUpgrades()) {
-
-				return false;
-			}
-		}
-
-		return _hasUnsatisfiedUpgradeComponents();
 	}
 
 	@Activate

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleaseManagerTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleaseManagerTest.java
@@ -52,7 +52,7 @@ public class ReleaseManagerTest {
 
 	@Test
 	public void testSuccessfulUpgrade() throws Exception {
-		Assert.assertTrue(_releaseManager.isUpgraded());
+		Assert.assertEquals("success", _releaseManager.getStatus());
 		Assert.assertTrue(
 			Validator.isBlank(_releaseManager.getShortStatusMessage(false)));
 		Assert.assertTrue(
@@ -79,7 +79,7 @@ public class ReleaseManagerTest {
 
 			release = _releaseLocalService.updateRelease(release);
 
-			Assert.assertFalse(_releaseManager.isUpgraded());
+			Assert.assertEquals("failure", _releaseManager.getStatus());
 			Assert.assertFalse(
 				Validator.isBlank(
 					_releaseManager.getShortStatusMessage(false)));
@@ -103,7 +103,7 @@ public class ReleaseManagerTest {
 				connection, new Version(0, 0, 0));
 
 			try {
-				Assert.assertFalse(_releaseManager.isUpgraded());
+				Assert.assertEquals("failure", _releaseManager.getStatus());
 				Assert.assertFalse(
 					Validator.isBlank(
 						_releaseManager.getShortStatusMessage(false)));

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
@@ -68,22 +68,7 @@ public class UpgradeRecorderTest {
 	}
 
 	@Test
-	public void testFailure() throws Exception {
-		StartupHelperUtil.setUpgrading(true);
-
-		ErrorUpgradeProcess errorUpgradeProcess = new ErrorUpgradeProcess();
-
-		errorUpgradeProcess.doUpgrade();
-
-		StartupHelperUtil.setUpgrading(false);
-
-		Assert.assertEquals("failure", _getResult());
-
-		Assert.assertEquals("no upgrade", _getType());
-	}
-
-	@Test
-	public void testFailureByPendingUpgrade() throws SQLException {
+	public void testFailureStatusByPendingCoreUpgrade() throws SQLException {
 		try (Connection connection = DataAccess.getConnection()) {
 			Version version = PortalUpgradeProcess.getCurrentSchemaVersion(
 				connection);
@@ -101,9 +86,9 @@ public class UpgradeRecorderTest {
 			}
 		}
 
-		Assert.assertEquals("unresolved", _getResult());
+		Assert.assertEquals("failure", _getResult());
 
-		Assert.assertEquals("no upgrade", _getType());
+		Assert.assertEquals("major", _getType());
 	}
 
 	@Test
@@ -135,7 +120,7 @@ public class UpgradeRecorderTest {
 	}
 
 	@Test
-	public void testSuccessByNoUpgrades() {
+	public void testSuccessResultByNoUpgrades() {
 		StartupHelperUtil.setUpgrading(true);
 
 		StartupHelperUtil.setUpgrading(false);
@@ -146,7 +131,23 @@ public class UpgradeRecorderTest {
 	}
 
 	@Test
-	public void testWarning() throws Exception {
+	public void testSuccessResultWithUnrelatedError() throws Exception {
+		StartupHelperUtil.setUpgrading(true);
+
+		UnrelatedErrorUpgradeProcess unrelatedErrorUpgradeProcess =
+			new UnrelatedErrorUpgradeProcess();
+
+		unrelatedErrorUpgradeProcess.doUpgrade();
+
+		StartupHelperUtil.setUpgrading(false);
+
+		Assert.assertEquals("success", _getResult());
+
+		Assert.assertEquals("no upgrade", _getType());
+	}
+
+	@Test
+	public void testSuccessResultWithWarning() throws Exception {
 		StartupHelperUtil.setUpgrading(true);
 
 		WarningUpgradeProcess warningUpgradeProcess =
@@ -156,7 +157,7 @@ public class UpgradeRecorderTest {
 
 		StartupHelperUtil.setUpgrading(false);
 
-		Assert.assertEquals("warning", _getResult());
+		Assert.assertEquals("success", _getResult());
 
 		Assert.assertEquals("no upgrade", _getType());
 	}
@@ -254,7 +255,7 @@ public class UpgradeRecorderTest {
 	@Inject
 	private ReleaseLocalService _releaseLocalService;
 
-	private class ErrorUpgradeProcess extends UpgradeProcess {
+	private class UnrelatedErrorUpgradeProcess extends UpgradeProcess {
 
 		@Override
 		protected void doUpgrade() {
@@ -263,8 +264,8 @@ public class UpgradeRecorderTest {
 					_upgradeRecorder, "_errorMessages");
 
 			errorMessages.put(
-				"ErrorUpgradeProcess",
-				Collections.singletonMap("Error on upgrade", 0));
+				"UnrelatedErrorUpgradeProcess",
+				Collections.singletonMap("Error during upgrade", 0));
 		}
 
 	}
@@ -279,7 +280,7 @@ public class UpgradeRecorderTest {
 
 			warningMessages.put(
 				"WarningUpgradeProcess",
-				Collections.singletonMap("Warn on upgrade", 0));
+				Collections.singletonMap("Warn during upgrade", 0));
 		}
 
 	}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.verify.VerifyProcessSuite;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -30,6 +31,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.time.StopWatch;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.message.SimpleMessage;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -62,17 +68,28 @@ public class UpgradeRecorderTest {
 
 		_originalStopWatch = ReflectionTestUtil.getFieldValue(
 			DBUpgrader.class, "_stopWatch");
+
+		_originalVerifyProcessError = ReflectionTestUtil.getFieldValue(
+			_upgradeRecorder, "_verifyProcessError");
 	}
 
 	@AfterClass
 	public static void tearDownClass() {
 		ReflectionTestUtil.setFieldValue(
 			DBUpgrader.class, "_stopWatch", _originalStopWatch);
+
+		ReflectionTestUtil.setFieldValue(
+			_upgradeRecorder, "_verifyProcessError",
+			_originalVerifyProcessError);
 	}
 
 	@Before
 	public void setUp() {
 		ReflectionTestUtil.setFieldValue(DBUpgrader.class, "_stopWatch", null);
+
+		ReflectionTestUtil.setFieldValue(
+			_upgradeRecorder, "_verifyProcessError",
+			_originalVerifyProcessError);
 	}
 
 	@Test
@@ -130,6 +147,26 @@ public class UpgradeRecorderTest {
 		Assert.assertEquals("failure", _getResult());
 
 		Assert.assertEquals("micro", _getType());
+	}
+
+	@Test
+	public void testFailureResultByVerifyException() throws Exception {
+		StartupHelperUtil.setUpgrading(true);
+
+		VerifyExceptionProcess verifyExceptionProcess =
+			new VerifyExceptionProcess();
+
+		verifyExceptionProcess.doVerify();
+
+		StartupHelperUtil.setUpgrading(false);
+
+		Assert.assertEquals("failure", _getResult());
+
+		Assert.assertEquals("major", _getType());
+
+		ReflectionTestUtil.setFieldValue(
+			_upgradeRecorder, "_verifyProcessError",
+			_originalVerifyProcessError);
 	}
 
 	@Test
@@ -297,12 +334,16 @@ public class UpgradeRecorderTest {
 
 	private static Bundle _bundle;
 	private static StopWatch _originalStopWatch;
+	private static boolean _originalVerifyProcessError;
 
 	@Inject(
 		filter = "component.name=com.liferay.portal.upgrade.internal.recorder.UpgradeRecorder",
 		type = Inject.NoType.class
 	)
 	private static Object _upgradeRecorder;
+
+	@Inject(filter = "appender.name=UpgradeLogAppender")
+	private Appender _appender;
 
 	@Inject
 	private ReleaseLocalService _releaseLocalService;
@@ -320,6 +361,28 @@ public class UpgradeRecorderTest {
 			errorMessages.put(
 				"UnrelatedErrorUpgradeProcess",
 				Collections.singletonMap("Error during upgrade", 0));
+		}
+
+	}
+
+	private class VerifyExceptionProcess extends VerifyProcessSuite {
+
+		@Override
+		protected void doVerify() {
+			_appender.start();
+
+			LogEvent logEvent = Log4jLogEvent.newBuilder(
+			).setLoggerName(
+				"Verify Exception Error"
+			).setLevel(
+				Level.ERROR
+			).setMessage(
+				new SimpleMessage("com.liferay.portal.verify.VerifyException")
+			).build();
+
+			_appender.append(logEvent);
+
+			_appender.stop();
 		}
 
 	}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
@@ -6,22 +6,32 @@
 package com.liferay.portal.upgrade.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.service.ReleaseLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StreamUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.component.UpgradeRecorderTestComponent;
+import com.liferay.portal.upgrade.test.reference.UpgradeRecorderTestReference;
 import com.liferay.portal.verify.VerifyProcessSuite;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -29,6 +39,11 @@ import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
 
 import org.apache.commons.lang.time.StopWatch;
 import org.apache.logging.log4j.Level;
@@ -48,6 +63,7 @@ import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
 
@@ -90,30 +106,6 @@ public class UpgradeRecorderTest {
 		ReflectionTestUtil.setFieldValue(
 			_upgradeRecorder, "_verifyProcessError",
 			_originalVerifyProcessError);
-	}
-
-	@Test
-	public void testFailureStatusByPendingCoreUpgrade() throws SQLException {
-		try (Connection connection = DataAccess.getConnection()) {
-			Version version = PortalUpgradeProcess.getCurrentSchemaVersion(
-				connection);
-
-			PortalUpgradeProcess.updateSchemaVersion(
-				connection, new Version(0, 0, 0));
-
-			try {
-				StartupHelperUtil.setUpgrading(true);
-
-				StartupHelperUtil.setUpgrading(false);
-			}
-			finally {
-				PortalUpgradeProcess.updateSchemaVersion(connection, version);
-			}
-		}
-
-		Assert.assertEquals("failure", _getResult());
-
-		Assert.assertEquals("major", _getType());
 	}
 
 	@Test
@@ -167,6 +159,30 @@ public class UpgradeRecorderTest {
 		ReflectionTestUtil.setFieldValue(
 			_upgradeRecorder, "_verifyProcessError",
 			_originalVerifyProcessError);
+	}
+
+	@Test
+	public void testFailureStatusByPendingCoreUpgrade() throws SQLException {
+		try (Connection connection = DataAccess.getConnection()) {
+			Version version = PortalUpgradeProcess.getCurrentSchemaVersion(
+				connection);
+
+			PortalUpgradeProcess.updateSchemaVersion(
+				connection, new Version(0, 0, 0));
+
+			try {
+				StartupHelperUtil.setUpgrading(true);
+
+				StartupHelperUtil.setUpgrading(false);
+			}
+			finally {
+				PortalUpgradeProcess.updateSchemaVersion(connection, version);
+			}
+		}
+
+		Assert.assertEquals("failure", _getResult());
+
+		Assert.assertEquals("major", _getType());
 	}
 
 	@Test
@@ -240,6 +256,29 @@ public class UpgradeRecorderTest {
 		Assert.assertEquals("no upgrade", _getType());
 	}
 
+	@Test
+	public void testUnresolvedResultByUnsatisfiedComponent() throws Exception {
+		BundleContext bundleContext = _bundle.getBundleContext();
+
+		Bundle bundle = bundleContext.installBundle(
+			"location", _createBundle());
+
+		bundle.start();
+
+		try {
+			StartupHelperUtil.setUpgrading(true);
+
+			StartupHelperUtil.setUpgrading(false);
+		}
+		finally {
+			bundle.uninstall();
+		}
+
+		Assert.assertEquals("unresolved", _getResult());
+
+		Assert.assertEquals("major", _getType());
+	}
+
 	public static class TestUpgradeStepRegistrator
 		implements UpgradeStepRegistrator {
 
@@ -248,6 +287,52 @@ public class UpgradeRecorderTest {
 			registry.registerInitialization();
 		}
 
+	}
+
+	private InputStream _createBundle() throws Exception {
+		try (UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+				new UnsyncByteArrayOutputStream()) {
+
+			try (JarOutputStream jarOutputStream = new JarOutputStream(
+					unsyncByteArrayOutputStream)) {
+
+				Manifest manifest = new Manifest();
+
+				Attributes attributes = manifest.getMainAttributes();
+
+				attributes.putValue(Constants.BUNDLE_MANIFESTVERSION, "2");
+				attributes.putValue(
+					Constants.BUNDLE_SYMBOLICNAME,
+					"com.liferay.portal.upgrade.test.bundle");
+				attributes.putValue(Constants.BUNDLE_VERSION, "1.0.0");
+				attributes.putValue("Manifest-Version", "1.0");
+				attributes.putValue(
+					"Service-Component",
+					"OSGI-INF/" + _TEST_COMPONENT_FILE_NAME);
+
+				jarOutputStream.putNextEntry(
+					new ZipEntry(JarFile.MANIFEST_NAME));
+
+				manifest.write(jarOutputStream);
+
+				jarOutputStream.closeEntry();
+
+				_writeClasses(
+					jarOutputStream, UpgradeRecorderTestComponent.class,
+					UpgradeRecorderTestReference.class);
+
+				jarOutputStream.putNextEntry(
+					new ZipEntry("OSGI-INF/" + _TEST_COMPONENT_FILE_NAME));
+
+				_writeServiceComponentFile(jarOutputStream, getClass());
+
+				jarOutputStream.closeEntry();
+			}
+
+			return new UnsyncByteArrayInputStream(
+				unsyncByteArrayOutputStream.unsafeGetByteArray(), 0,
+				unsyncByteArrayOutputStream.size());
+		}
 	}
 
 	private String _getResult() {
@@ -331,6 +416,51 @@ public class UpgradeRecorderTest {
 			_releaseLocalService.updateRelease(minorRelease);
 		}
 	}
+
+	private void _writeClasses(
+			JarOutputStream jarOutputStream, Class<?>... classes)
+		throws IOException, IOException {
+
+		for (Class<?> clazz : classes) {
+			String className = clazz.getName();
+
+			String path = StringUtil.replace(
+				className, CharPool.PERIOD, CharPool.SLASH);
+
+			String resourcePath = path.concat(".class");
+
+			jarOutputStream.putNextEntry(new ZipEntry(resourcePath));
+
+			ClassLoader classLoader = clazz.getClassLoader();
+
+			StreamUtil.transfer(
+				classLoader.getResourceAsStream(resourcePath), jarOutputStream,
+				false);
+
+			jarOutputStream.closeEntry();
+		}
+	}
+
+	private void _writeServiceComponentFile(
+			JarOutputStream jarOutputStream, Class<?> clazz)
+		throws IOException {
+
+		ClassLoader classLoader = clazz.getClassLoader();
+
+		Package pkg = clazz.getPackage();
+
+		String packagePath = StringUtil.replace(
+			pkg.getName(), CharPool.PERIOD, CharPool.SLASH);
+
+		StreamUtil.transfer(
+			classLoader.getResourceAsStream(
+				StringBundler.concat(
+					packagePath, "/dependencies/", _TEST_COMPONENT_FILE_NAME)),
+			jarOutputStream, false);
+	}
+
+	private static final String _TEST_COMPONENT_FILE_NAME =
+		"UpgradeRecorderTestComponent.xml";
 
 	private static Bundle _bundle;
 	private static StopWatch _originalStopWatch;

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -39,6 +40,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
 /**
  * @author Luis Ortiz
  */
@@ -52,6 +58,8 @@ public class UpgradeRecorderTest {
 
 	@BeforeClass
 	public static void setUpClass() {
+		_bundle = FrameworkUtil.getBundle(UpgradeRecorderTest.class);
+
 		_originalStopWatch = ReflectionTestUtil.getFieldValue(
 			DBUpgrader.class, "_stopWatch");
 	}
@@ -89,6 +97,39 @@ public class UpgradeRecorderTest {
 		Assert.assertEquals("failure", _getResult());
 
 		Assert.assertEquals("major", _getType());
+	}
+
+	@Test
+	public void testFailureResultByPendingModuleUpgrade() throws Exception {
+		BundleContext bundleContext = _bundle.getBundleContext();
+
+		_serviceRegistration = bundleContext.registerService(
+			UpgradeStepRegistrator.class,
+			new UpgradeRecorderTest.TestUpgradeStepRegistrator(), null);
+
+		Release release = _releaseLocalService.fetchRelease(
+			_bundle.getSymbolicName());
+
+		try {
+			StartupHelperUtil.setUpgrading(true);
+
+			release.setSchemaVersion("0.0.0");
+
+			release = _releaseLocalService.updateRelease(release);
+
+			StartupHelperUtil.setUpgrading(false);
+		}
+		finally {
+			_releaseLocalService.deleteRelease(release);
+
+			if (_serviceRegistration != null) {
+				_serviceRegistration.unregister();
+			}
+		}
+
+		Assert.assertEquals("failure", _getResult());
+
+		Assert.assertEquals("micro", _getType());
 	}
 
 	@Test
@@ -160,6 +201,16 @@ public class UpgradeRecorderTest {
 		Assert.assertEquals("success", _getResult());
 
 		Assert.assertEquals("no upgrade", _getType());
+	}
+
+	public static class TestUpgradeStepRegistrator
+		implements UpgradeStepRegistrator {
+
+		@Override
+		public void register(Registry registry) {
+			registry.registerInitialization();
+		}
+
 	}
 
 	private String _getResult() {
@@ -244,6 +295,7 @@ public class UpgradeRecorderTest {
 		}
 	}
 
+	private static Bundle _bundle;
 	private static StopWatch _originalStopWatch;
 
 	@Inject(
@@ -254,6 +306,8 @@ public class UpgradeRecorderTest {
 
 	@Inject
 	private ReleaseLocalService _releaseLocalService;
+
+	private ServiceRegistration<UpgradeStepRegistrator> _serviceRegistration;
 
 	private class UnrelatedErrorUpgradeProcess extends UpgradeProcess {
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/component/UpgradeRecorderTestComponent.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/component/UpgradeRecorderTestComponent.java
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.test.component;
+
+import com.liferay.portal.upgrade.test.reference.UpgradeRecorderTestReference;
+
+/**
+ * @author Jorge Avalos
+ */
+public class UpgradeRecorderTestComponent {
+
+	protected UpgradeRecorderTestReference upgradeRecorderTestReference;
+
+}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/reference/UpgradeRecorderTestReference.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/reference/UpgradeRecorderTestReference.java
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.test.reference;
+
+/**
+ * @author Jorge Avalos
+ */
+public interface UpgradeRecorderTestReference {
+}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/resources/com/liferay/portal/upgrade/test/dependencies/UpgradeRecorderTestComponent.xml
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/resources/com/liferay/portal/upgrade/test/dependencies/UpgradeRecorderTestComponent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+
+<scr:component immediate="true" name="com.liferay.portal.upgrade.test.component.UpgradeRecorderTestComponent" xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0">
+	<implementation class="com.liferay.portal.upgrade.test.component.UpgradeRecorderTestComponent" />
+	<reference field="upgradeRecorderTestReference" interface="com.liferay.portal.upgrade.test.reference.UpgradeRecorderTestReference" name="UpgradeStepRegistrator" />
+</scr:component>

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/ReleaseManager.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/ReleaseManager.java
@@ -13,8 +13,8 @@ public interface ReleaseManager {
 
 	public String getShortStatusMessage(boolean onlyRequiredUpgrades);
 
-	public String getStatusMessage(boolean showUpgradeSteps);
+	public String getStatus() throws Exception;
 
-	public boolean isUpgraded() throws Exception;
+	public String getStatusMessage(boolean showUpgradeSteps);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
@@ -1,1 +1,1 @@
-version 21.3.0
+version 22.0.0


### PR DESCRIPTION
Issue:
The upgrade status of an upgrade is currently influenced by the presence of any error.  
This causes the upgrade to complete with a status that may not be accurate. 

Solution:
The aim is to calculate the Upgrade Status based on the combine result of:

Core Upgrades
Module Upgrades
Verify Process Exceptions
Unsatisfied Components

The upgrade will only have one of three statuses upon completion:

Success - Needs 1 & 2 & 3 & 4 to Pass
Failure - Needs 1 OR 2 OR 3 to Fail
Unresolved - Needs 4 to Fail

Based on this,  we can ignore errors that occur during the upgrade process that may or may not be relevant.  

Ticket:
[LPS-197686](https://liferay.atlassian.net/browse/LPS-197686)



Tests were modified to account for the changes.
Tests were added to account for all of the different statuses and cause of the status. 

