### PR TITLE
LPS-199353 Create new test batch to run integration tests with DB Partition enabled

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -2358,6 +2358,7 @@ log.sanitizer.enabled=false</echo>
 	<macrodef name="run-modules-integration-test">
 		<attribute default="tomcat" name="app.server.type" />
 		<attribute default="" name="aws.store.enabled" />
+		<attribute default="" name="database.partition.enabled" />
 		<attribute name="database.type" />
 		<attribute default="${database.@{database.type}.version}" name="database.version" />
 		<attribute default="" name="refreshdependencies" />
@@ -2390,6 +2391,7 @@ log.sanitizer.enabled=false</echo>
 
 							<antcall if:set="env.JENKINS_HOME" inheritAll="false" target="prepare-portal-ext-properties">
 								<param name="aws.store.enabled" value="@{aws.store.enabled}" />
+								<param name="database.partition.enabled" value="@{database.partition.enabled}" />
 								<param name="database.type" value="@{database.type}" />
 							</antcall>
 
@@ -6813,6 +6815,14 @@ information. Make sure to commit in all format-javadoc results.
 
 	<target name="modules-integration-mysql56-jdk8">
 		<run-modules-integration-test database.type="mysql" />
+	</target>
+
+	<target name="modules-integration-mysql57-db-partition-jdk8">
+		<run-modules-integration-test
+			database.partition.enabled="true"
+			database.type="mysql"
+			database.version="5.7"
+		/>
 	</target>
 
 	<target name="modules-integration-mysql57-jdk8">

--- a/build-test.xml
+++ b/build-test.xml
@@ -11864,7 +11864,16 @@ ${update.properties}</echo>
 			</then>
 		</if>
 
-		<get-testcase-property property.name="database.partition.enabled" />
+		<if>
+			<equals arg1="${database.partition.enabled}" arg2="true" />
+			<then>
+				<property name="database.partition.enabled" value="true" />
+			</then>
+			<else>
+				<get-testcase-property property.name="database.partition.enabled" />
+			</else>
+		</if>
+
 		<get-testcase-property property.name="liferay.online.properties" />
 		<get-testcase-property property.name="portal.version" />
 
@@ -12115,13 +12124,13 @@ upgrade.report.enabled=true</echo>
 			</then>
 		</if>
 
-		<get-testcase-property property.name="database.partition.enabled" />
 		<propertycopy from="database.partition.enabled[${env.CI_TEST_SUITE}]" name="database.partition.enabled" silent="true" />
 
 		<if>
 			<equals arg1="${database.partition.enabled}" arg2="true" />
 			<then>
 				<echo append="true" file="portal-impl/src/portal-ext.properties">
+
 database.partition.enabled=true</echo>
 			</then>
 		</if>

--- a/test.properties
+++ b/test.properties
@@ -4082,16 +4082,23 @@
     #
 
     test.batch.class.names.includes[db-partition]=\
+        **/portal-dao-test/**/*Test.java,\
         **/portal-db-partition-test/**/*Test.java,\
         **/portal-tools-db-partition*/**/*Test.java,\
-        **/testIntegration/**/*DatabasePartitionUpgrade*Test.java
+        **/src/test/**/*Upgrade*Test.java,\
+        **/src/testIntegration/**/*Upgrade*Test.java,\
+        **/src/testIntegration/**/Verify*Test.java,\
+        **/test/**/*Upgrade*Test.java,\
+        **/testIntegration/**/*DatabasePartitionUpgrade*Test.java,\
+        **/testIntegration/**/*Upgrade*Test.java,\
+        **/testIntegration/**/upgrade/**/Release*Test.java
 
     test.batch.dist.app.servers[db-partition]=tomcat
 
     test.batch.names[db-partition]=\
         functional-tomcat90-mysql57-jdk8,\
         functional-upgrade-tomcat90-mysql57-jdk8,\
-        modules-integration-mysql57-jdk8,\
+        modules-integration-mysql57-db-partition-jdk8,\
         modules-unit-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][db-partition]=\

--- a/test.properties
+++ b/test.properties
@@ -3066,6 +3066,7 @@
     test.batch.size[modules-integration-mariadb102-jdk8]=20
     test.batch.size[modules-integration-mariadb104-jdk8]=20
     test.batch.size[modules-integration-mariadb106-jdk8]=20
+    test.batch.size[modules-integration-mysql57-db-partition-jdk8]=20
     test.batch.size[modules-integration-mysql57-jdk8]=20
     test.batch.size[modules-integration-mysql80-jdk8]=20
     test.batch.size[modules-integration-oracle193-jdk8]=20


### PR DESCRIPTION
**Background**
When running DB Partition integration tests we enable DB Partitioning at runtime. That's hard and fragile because we have to execute some complex infrastructure operations. Is difficult to maintain since anytime we add new tests we may require other infrastructure changes to make them possible.
To avoid this, one option is to only run this tests when DB Partitioning is already enabled. For that we need to startup the server with that configuration.

**Proposed solution:**
Create a new test batch that activate db partition when calling `prepare-portal-ext-properties` target, and we could run it where it is needed. 

**Tested at:** https://github.com/lucasperj/liferay-portal/pull/396

**JIRA Ticket:** https://liferay.atlassian.net/browse/LPS-199353