### PR TITLE
LPS-171695 increase idle connections to 5 to avoid stale connection

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -673,7 +673,7 @@ jdbc.default.password=${database.password}
 
 jdbc.default.connectionTimeout=600000
 jdbc.default.maximumPoolSize=30
-jdbc.default.minimumIdle=0]]></echo>
+jdbc.default.minimumIdle=5]]></echo>
 
 			<if>
 				<equals arg1="${database.type}" arg2="oracle" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -671,7 +671,7 @@ jdbc.default.password=${database.password}
 
 // HikariCP
 
-jdbc.default.connectionTimeout=600000
+jdbc.default.connectionTimeout=900000
 jdbc.default.maximumPoolSize=30
 jdbc.default.minimumIdle=10]]></echo>
 
@@ -11902,7 +11902,7 @@ jdbc.default.password=${database.password}
 
 // HikariCP
 
-jdbc.default.connectionTimeout=600000
+jdbc.default.connectionTimeout=900000
 jdbc.default.maximumPoolSize=${database.max.pool.size}
 jdbc.default.minimumIdle=10
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -673,7 +673,7 @@ jdbc.default.password=${database.password}
 
 jdbc.default.connectionTimeout=600000
 jdbc.default.maximumPoolSize=30
-jdbc.default.minimumIdle=5]]></echo>
+jdbc.default.minimumIdle=10]]></echo>
 
 			<if>
 				<equals arg1="${database.type}" arg2="oracle" />
@@ -11904,7 +11904,7 @@ jdbc.default.password=${database.password}
 
 jdbc.default.connectionTimeout=600000
 jdbc.default.maximumPoolSize=${database.max.pool.size}
-jdbc.default.minimumIdle=0
+jdbc.default.minimumIdle=10
 
 enterprise.product.notification.enabled=false
 company.security.strangers.verify=false

--- a/portal-impl/src/com/liferay/portal/util/InitUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/InitUtil.java
@@ -147,6 +147,9 @@ public class InitUtil {
 
 		// Log sanitizer
 
+		Log4JUtil.setLevel(
+			"com.zaxxer.hikari", "ALL", true);
+
 		SanitizerLogWrapper.init();
 
 		// Configuration factory

--- a/test.properties
+++ b/test.properties
@@ -9521,6 +9521,7 @@
         functional-upgrade-tomcat90-db2111-jdk8,\
         functional-upgrade-tomcat90-mariadb102-jdk8,\
         functional-upgrade-tomcat90-mysql57-jdk8,\
+        functional-upgrade-tomcat90-mysql80-jdk8,\
         functional-upgrade-tomcat90-oracle193-jdk8,\
         functional-upgrade-tomcat90-postgresql144-jdk8,\
         functional-upgrade-tomcat90-postgresql153-jdk8,\
@@ -9590,22 +9591,7 @@
         (portal.upstream == true) AND \
         (testray.main.component.name == "Database Upgrade Framework")
 
-    test.batch.run.property.query[functional-tomcat90-mysql80-jdk8][upgrade]=\
-        (\
-            (app.server.types == null) OR \
-            (app.server.types ~ tomcat)\
-        ) AND \
-        (data.archive.type == null) AND \
-        (\
-            (database.types == null) OR \
-            (database.types ~ mysql)\
-        ) AND \
-        (database.partition.enabled == null) AND \
-        (portal.acceptance != quarantine) AND \
-        (portal.upstream == true) AND \
-        (testray.main.component.name == "Database Upgrade Framework")
-
-    test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][upgrade]=\
+    test.batch.run.property.query[functional-tomcat90-mysql*-jdk8][upgrade]=\
         (\
             (app.server.types == null) OR \
             (app.server.types ~ tomcat)\
@@ -9657,7 +9643,7 @@
             (testray.main.component.name == "Database Upgrade Tool")\
         )
 
-    test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][upgrade]=\
+    test.batch.run.property.query[functional-upgrade-tomcat90-mysql*-jdk8][upgrade]=\
         (\
             (app.server.types == null) OR \
             (app.server.types ~ tomcat)\


### PR DESCRIPTION
Issue:
When upgrading and during the CTModleUpgradeProcess, there is a high chance of a connection being killed while altering the tables in this process.  This was caused by setting the idle connecitons count to 0 when running the test.

Solution:
Increase idle connections to 5(only 30 connections are available during the upgrade test)

Update:
Failed 1 test with error,  I increased the idle count to match master.

@lucasperj 
I think this the right solution,  especially if we are setting this for the upgrade test only.  I haven't experienced the error in my testing on my own repo, but it occurred once on the second attempt here. 
I think if it clears the upgrade test after 3 consecutive attempts, we could move forward.  




