### PR TITLE
LPS-202977 Creating temporary indexes with different names to allow them to coexist

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeProcessTest.java
@@ -9,14 +9,16 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.db.DB;
-import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.sql.Connection;
+
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -46,9 +48,10 @@ public class UpgradeProcessTest {
 	public static void setUpClass() throws Exception {
 		_connection = DataAccess.getConnection();
 
-		_dbInspector = new DBInspector(_connection);
-
 		_db = DBManagerUtil.getDB();
+
+		_tempIndexCounter = ReflectionTestUtil.getFieldValue(
+			UpgradeProcess.class, "_temporaryIndexSuffix");
 	}
 
 	@AfterClass
@@ -70,7 +73,36 @@ public class UpgradeProcessTest {
 	}
 
 	@Test
+	public void testAddMultipleTemporaryIndex() throws Exception {
+		String tempIndexName1 = "IX_TEMP_" + (_tempIndexCounter.get() + 1);
+		String tempIndexName2 = "IX_TEMP_" + (_tempIndexCounter.get() + 2);
+
+		UpgradeProcess upgradeProcess = new UpgradeProcess() {
+
+			@Override
+			protected void doUpgrade() throws Exception {
+				try (SafeCloseable safeCloseable1 = addTemporaryIndex(
+						TABLE_NAME, false, "typeVarchar");
+					SafeCloseable safeCloseable2 = addTemporaryIndex(
+						TABLE_NAME, false, "id", "typeVarchar")) {
+
+					Assert.assertTrue(hasIndex(TABLE_NAME, tempIndexName1));
+					Assert.assertTrue(hasIndex(TABLE_NAME, tempIndexName2));
+				}
+
+				Assert.assertFalse(hasIndex(TABLE_NAME, tempIndexName1));
+				Assert.assertFalse(hasIndex(TABLE_NAME, tempIndexName2));
+			}
+
+		};
+
+		upgradeProcess.upgrade();
+	}
+
+	@Test
 	public void testAddTemporaryIndex() throws Exception {
+		String tempIndexName = "IX_TEMP_" + (_tempIndexCounter.get() + 1);
+
 		UpgradeProcess upgradeProcess = new UpgradeProcess() {
 
 			@Override
@@ -78,10 +110,10 @@ public class UpgradeProcessTest {
 				try (SafeCloseable safeCloseable = addTemporaryIndex(
 						TABLE_NAME, false, "typeVarchar")) {
 
-					Assert.assertTrue(hasIndex(TABLE_NAME, "IX_TEMP"));
+					Assert.assertTrue(hasIndex(TABLE_NAME, tempIndexName));
 				}
 
-				Assert.assertFalse(hasIndex(TABLE_NAME, "IX_TEMP"));
+				Assert.assertFalse(hasIndex(TABLE_NAME, tempIndexName));
 			}
 
 		};
@@ -91,6 +123,6 @@ public class UpgradeProcessTest {
 
 	private static Connection _connection;
 	private static DB _db;
-	private static DBInspector _dbInspector;
+	private static AtomicLong _tempIndexCounter;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java
@@ -45,6 +45,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * @author Brian Wing Shun Chan
@@ -175,8 +176,10 @@ public abstract class UpgradeProcess
 			String tableName, boolean unique, String... columnNames)
 		throws Exception {
 
+		String indexName = "IX_TEMP_" + _temporaryIndexSuffix.incrementAndGet();
+
 		IndexMetadata indexMetadata = new IndexMetadata(
-			"IX_TEMP", tableName, unique, columnNames);
+			indexName, tableName, unique, columnNames);
 
 		try (LoggingTimer loggingTimer = new LoggingTimer(tableName)) {
 			addIndexes(
@@ -185,13 +188,16 @@ public abstract class UpgradeProcess
 
 		return () -> {
 			try {
-				runSQL("drop index IX_TEMP on " + tableName);
+				runSQL(
+					StringBundler.concat(
+						"drop index ", indexName, " on ", tableName));
 			}
 			catch (Exception exception) {
 				if (_log.isWarnEnabled()) {
 					_log.warn(
-						"Unable to drop temporary index IX_TEMP on " +
-							tableName);
+						StringBundler.concat(
+							"Unable to drop temporary index ", indexName,
+							" on ", tableName));
 				}
 			}
 		};
@@ -406,6 +412,7 @@ public abstract class UpgradeProcess
 	private static final Map
 		<String, List<ObjectValuePair<String, IndexMetadata>>>
 			_portalIndexesSQL = new HashMap<>();
+	private static final AtomicLong _temporaryIndexSuffix = new AtomicLong(0);
 
 	private String _upgradeInfo;
 


### PR DESCRIPTION
In the context of a failed upgrade process for module com.liferay.layout.page.template.service, we saw that some databases do not support to have indexes with the same name even if they apply to different tables.
With this PR we are adding support to generate the temporary indexes with different names, so this situation is avoided.

@lucasperj @susanchen3 Could we make sure the PR passes on all the supported databases? I think there should not be problems, but it is better if we make sure. I tested in local with Postgres and the attached dump in the ticket, and it worked.