### PR TITLE
LPS 201226 Run only uniform team owned tests in upgrade test suite

### DIFF
--- a/modules/util/portal-tools-db-partition-virtual-instance-migrator/test.properties
+++ b/modules/util/portal-tools-db-partition-virtual-instance-migrator/test.properties
@@ -1,0 +1,38 @@
+##
+## Modules
+##
+
+    modules.includes.required.test.batch.class.names.includes=\
+        **/portal-tools-db-partition-virtual-instance-migrator/**/*Test.java
+
+##
+## Test Batch
+##
+
+    #
+    # Portal Hotfix Release
+    #
+
+    test.batch.run.property.query[functional-bundle-tomcat-mysql57-jdk8][test-portal-hotfix-release]=\
+        ${test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]}
+
+    #
+    # Relevant
+    #
+
+    test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
+        (portal.acceptance == true) AND \
+        (\
+            (testray.component.names ~ "Database Partitioning") OR \
+            (testray.main.component.name ~ "Database Partitioning")\
+        )
+
+    test.batch.run.property.query[functional-upgrade*-tomcat*-mysql*-jdk8][relevant]=\
+        (portal.acceptance == true) AND \
+        (testray.main.component.name ~ "Database Partitioning")
+
+##
+## Testray
+##
+
+    testray.main.component.name=Database Partitioning

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/verifyproperties/VerifyProperties.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/verifyproperties/VerifyProperties.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-verify-properties"
+@component-name = "portal-upgrades"
 definition {
 
 	property app.server.types = "tomcat";
@@ -6,7 +6,7 @@ definition {
 	property database.types = "mysql";
 	property portal.release = "true";
 	property portal.upstream = "true";
-	property testray.main.component.name = "Verify Properties";
+	property testray.main.component.name = "Upgrade Logging";
 
 	@description = "LRQA-78904: Upgrade will be stopped if Verify Properties fails when enable AutoUpgrade"
 	@priority = 3

--- a/test.properties
+++ b/test.properties
@@ -9498,15 +9498,9 @@
     #
 
     test.batch.class.names.includes[upgrade]=\
-        **/portal-dao-test/**/*Test.java,\
         **/portal-db-partition-test/**/*Test.java,\
         **/portal-tools-db-partition*/**/*Test.java,\
-        **/src/test/**/*Upgrade*Test.java,\
-        **/src/testIntegration/**/*Upgrade*Test.java,\
-        **/src/testIntegration/**/Verify*Test.java,\
-        **/test/**/*Upgrade*Test.java,\
-        **/testIntegration/**/*Upgrade*Test.java,\
-        **/testIntegration/**/upgrade/**/Release*Test.java
+        **/portal-upgrade-test/**/*Test.java,\
 
     test.batch.dist.app.servers[upgrade]=tomcat
 

--- a/test.properties
+++ b/test.properties
@@ -9667,7 +9667,6 @@
             (testray.main.component.name == "Database Partitioning") OR \
             (testray.main.component.name == "Database Upgrade Framework") OR \
             (testray.main.component.name == "Database Upgrade Tool") OR \
-            (testray.main.component.name == "Portal Configuration") OR \
             (testray.main.component.name == "Verify Properties")\
         )
 

--- a/test.properties
+++ b/test.properties
@@ -9631,7 +9631,7 @@
         (\
             (testray.main.component.name == "Database Upgrade Framework") OR \
             (testray.main.component.name == "Database Upgrade Tool") OR \
-            (testray.main.component.name == "Verify Properties")\
+            (testray.main.component.name == "Upgrade Logging")\
         )
 
     test.batch.run.property.query[functional-upgrade-tomcat90-mariadb102-jdk8][upgrade]=\
@@ -9667,7 +9667,7 @@
             (testray.main.component.name == "Database Partitioning") OR \
             (testray.main.component.name == "Database Upgrade Framework") OR \
             (testray.main.component.name == "Database Upgrade Tool") OR \
-            (testray.main.component.name == "Verify Properties")\
+            (testray.main.component.name == "Upgrade Logging")\
         )
 
     test.batch.run.property.query[functional-upgrade-tomcat90-oracle193-jdk8][upgrade]=\
@@ -9685,7 +9685,7 @@
         (\
             (testray.main.component.name == "Database Upgrade Framework") OR \
             (testray.main.component.name == "Database Upgrade Tool") OR \
-            (testray.main.component.name == "Verify Properties")\
+            (testray.main.component.name == "Upgrade Logging")\
         )
 
     test.batch.run.property.query[functional-upgrade-tomcat90-postgresql*-jdk8][upgrade]=\
@@ -9703,7 +9703,7 @@
         (\
             (testray.main.component.name == "Database Upgrade Framework") OR \
             (testray.main.component.name == "Database Upgrade Tool") OR \
-            (testray.main.component.name == "Verify Properties")\
+            (testray.main.component.name == "Upgrade Logging")\
         )
 
     test.batch.run.property.query[functional-upgrade-tomcat90-sqlserver2017-jdk8][upgrade]=\
@@ -9721,7 +9721,7 @@
         (\
             (testray.main.component.name == "Database Upgrade Framework") OR \
             (testray.main.component.name == "Database Upgrade Tool") OR \
-            (testray.main.component.name == "Verify Properties")\
+            (testray.main.component.name == "Upgrade Logging")\
         )
 
     #
@@ -10920,7 +10920,6 @@
         Unit,\
         User Tracker,\
         Util,\
-        Verify Properties,\
         Virtual Instances
 
     testray.team.data-engine.component.names=\
@@ -11055,7 +11054,8 @@
     testray.team.upgrades.component.names=\
         Database Partitioning,\
         Database Upgrade Framework,\
-        Database Upgrade Tool
+        Database Upgrade Tool,\
+        Upgrade Logging
 
     testray.team.user-management.component.names=\
         Account,\

--- a/test.properties
+++ b/test.properties
@@ -9500,7 +9500,8 @@
     test.batch.class.names.includes[upgrade]=\
         **/portal-db-partition-test/**/*Test.java,\
         **/portal-tools-db-partition*/**/*Test.java,\
-        **/portal-upgrade-test/**/*Test.java,\
+        **/portal-upgrade-impl/**/*Test.java,\
+        **/portal-upgrade-test/**/*Test.java
 
     test.batch.dist.app.servers[upgrade]=tomcat
 


### PR DESCRIPTION
**Description**
Audit and clean out unnecessary tests from upgrade test suite. Main goal is to have uniform team owned tests only.

**Test Plan**
- [x] ci:test:upgrade only runs Uniform Team owned tests on Testray - test results in https://github.com/john-co/liferay-portal/pull/518#issuecomment-1839820527 remaining core infra test components will be updated automatically to Uniform team owned components after the merge.

**JIRA Ticket**
https://liferay.atlassian.net/browse/LPS-201226