### PR TITLE
LPS-203553 Add baseURL when appending role admin portlet

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Role.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Role.macro
@@ -268,8 +268,10 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro openRolesAdmin() {
-		Navigator.openWithAppendToBaseURL(urlAppend = "group/control_panel/manage?p_p_id=com_liferay_roles_admin_web_portlet_RolesAdminPortlet");
+	macro openRolesAdmin(baseURL = null) {
+		Navigator.openWithAppendToBaseURL(
+			baseURL = ${baseURL},
+			urlAppend = "group/control_panel/manage?p_p_id=com_liferay_roles_admin_web_portlet_RolesAdminPortlet");
 	}
 
 	@summary = "Default summary"


### PR DESCRIPTION
**Background**
Test fix, DatabasePartitioningUpgrade#CanUpgradePartitionedDatabase7413U33 is trying to view roles on localhost when it’s supposed to view it on [www.able.com](http://www.able.com/)

Caused by changes in [Comparing b44bccb6bf49d67689be2a0d66c03a6b1d60ab4a...5a8d52ce6d2019e00c4a46c38be2fa52fef067db · liferay/liferay-portal](https://github.com/liferay/liferay-portal/compare/b44bccb6bf49d67689be2a0d66c03a6b1d60ab4a...5a8d52ce6d2019e00c4a46c38be2fa52fef067db)


**JIRA Ticket:**
https://liferay.atlassian.net/browse/LPS-203553