### PR TITLE
LPS 203313 Add critical upgrade tests to acceptance layer

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalConfigurationUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalConfigurationUpgrade.testcase
@@ -137,6 +137,7 @@ definition {
 	@priority = 5
 	test ViewPortalConfigurationAfterUpgrade7413 {
 		property data.archive.type = "data-archive-portal-settings";
+		property portal.acceptance = "true";
 		property portal.version = "7.4.13";
 		property test.run.environment = "EE";
 
@@ -148,6 +149,7 @@ definition {
 	@priority = 5
 	test ViewPortalConfigurationAfterUpgrade70106 {
 		property data.archive.type = "data-archive-portal-settings";
+		property portal.acceptance = "true";
 		property portal.version = "7.0.10.6";
 
 		ValidateInstanceSettingsUpgrade.viewInstanceSettings();
@@ -178,6 +180,7 @@ definition {
 	test ViewPortalConfigurationAfterUpgrade621021 {
 		property data.archive.type = "data-archive-portal-settings";
 		property database.types = "db2,mysql,oracle,postgresql,sybase";
+		property portal.acceptance = "true";
 		property portal.version = "6.2.10.21";
 
 		ValidateInstanceSettingsUpgrade.viewInstanceSettings();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
@@ -14,6 +14,7 @@ definition {
 	test CompareLatest7413PartitionedUpgradedAndFreshDBSchemas {
 		property database.bare.enabled = "true";
 		property database.partition.enabled = "true";
+		property portal.acceptance = "true";
 		property portal.smoke.upgrades = "false";
 		property skip.start.app.server = "true";
 		property testcase.url = "file:///opt/dev/projects/github/liferay-portal/";
@@ -247,6 +248,7 @@ definition {
 	@priority = 4
 	test CompareUpgradedAndFreshDatabaseSchemas7413 {
 		property data.archive.type = "data-archive-portal";
+		property portal.acceptance = "true";
 		property portal.smoke.upgrades = "true";
 		property portal.version = "7.4.13";
 
@@ -314,6 +316,7 @@ definition {
 	@priority = 4
 	test CompareUpgradedAndFreshDatabaseSchemas621021 {
 		property data.archive.type = "data-archive-portal";
+		property portal.acceptance = "true";
 		property portal.smoke.upgrades = "true";
 		property portal.version = "6.2.10.21";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalSmokeAutoUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalSmokeAutoUpgrade.testcase
@@ -78,6 +78,7 @@ definition {
 	@priority = 5
 	test ViewPortalSmokeArchiveAutoUpgrade7413 {
 		property data.archive.type = "data-archive-portal";
+		property portal.acceptance = "true";
 		property portal.version = "7.4.13";
 		property test.run.environment = "EE";
 
@@ -97,6 +98,7 @@ definition {
 	@priority = 5
 	test ViewPortalSmokeArchiveAutoUpgrade70106 {
 		property data.archive.type = "data-archive-portal";
+		property portal.acceptance = "true";
 		property portal.version = "7.0.10.6";
 
 		ValidateSmokeUpgrade.viewUpgrade();
@@ -113,6 +115,7 @@ definition {
 	@priority = 5
 	test ViewPortalSmokeArchiveAutoUpgrade621021 {
 		property data.archive.type = "data-archive-portal";
+		property portal.acceptance = "true";
 		property portal.version = "6.2.10.21";
 
 		ValidateSmokeUpgrade.viewUpgrade();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalSmokeUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalSmokeUpgrade.testcase
@@ -126,6 +126,7 @@ definition {
 	@priority = 5
 	test ViewPortalSmokeArchive7413 {
 		property data.archive.type = "data-archive-portal";
+		property portal.acceptance = "true";
 		property portal.smoke.upgrades = "true";
 		property portal.version = "7.4.13";
 		property test.assert.warning.exceptions = "true";
@@ -137,6 +138,7 @@ definition {
 	@priority = 5
 	test ViewPortalSmokeArchive70106 {
 		property data.archive.type = "data-archive-portal";
+		property portal.acceptance = "true";
 		property portal.smoke.upgrades = "true";
 		property portal.upstream = "true";
 		property portal.version = "7.0.10.6";
@@ -168,6 +170,7 @@ definition {
 	@priority = 5
 	test ViewPortalSmokeArchive621021 {
 		property data.archive.type = "data-archive-portal";
+		property portal.acceptance = "true";
 		property portal.smoke.upgrades = "true";
 		property portal.version = "6.2.10.21";
 		property test.assert.warning.exceptions = "true";

--- a/test.properties
+++ b/test.properties
@@ -8295,7 +8295,7 @@
             (database.types ~ mysql)\
         ) AND \
         (\
-            (portal.acceptance != quarantine) AND \
+            (portal.acceptance == true) AND \
             (portal.upstream == true)\
         )
 
@@ -8309,7 +8309,7 @@
             (database.types ~ postgresql)\
         ) AND \
         (\
-            (portal.acceptance != quarantine) AND \
+            (portal.acceptance == true) AND \
             (portal.upstream == true)\
         )
 


### PR DESCRIPTION
**Description**
Failing Upgrade tests that run on relevant need to be on acceptance layer in order to leverage PR tester's unique failure logic. See https://liferay.slack.com/archives/CL3TWSMHQ/p1701473968835709?thread_ts=1701473678.228849&cid=CL3TWSMHQ
Proposal is to add 7.4 and 6.2.10 upgrade smoke tests. This will add the minimal amount of tests for relevant suite which is used among all product teams. Product teams will need to tailor their module level relevant suites to include targeted tests as needed. Uniform team currently uses `ci:test:upgrade` so will be essentially unaffected.

**Test Plan**
- [x] upgrade tests on `ci:test:relevant` have portal.acceptance = "true" set.

**JIRA Ticket**
https://liferay.atlassian.net/browse/LPS-203313