### PR TITLE
LPS-199110 Create test suites to run DB Partitioning tests on PostgreSQL

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -2898,11 +2898,16 @@ s3Region=&quot;us-east&quot;</echo>
 			<echo append="true" file="portal-impl/src/portal-ext.properties">
 include-and-override=portal-liferay-online.properties</echo>
 
-			<replace
-				file="portal-impl/src/portal-ext.properties"
-				token="${database.mysql.driver}"
-				value="${database.mariadb.driver}"
-			/>
+			<if>
+				<equals arg1="${database.type}" arg2="mysql" />
+				<then>
+					<replace
+						file="portal-impl/src/portal-ext.properties"
+						token="${database.mysql.driver}"
+						value="${database.mariadb.driver}"
+					/>
+				</then>
+			</if>
 
 			<replace
 				file="${app.server.tomcat.classes.portal.dir}/portal-liferay-online-config.properties"
@@ -5121,11 +5126,16 @@ database.partition.enabled=true</echo>
 					<echo append="true" file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">
 include-and-override=portal-liferay-online.properties</echo>
 
-					<replace
-						file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-database.properties"
-						token="${database.mysql.driver}"
-						value="${database.mariadb.driver}"
-					/>
+					<if>
+						<equals arg1="${database.type}" arg2="mysql" />
+						<then>
+							<replace
+								file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-database.properties"
+								token="${database.mysql.driver}"
+								value="${database.mariadb.driver}"
+							/>
+						</then>
+					</if>
 
 					<get-testcase-property property.name="data.archive.type" />
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -10628,6 +10628,12 @@ send_user $expect_out(buffer)]]></echo>
 		<sql classpath="${test.app.server.lib.portal.dir}/${jdbc.mysql.driver}" driver="${database.mysql.driver}" onerror="continue" output="${mysql.output.file}" password="${database.mysql.password}" print="true" showheaders="false" showtrailers="false" src="${mysql.input.file}" url="${database.mysql.url}" userid="${database.mysql.username}" />
 	</target>
 
+	<target name="execute-psql">
+		<get-test-app-server-lib-portal-dir />
+
+		<sql classpath="${test.app.server.lib.portal.dir}/${jdbc.postgresql.driver}" driver="${database.postgresql.driver}" onerror="continue" output="${psql.output.file}" password="${database.postgresql.password}" print="true" showheaders="false" showtrailers="false" src="${psql.input.file}" url="${database.postgresql.url}" userid="${database.postgresql.username}" />
+	</target>
+
 	<target name="export-database-schema">
 		<export-database-mysql-compact database.file.prefix="${database.file.prefix}" database.schema.name="${database.schema.name}" />
 	</target>

--- a/ci.properties
+++ b/ci.properties
@@ -22,6 +22,7 @@ ci.test.available.suites=\
     acceptance,\
     acceptance-functional,\
     acceptance-functional-db-partition,\
+    acceptance-functional-db-partition-psql,\
     acceptance-release,\
     acceptance-upstream,\
     accessibility,\
@@ -60,6 +61,7 @@ ci.test.available.suites=\
     data-integration,\
     data-integration-functional,\
     db-partition,\
+    db-partition-psql,\
     depot,\
     digital-signature,\
     dl-store,\
@@ -244,6 +246,7 @@ ci.test.relevant.bypass.file.path.patterns=\
 ci.test.suite.description[acceptance]=Test acceptance tests.
 ci.test.suite.description[acceptance-functional]=Test acceptance functional tests.
 ci.test.suite.description[acceptance-functional-db-partition]=Test acceptance functional tests with Database Partitioning.
+ci.test.suite.description[acceptance-functional-db-partition-psql]=Test acceptance functional tests with Database Partitioning and PostgreSQL.
 ci.test.suite.description[acceptance-release]=Compile a release bundle and execute acceptance tests.
 ci.test.suite.description[acceptance-upstream]=Test acceptance upstream tests.
 ci.test.suite.description[accessibility]=Test all accessibility tests.
@@ -280,6 +283,7 @@ ci.test.suite.description[data-engine-db-partition]=Test Data Engine functional 
 ci.test.suite.description[data-integration]=Test only Data Integration tests.
 ci.test.suite.description[data-integration-functional]=Test only functional Data Integration tests.
 ci.test.suite.description[db-partition]=Test Database Partitioning functional tests.
+ci.test.suite.description[db-partition-psql]=Test Database Partitioning functional tests on PostgreSQL.
 ci.test.suite.description[digital-signature]=Test Digital Signature tests.
 ci.test.suite.description[document]=Test Document and Media tests.
 ci.test.suite.description[document-antivirus]=Test Antivirus against DM.

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/Clustering/ChangePublicationStatusOnClusterNodes.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/Clustering/ChangePublicationStatusOnClusterNodes.testcase
@@ -132,9 +132,142 @@ definition {
 	}
 
 	@priority = 5
+	test CanAddAPIApplicationWithClusterPSQL {
+		property app.server.bundles.size = "1";
+		property cluster.enabled = "true";
+		property database.types = "postgresql";
+		property minimum.slave.ram = "24";
+		property portal.acceptance = "true";
+		property remote.elasticsearch.enabled = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("And Given APIApplication with endpoint created on the default node") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
+				mainObjectDefinitionErc = "Student",
+				objectFieldErc = "nameStudent",
+				relatedEndpoint = "true",
+				relatedSchema = "true",
+				schemaName = "testSchema",
+				status = "published",
+				title = "My-app");
+
+			SchemaAPI.relateRequestSchemaToEndpointByErc(
+				endpointErc = "My-app_testendpoint",
+				requestSchemaErc = "My-app_testSchema");
+
+			SchemaAPI.relateResponseSchemaToEndpointByErc(
+				endpointErc = "My-app_testendpoint",
+				responseSchemaErc = "My-app_testSchema");
+		}
+
+		task ("When executing the endpoint on second node") {
+			var response = APIApplicationEndpoint.getEndpoint(
+				baseURL = "my-app",
+				path = "/testendpoint",
+				portalURL = "http://localhost:9080");
+		}
+
+		task ("Then endpoint response is correct") {
+			var itemsCount = JSONUtil.getWithJSONPath(${response}, "$..totalCount");
+
+			TestUtils.assertEquals(
+				actual = ${itemsCount},
+				expected = 1);
+		}
+
+		task ("And Then api application present in API Builder of second node") {
+			User.loginPG(
+				nodePort = 9080,
+				password = "test",
+				userEmailAddress = "test@liferay.com");
+
+			ApplicationsMenu.gotoPortlet(
+				category = "Object",
+				panel = "Control Panel",
+				portlet = "API Builder");
+
+			AssertElementPresent(
+				key_name = "My-app",
+				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
+		}
+	}
+
+	@priority = 5
 	test CanAddAPIApplicationWithClusterSecondNode {
 		property app.server.bundles.size = "1";
 		property cluster.enabled = "true";
+		property minimum.slave.ram = "24";
+		property portal.acceptance = "true";
+		property remote.elasticsearch.enabled = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("And Given APIApplication with endpoint created on the second node") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
+				mainObjectDefinitionErc = "Student",
+				objectFieldErc = "nameStudent",
+				portalURL = "http://localhost:9080",
+				relatedEndpoint = "true",
+				relatedSchema = "true",
+				schemaName = "testSchema",
+				status = "published",
+				title = "My-app");
+
+			SchemaAPI.relateRequestSchemaToEndpointByErc(
+				endpointErc = "My-app_testendpoint",
+				portalURL = "http://localhost:9080",
+				requestSchemaErc = "My-app_testSchema");
+
+			SchemaAPI.relateResponseSchemaToEndpointByErc(
+				endpointErc = "My-app_testendpoint",
+				portalURL = "http://localhost:9080",
+				responseSchemaErc = "My-app_testSchema");
+		}
+
+		task ("When executing the endpoint on the default node") {
+			var response = APIApplicationEndpoint.getEndpoint(
+				baseURL = "my-app",
+				path = "/testendpoint",
+				portalURL = "http://localhost:8080");
+		}
+
+		task ("Then endpoint response is correct") {
+			var itemsCount = JSONUtil.getWithJSONPath(${response}, "$..totalCount");
+
+			TestUtils.assertEquals(
+				actual = ${itemsCount},
+				expected = 1);
+		}
+
+		task ("And Then api application present in API Builder of the default node") {
+			User.loginPG(
+				nodePort = 8080,
+				password = "test",
+				userEmailAddress = "test@liferay.com");
+
+			ApplicationsMenu.gotoPortlet(
+				category = "Object",
+				panel = "Control Panel",
+				portlet = "API Builder");
+
+			AssertElementPresent(
+				key_name = "My-app",
+				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
+		}
+	}
+
+	@priority = 5
+	test CanAddAPIApplicationWithClusterSecondNodePSQL {
+		property app.server.bundles.size = "1";
+		property cluster.enabled = "true";
+		property database.types = "postgresql";
 		property minimum.slave.ram = "24";
 		property portal.acceptance = "true";
 		property remote.elasticsearch.enabled = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/macros/SQL.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SQL.macro
@@ -1,12 +1,27 @@
 definition {
 
 	@summary = "Compare the database count with the ${expectedCount}"
-	macro assertDatabaseCount(databaseSubstring = null, databaseFilter = null, expectedCount = null) {
+	macro assertMySQLDatabaseCount(databaseSubstring = null, databaseFilter = null, expectedCount = null) {
 		Variables.assertDefined(parameterList = "${databaseFilter},${databaseSubstring},${expectedCount}");
 
 		var mysqlStatement = "SHOW DATABASES LIKE '${databaseFilter}';";
 
 		var sqlResults = SQL.executeMySQLStatement(mysqlStatement = ${mysqlStatement});
+
+		var matches = StringUtil.count(${sqlResults}, ${databaseSubstring});
+
+		if (${matches} != ${expectedCount}) {
+			fail("Expected ${expectedCount} matches of ${databaseSubstring}, found ${matches}.");
+		}
+	}
+
+	@summary = "Compare the database count with the ${expectedCount}"
+	macro assertPSQLDatabaseCount(databaseSubstring = null, databaseFilter = null, expectedCount = null) {
+		Variables.assertDefined(parameterList = "${databaseFilter},${databaseSubstring},${expectedCount}");
+
+		var psqlStatement = "SELECT datname FROM pg_catalog.pg_database WHERE datname LIKE '${databaseFilter}';";
+
+		var sqlResults = SQL.executePSQLStatement(psqlStatement = ${psqlStatement});
 
 		var matches = StringUtil.count(${sqlResults}, ${databaseSubstring});
 
@@ -57,6 +72,23 @@ definition {
 		FileUtil.write("${liferayHome}/${inputFile}", ${mysqlStatement});
 
 		AntCommands.runCommand("build-test.xml", "execute-mysql -Dmysql.input.file=${liferayHome}/${inputFile} -Dmysql.output.file=${liferayHome}/${outputFile}");
+
+		var output = FileUtil.read("${liferayHome}/${outputFile}");
+
+		return ${output};
+	}
+
+	@summary = "Execute ${psqlStatement}"
+	macro executePSQLStatement(psqlStatement = null) {
+		Variables.assertDefined(parameterList = ${psqlStatement});
+
+		var liferayHome = PropsUtil.get("liferay.home.dir.name");
+		var inputFile = "psqltemp.sql";
+		var outputFile = "psqltemp.txt";
+
+		FileUtil.write("${liferayHome}/${inputFile}", ${psqlStatement});
+
+		AntCommands.runCommand("build-test.xml", "execute-psql -Dpsql.input.file=${liferayHome}/${inputFile} -Dpsql.output.file=${liferayHome}/${outputFile}");
 
 		var output = FileUtil.read("${liferayHome}/${outputFile}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/passwordpolicies/PasswordPolicies.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/passwordpolicies/PasswordPolicies.testcase
@@ -847,6 +847,42 @@ definition {
 		}
 	}
 
+	@description = "This is a use case for LPS-179688 TC-9: Verify Allow Custom Password At Account Creation parameter is unique by instance when database partitioning is enabled."
+	@priority = 5
+	test PasswordCreationParameterIsUniqueByInstanceWithEnableDatabasePartitioningPSQL {
+		property custom.properties = "jsonws.web.service.paths.excludes=";
+		property database.partition.enabled = "true";
+		property database.types = "postgresql";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Given Disable Allow Custom Password At Account Creation in the default instance the password will still be present in the newly created virtual instance") {
+			HeadlessPortalInstanceAPI.addPortalInstance(
+				domain = "www.able.com",
+				portalInstanceId = "www.able.com",
+				virtualHost = "www.able.com");
+
+			User.configureCustomPasswordField();
+
+			User.viewNoPasswordSection();
+
+			User.viewPasswordSection(specificURL = "http://www.able.com:8080");
+		}
+
+		task ("When Disable Allow Custom Password At Account Creation in new instance") {
+			User.firstLoginUI(
+				password = "test",
+				specificURL = "http://www.able.com:8080",
+				userEmailAddress = "test@www.able.com");
+
+			User.configureCustomPasswordField(baseURL = "http://www.able.com:8080");
+		}
+
+		task ("Then Verify password field is not present www.able.com virtual instance") {
+			User.viewNoPasswordSection(specificURL = "http://www.able.com:8080");
+		}
+	}
+
 	@description = "This is a test for LPS-179689. TC-2: Verify password item is hidden on the user's My Account page after disabling the change password option from the custom password policy."
 	@priority = 5
 	test PasswordItemIsHiddenAfterDisablingChangeableFromCustomPolicy {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
@@ -106,7 +106,7 @@ definition {
 			webContentContent = "WC WebContent Content",
 			webContentTitle = "WC WebContent Title");
 
-		SQL.assertDatabaseCount(
+		SQL.assertMySQLDatabaseCount(
 			databaseFilter = "lpartition%",
 			databaseSubstring = "lpartition",
 			expectedCount = 1);
@@ -279,7 +279,7 @@ definition {
 			webContentContent = "WC WebContent Content",
 			webContentTitle = "WC WebContent Title");
 
-		SQL.assertDatabaseCount(
+		SQL.assertMySQLDatabaseCount(
 			databaseFilter = "lpartition%",
 			databaseSubstring = "lpartition",
 			expectedCount = 1);
@@ -401,7 +401,7 @@ definition {
 
 		DMDocument.viewCP(dmDocumentTitle = "DM Document Title");
 
-		SQL.assertDatabaseCount(
+		SQL.assertMySQLDatabaseCount(
 			databaseFilter = "lpartition%",
 			databaseSubstring = "lpartition",
 			expectedCount = 1);
@@ -484,7 +484,7 @@ definition {
 
 		DMDocument.viewCP(dmDocumentTitle = "DM Document Title");
 
-		SQL.assertDatabaseCount(
+		SQL.assertMySQLDatabaseCount(
 			databaseFilter = "testPartition%",
 			databaseSubstring = "testPartition",
 			expectedCount = 1);
@@ -569,7 +569,7 @@ definition {
 
 		PortalInstances.deleteCP(virtualHost = "www.able.com");
 
-		SQL.assertDatabaseCount(
+		SQL.assertMySQLDatabaseCount(
 			databaseFilter = "testPartition%",
 			databaseSubstring = "testPartition",
 			expectedCount = 0);
@@ -936,7 +936,7 @@ definition {
 
 		DMDocument.viewCP(dmDocumentTitle = "DM Document Title");
 
-		SQL.assertDatabaseCount(
+		SQL.assertMySQLDatabaseCount(
 			databaseFilter = "testPartition%",
 			databaseSubstring = "testPartition",
 			expectedCount = 2);

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
@@ -113,6 +113,98 @@ definition {
 	}
 
 	@priority = 5
+	test CanAddCompanyWithClusterPSQL {
+		property app.server.bundles.size = "1";
+		property cluster.enabled = "true";
+		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
+		property database.types = "postgresql";
+		property minimum.slave.ram = "24";
+		property portal.acceptance = "true";
+		property remote.elasticsearch.enabled = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		Clustering.viewClusterStatusInConsole();
+
+		Page.assertNodePortPG(nodePort = 8080);
+
+		User.logoutPG(
+			password = "test",
+			userEmailAddress = "test@liferay.com");
+
+		User.loginPG(
+			nodePort = 9080,
+			password = "test",
+			userEmailAddress = "test@liferay.com");
+
+		Page.assertNodePortPG(nodePort = 9080);
+
+		User.logoutPG(
+			nodePort = 9080,
+			password = "test",
+			userEmailAddress = "test@liferay.com");
+
+		User.loginPG(
+			nodePort = 8080,
+			password = "test",
+			userEmailAddress = "test@liferay.com");
+
+		PortalInstances.openVirtualInstancesAdmin();
+
+		PortalInstances.addCP(
+			mailDomain = "www.able.com",
+			virtualHost = "www.able.com",
+			webId = "www.able.com");
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://www.able.com:8080",
+			userEmailAddress = "test@www.able.com");
+
+		Navigator.openSpecificURL(url = "http://www.able.com:8080");
+
+		ProductMenu.gotoPortlet(
+			category = "Content & Data",
+			panel = "Site Administration",
+			portlet = "Web Content");
+
+		WebContentNavigator.gotoAddCP();
+
+		WebContent.addCP(
+			webContentContent = "WC WebContent Content",
+			webContentTitle = "WC WebContent Title");
+
+		PortletEntry.publish();
+
+		WebContentNavigator.gotoEditCP(webContentTitle = "WC WebContent Title");
+
+		WebContent.viewCP(
+			webContentContent = "WC WebContent Content",
+			webContentTitle = "WC WebContent Title");
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://www.able.com:9080",
+			userEmailAddress = "test@www.able.com");
+
+		ProductMenu.gotoPortlet(
+			category = "Content & Data",
+			panel = "Site Administration",
+			portlet = "Web Content");
+
+		WebContentNavigator.gotoEditCP(webContentTitle = "WC WebContent Title");
+
+		WebContent.viewCP(
+			webContentContent = "WC WebContent Content",
+			webContentTitle = "WC WebContent Title");
+
+		SQL.assertPSQLDatabaseCount(
+			databaseFilter = "lpartition%",
+			databaseSubstring = "lpartition",
+			expectedCount = 1);
+	}
+
+	@priority = 5
 	test CanAddCompanyWithClusterSecondNode {
 		property app.server.bundles.size = "1";
 		property cluster.enabled = "true";
@@ -193,6 +285,88 @@ definition {
 			expectedCount = 1);
 	}
 
+	@priority = 5
+	test CanAddCompanyWithClusterSecondNodePSQL {
+		property app.server.bundles.size = "1";
+		property cluster.enabled = "true";
+		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
+		property database.types = "postgresql";
+		property minimum.slave.ram = "24";
+		property portal.acceptance = "true";
+		property remote.elasticsearch.enabled = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		Clustering.viewClusterStatusInConsole();
+
+		Page.assertNodePortPG(nodePort = 8080);
+
+		User.logoutPG(
+			password = "test",
+			userEmailAddress = "test@liferay.com");
+
+		User.loginPG(
+			nodePort = 9080,
+			password = "test",
+			userEmailAddress = "test@liferay.com");
+
+		Page.assertNodePortPG(nodePort = 9080);
+
+		PortalInstances.openVirtualInstancesAdmin(baseURL = "http://localhost:9080");
+
+		PortalInstances.addCP(
+			mailDomain = "www.able.com",
+			virtualHost = "www.able.com",
+			webId = "www.able.com");
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://www.able.com:9080",
+			userEmailAddress = "test@www.able.com");
+
+		Navigator.openSpecificURL(url = "http://www.able.com:9080");
+
+		ProductMenu.gotoPortlet(
+			category = "Content & Data",
+			panel = "Site Administration",
+			portlet = "Web Content");
+
+		WebContentNavigator.gotoAddCP();
+
+		WebContent.addCP(
+			webContentContent = "WC WebContent Content",
+			webContentTitle = "WC WebContent Title");
+
+		PortletEntry.publish();
+
+		WebContentNavigator.gotoEditCP(webContentTitle = "WC WebContent Title");
+
+		WebContent.viewCP(
+			webContentContent = "WC WebContent Content",
+			webContentTitle = "WC WebContent Title");
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://www.able.com:8080",
+			userEmailAddress = "test@www.able.com");
+
+		ProductMenu.gotoPortlet(
+			category = "Content & Data",
+			panel = "Site Administration",
+			portlet = "Web Content");
+
+		WebContentNavigator.gotoEditCP(webContentTitle = "WC WebContent Title");
+
+		WebContent.viewCP(
+			webContentContent = "WC WebContent Content",
+			webContentTitle = "WC WebContent Title");
+
+		SQL.assertPSQLDatabaseCount(
+			databaseFilter = "lpartition%",
+			databaseSubstring = "lpartition",
+			expectedCount = 1);
+	}
+
 	@description = "This is a use case for LPS-160064."
 	@priority = 4
 	test CanAddCompanyWithHeadlessAPI {
@@ -228,6 +402,47 @@ definition {
 		DMDocument.viewCP(dmDocumentTitle = "DM Document Title");
 
 		SQL.assertDatabaseCount(
+			databaseFilter = "lpartition%",
+			databaseSubstring = "lpartition",
+			expectedCount = 1);
+	}
+
+	@description = "This is a use case for LPS-160064."
+	@priority = 4
+	test CanAddCompanyWithHeadlessAPIPSQL {
+		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.baker.com";
+		property database.types = "postgresql";
+		property test.assert.warning.exceptions = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		HeadlessPortalInstanceAPI.addPortalInstance(
+			domain = "www.baker.com",
+			portalInstanceId = "www.baker.com",
+			virtualHost = "www.baker.com");
+
+		SignOut.signOut();
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://www.baker.com:8080",
+			userEmailAddress = "test@www.baker.com");
+
+		ProductMenu.gotoPortlet(
+			category = "Content & Data",
+			panel = "Site Administration",
+			portlet = "Documents and Media");
+
+		DMDocument.addCP(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentFile = "Document_1.doc",
+			dmDocumentTitle = "DM Document Title");
+
+		DMNavigator.gotoDocumentCP(dmDocumentTitle = "DM Document Title");
+
+		DMDocument.viewCP(dmDocumentTitle = "DM Document Title");
+
+		SQL.assertPSQLDatabaseCount(
 			databaseFilter = "lpartition%",
 			databaseSubstring = "lpartition",
 			expectedCount = 1);
@@ -276,6 +491,49 @@ definition {
 	}
 
 	@priority = 5
+	test CanAddCompanyWithPortalInstancesAdminUIPSQL {
+		property custom.properties = "database.partition.schema.name.prefix=testPartition${line.separator}virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
+		property database.types = "postgresql";
+		property portal.acceptance = "true";
+		property test.assert.warning.exceptions = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		PortalInstances.openVirtualInstancesAdmin();
+
+		PortalInstances.addCP(
+			mailDomain = "www.able.com",
+			virtualHost = "www.able.com",
+			webId = "www.able.com");
+
+		SignOut.signOut();
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://www.able.com:8080",
+			userEmailAddress = "test@www.able.com");
+
+		ProductMenu.gotoPortlet(
+			category = "Content & Data",
+			panel = "Site Administration",
+			portlet = "Documents and Media");
+
+		DMDocument.addCP(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentFile = "Document_1.doc",
+			dmDocumentTitle = "DM Document Title");
+
+		DMNavigator.gotoDocumentCP(dmDocumentTitle = "DM Document Title");
+
+		DMDocument.viewCP(dmDocumentTitle = "DM Document Title");
+
+		SQL.assertPSQLDatabaseCount(
+			databaseFilter = "testPartition%",
+			databaseSubstring = "testPartition",
+			expectedCount = 1);
+	}
+
+	@priority = 5
 	test CanDeleteCompany {
 		property custom.properties = "database.partition.schema.name.prefix=testPartition${line.separator}virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
 		property portal.acceptance = "true";
@@ -312,6 +570,49 @@ definition {
 		PortalInstances.deleteCP(virtualHost = "www.able.com");
 
 		SQL.assertDatabaseCount(
+			databaseFilter = "testPartition%",
+			databaseSubstring = "testPartition",
+			expectedCount = 0);
+	}
+
+	@priority = 5
+	test CanDeleteCompanyPSQL {
+		property custom.properties = "database.partition.schema.name.prefix=testPartition${line.separator}virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
+		property database.types = "postgresql";
+		property portal.acceptance = "true";
+		property test.assert.warning.exceptions = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		HeadlessPortalInstanceAPI.addPortalInstance(
+			domain = "www.able.com",
+			portalInstanceId = "www.able.com",
+			virtualHost = "www.able.com");
+
+		SignOut.signOut();
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://www.able.com:8080",
+			userEmailAddress = "test@www.able.com");
+
+		ProductMenu.gotoPortlet(
+			category = "Content & Data",
+			panel = "Site Administration",
+			portlet = "Documents and Media");
+
+		DMDocument.addCP(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentFile = "Document_1.doc",
+			dmDocumentTitle = "DM Document Title");
+
+		User.loginPG();
+
+		PortalInstances.openVirtualInstancesAdmin();
+
+		PortalInstances.deleteCP(virtualHost = "www.able.com");
+
+		SQL.assertPSQLDatabaseCount(
 			databaseFilter = "testPartition%",
 			databaseSubstring = "testPartition",
 			expectedCount = 0);
@@ -400,8 +701,139 @@ definition {
 			value1 = "APPROVED");
 	}
 
+	@description = "This is a use case for LPS-171480."
+	@priority = 3
+	test CanScheduleJobInVariousCompaniesWhenAutoUpgradeIsEnabledPSQL {
+		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
+		property database.auto.upgrade.enabled = "true";
+		property database.partition.enabled = "true";
+		property database.types = "postgresql";
+		property liferay.online.properties = "false";
+		property osgi.module.configuration.file.names = "com.liferay.journal.configuration.JournalServiceConfiguration.config";
+		property osgi.module.configurations = "checkInterval=I\"1\"";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		HeadlessPortalInstanceAPI.addPortalInstance(
+			domain = "www.able.com",
+			portalInstanceId = "www.able.com",
+			virtualHost = "www.able.com");
+
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "Guest");
+
+		WebContentNavigator.gotoAddCP();
+
+		WebContent.addCP(
+			webContentContent = "Web Content Content",
+			webContentTitle = "Web Content Title");
+
+		WebContent.increaseDisplayDate(minuteIncrease = 2);
+
+		PortletEntry.publish();
+
+		TestUtils.hardRefresh();
+
+		AssertTextEquals(
+			key_webContentTitle = "Web Content Title",
+			locator1 = "WC#ENTRY_LIST_WORKFLOW_STATUS",
+			value1 = "SCHEDULED");
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://www.able.com:8080",
+			userEmailAddress = "test@www.able.com");
+
+		WebContentNavigator.openWebContentAdmin(
+			baseURL = "http://www.able.com:8080",
+			siteURLKey = "Guest");
+
+		WebContentNavigator.gotoAddCP();
+
+		WebContent.addCP(
+			webContentContent = "Web Content Content",
+			webContentTitle = "Web Content Title");
+
+		WebContent.increaseDisplayDate(minuteIncrease = 2);
+
+		PortletEntry.publish();
+
+		TestUtils.hardRefresh();
+
+		AssertTextEquals(
+			key_webContentTitle = "Web Content Title",
+			locator1 = "WC#ENTRY_LIST_WORKFLOW_STATUS",
+			value1 = "SCHEDULED");
+
+		// Pausing 210 seconds due to LRQA-75909
+
+		Pause(value1 = 210000);
+
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "Guest");
+
+		AssertTextEquals(
+			key_webContentTitle = "Web Content Title",
+			locator1 = "WC#ENTRY_LIST_WORKFLOW_STATUS",
+			value1 = "APPROVED");
+
+		WebContentNavigator.openWebContentAdmin(
+			baseURL = "http://www.able.com:8080",
+			siteURLKey = "Guest");
+
+		AssertTextEquals(
+			key_webContentTitle = "Web Content Title",
+			locator1 = "WC#ENTRY_LIST_WORKFLOW_STATUS",
+			value1 = "APPROVED");
+	}
+
 	@priority = 4
 	test CanSetVirtualHostViaPages {
+		property test.assert.warning.exceptions = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		HeadlessPortalInstanceAPI.addPortalInstance(
+			domain = "www.able.com",
+			portalInstanceId = "www.able.com",
+			virtualHost = "www.able.com");
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://www.able.com:8080",
+			userEmailAddress = "test@www.able.com");
+
+		ProductMenu.gotoPortlet(
+			category = "Configuration",
+			panel = "Site Administration",
+			portlet = "Site Settings");
+
+		Site.addVirtualHostsURLCP(
+			pageVirtualHosts = "true",
+			pageVirtualHostURL = "www.baker.com");
+
+		Navigator.gotoPage(
+			baseURL = "http://www.baker.com:8080",
+			pageName = "Home");
+
+		AssertLocation(value1 = "http://www.baker.com:8080/web/guest/home");
+
+		SignOut.signOut();
+
+		User.firstLoginPG();
+
+		ServerAdministration.openServerAdmin();
+
+		ServerAdministration.executeServerResourcesActions(actionsDescription = "Clear the database cache.");
+
+		Navigator.gotoPage(
+			baseURL = "http://www.baker.com:8080",
+			pageName = "Home");
+
+		AssertLocation(value1 = "http://www.baker.com:8080/web/guest/home");
+	}
+
+	@priority = 4
+	test CanSetVirtualHostViaPagesPSQL {
+		property database.types = "postgresql";
 		property test.assert.warning.exceptions = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
@@ -559,6 +991,54 @@ definition {
 		DMDocument.viewCP(dmDocumentTitle = "DM Document Title");
 	}
 
+	@priority = 3
+	test NewCompanyStillAccessibleAfterRestartPSQL {
+		property custom.properties = "database.partition.schema.name.prefix=testPartition${line.separator}virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
+		property database.types = "postgresql";
+		property test.assert.warning.exceptions = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		HeadlessPortalInstanceAPI.addPortalInstance(
+			domain = "www.able.com",
+			portalInstanceId = "www.able.com",
+			virtualHost = "www.able.com");
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://www.able.com:8080",
+			userEmailAddress = "test@www.able.com");
+
+		ProductMenu.gotoPortlet(
+			category = "Content & Data",
+			panel = "Site Administration",
+			portlet = "Documents and Media");
+
+		DMDocument.addCP(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentFile = "Document_1.doc",
+			dmDocumentTitle = "DM Document Title");
+
+		DMNavigator.gotoDocumentCP(dmDocumentTitle = "DM Document Title");
+
+		DMDocument.viewCP(dmDocumentTitle = "DM Document Title");
+
+		Portlet.shutdownServer();
+
+		Portlet.startServer(deleteLiferayHome = "false");
+
+		Navigator.openSpecificURL(url = "http://www.able.com:8080");
+
+		ProductMenu.gotoPortlet(
+			category = "Content & Data",
+			panel = "Site Administration",
+			portlet = "Documents and Media");
+
+		DMNavigator.gotoDocumentCP(dmDocumentTitle = "DM Document Title");
+
+		DMDocument.viewCP(dmDocumentTitle = "DM Document Title");
+	}
+
 	@description = "LPS-163671 - Scenario to cover creation of Virtual Instances with case insensitive DB and DB partitioning enabled"
 	@priority = 3
 	test NewCompanyStillAccessibleAfterRestartWithCaseInsensitiveDatabase {
@@ -615,6 +1095,123 @@ definition {
 	@priority = 3
 	test ScheduleWebContentChangesWithDBPartitioningActivatedAcrossVariousCompanies {
 		property database.partition.enabled = "true";
+		property liferay.online.properties = "false";
+		property osgi.module.configuration.file.names = "com.liferay.journal.configuration.JournalServiceConfiguration.config";
+		property osgi.module.configurations = "checkInterval=I\"1\"";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Add a new Company") {
+			HeadlessPortalInstanceAPI.addPortalInstance(
+				domain = "www.able.com",
+				portalInstanceId = "www.able.com",
+				virtualHost = "www.able.com");
+
+			User.firstLoginUI(
+				password = "test",
+				specificURL = "http://www.able.com:8080",
+				userEmailAddress = "test@www.able.com");
+		}
+
+		task ("Add a WebContent article on new Company") {
+			ProductMenu.gotoPortlet(
+				category = "Content & Data",
+				portlet = "Web Content");
+
+			WebContentNavigator.gotoAddCP();
+
+			WebContent.addCP(
+				webContentContent = "WC WebContent Content New Company",
+				webContentTitle = "WC WebContent Title New Company");
+
+			WebContent.increaseDisplayDate(minuteIncrease = 4);
+
+			PortletEntry.publish();
+
+			TestUtils.hardRefresh();
+
+			AssertTextEquals(
+				key_webContentTitle = "WC WebContent Title New Company",
+				locator1 = "WC#ENTRY_LIST_WORKFLOW_STATUS",
+				value1 = "SCHEDULED");
+		}
+
+		task ("Add a WebContent article on default Company") {
+			User.firstLoginPG();
+
+			ProductMenu.gotoPortlet(
+				category = "Content & Data",
+				portlet = "Web Content");
+
+			WebContentNavigator.gotoAddCP();
+
+			WebContent.addCP(
+				webContentContent = "WC WebContent Content Default Company",
+				webContentTitle = "WC WebContent Title Default Company");
+
+			WebContent.increaseDisplayDate(minuteIncrease = 2);
+
+			PortletEntry.publish();
+
+			TestUtils.hardRefresh();
+
+			AssertTextEquals(
+				key_webContentTitle = "WC WebContent Title Default Company",
+				locator1 = "WC#ENTRY_LIST_WORKFLOW_STATUS",
+				value1 = "SCHEDULED");
+		}
+
+		task ("View WebContent Article Publish on default Company") {
+
+			// Pausing 210 seconds due to LRQA-75909
+
+			Pause(value1 = 210000);
+
+			ProductMenu.gotoPortlet(
+				category = "Content & Data",
+				portlet = "Web Content");
+
+			AssertTextEquals(
+				key_webContentTitle = "WC WebContent Title Default Company",
+				locator1 = "WC#ENTRY_LIST_WORKFLOW_STATUS",
+				value1 = "APPROVED");
+		}
+
+		task ("New Company publish it's WebContent Article") {
+			Navigator.openSpecificURL(url = "http://www.able.com:8080");
+
+			// Pausing 150 seconds due to LRQA-75909
+
+			Pause(value1 = 150000);
+
+			ProductMenu.gotoPortlet(
+				category = "Content & Data",
+				portlet = "Web Content");
+
+			AssertTextEquals(
+				key_webContentTitle = "WC WebContent Title New Company",
+				locator1 = "WC#ENTRY_LIST_WORKFLOW_STATUS",
+				value1 = "APPROVED");
+		}
+
+		task ("WebContent Article not repulish on default Company") {
+			Navigator.openURL();
+
+			ProductMenu.gotoPortlet(
+				category = "Content & Data",
+				portlet = "Web Content");
+
+			AssertTextEquals(
+				key_webContentTitle = "WC WebContent Title Default Company",
+				locator1 = "WC#ENTRY_LIST_WORKFLOW_STATUS",
+				value1 = "APPROVED");
+		}
+	}
+
+	@priority = 3
+	test ScheduleWebContentChangesWithDBPartitioningActivatedAcrossVariousCompaniesPSQL {
+		property database.partition.enabled = "true";
+		property database.types = "postgresql";
 		property liferay.online.properties = "false";
 		property osgi.module.configuration.file.names = "com.liferay.journal.configuration.JournalServiceConfiguration.config";
 		property osgi.module.configurations = "checkInterval=I\"1\"";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioningCache.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioningCache.testcase
@@ -58,7 +58,66 @@ definition {
 	}
 
 	@priority = 5
+	test CacheIsClearedOnCompanyRemovalPSQL {
+		property database.types = "postgresql";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		HeadlessPortalInstanceAPI.addPortalInstance(
+			domain = "www.able.com",
+			portalInstanceId = "www.able.com",
+			virtualHost = "www.able.com");
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://www.able.com:8080",
+			userEmailAddress = "test@www.able.com");
+
+		User.firstLoginPG();
+
+		ServerAdministration.openServerAdmin();
+
+		var secondCompanyId = JSONCompany.getCompanyId(portalInstanceName = "www.able.com");
+
+		PortalCache.putCache(
+			cacheValue = "test.value",
+			companyId = ${secondCompanyId});
+
+		PortalInstances.openVirtualInstancesAdmin();
+
+		PortalInstances.deleteCP(virtualHost = "www.able.com");
+
+		ServerAdministration.openServerAdmin();
+
+		PortalCache.getCache(
+			cacheValue = "null",
+			companyId = ${secondCompanyId});
+	}
+
+	@priority = 5
 	test CacheIsOnlyPopulatedToSingleCompany {
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		PortalInstances.openVirtualInstancesAdmin();
+
+		PortalInstances.addCP(
+			mailDomain = "www.able.com",
+			virtualHost = "www.able.com",
+			webId = "www.able.com");
+
+		ServerAdministration.openServerAdmin();
+
+		PortalCache.putCache(
+			cacheValue = "test.value",
+			portalInstanceName = "www.able.com");
+
+		PortalCache.getCache(cacheValue = "null");
+	}
+
+	@priority = 5
+	test CacheIsOnlyPopulatedToSingleCompanyPSQL {
+		property database.types = "postgresql";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -147,8 +206,147 @@ definition {
 			portalInstanceName = "www.able.com");
 	}
 
+	@priority = 5
+	test CacheOnlyClearsOnSameCompanyAcrossClusterPSQL {
+		property app.server.bundles.size = "1";
+		property cluster.enabled = "true";
+		property database.types = "postgresql";
+		property minimum.slave.ram = "24";
+		property remote.elasticsearch.enabled = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		HeadlessPortalInstanceAPI.addPortalInstance(
+			domain = "www.able.com",
+			portalInstanceId = "www.able.com",
+			virtualHost = "www.able.com");
+
+		ServerAdministration.openServerAdmin();
+
+		PortalCache.putCache(cacheValue = "test.value.node.1.company.1");
+
+		PortalCache.putCache(
+			cacheValue = "test.value.node.1.company.2",
+			portalInstanceName = "www.able.com");
+
+		User.logoutPG();
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://localhost:9080",
+			userEmailAddress = "test@liferay.com");
+
+		if (IsElementNotPresent(locator1 = "ApplicationsMenu#TOGGLE")) {
+			Refresh();
+
+			User.firstLoginUI(
+				password = "test",
+				specificURL = "http://localhost:9080",
+				userEmailAddress = "test@liferay.com");
+		}
+
+		ServerAdministration.openServerAdmin(baseURL = "http://localhost:9080");
+
+		PortalCache.getCache(cacheValue = "null");
+
+		PortalCache.getCache(
+			cacheValue = "null",
+			portalInstanceName = "www.able.com");
+
+		PortalCache.putCache(
+			cacheValue = "test.value.node.2.company.2",
+			portalInstanceName = "www.able.com");
+
+		User.logoutPG();
+
+		User.firstLoginPG();
+
+		if (IsElementNotPresent(locator1 = "ApplicationsMenu#TOGGLE")) {
+			Refresh();
+
+			User.firstLoginPG();
+		}
+
+		ServerAdministration.openServerAdmin();
+
+		PortalCache.getCache(cacheValue = "test.value.node.1.company.1");
+
+		PortalCache.getCache(
+			cacheValue = "null",
+			portalInstanceName = "www.able.com");
+	}
+
 	@priority = 4
 	test NullCacheDoesNotBreakSiteFromAnotherPartition {
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		HeadlessPortalInstanceAPI.addPortalInstance(
+			domain = "www.able.com",
+			portalInstanceId = "www.able.com",
+			virtualHost = "www.able.com");
+
+		User.firstLoginPG(
+			password = "test",
+			userEmailAddress = "test@www.able.com",
+			virtualHostsURL = "http://www.able.com:8080");
+
+		Site.openSitesAdmin(baseURL = "http://www.able.com:8080");
+
+		Site.addBlankCP(siteName = "Site on Partition");
+
+		var siteId = Site.getSiteId();
+
+		ProductMenu.gotoPortlet(
+			category = "Site Builder",
+			portlet = "Pages");
+
+		PagesAdmin.addPage(
+			pageName = "homepage",
+			sitePageType = "Widget Page");
+
+		Navigator.openURL();
+
+		ApplicationsMenu.gotoPortlet(
+			category = "System",
+			panel = "Control Panel",
+			portlet = "Server Administration");
+
+		ServerAdministration.executeScript(
+			language = "Groovy",
+			script = "com.liferay.portal.kernel.service.GroupLocalServiceUtil.getGroup(${siteId});");
+
+		AssertTextEquals.assertPartialText(
+			locator1 = "Message#ERROR",
+			value1 = "No Group exists with the primary key");
+
+		ApplicationsMenu.gotoPortlet(
+			category = "System",
+			panel = "Control Panel",
+			portlet = "Server Administration");
+
+		ServerAdministration.executeServerResourcesActions(actionsDescription = "Clear content cached across the cluster.");
+
+		User.firstLoginPG();
+
+		ServerAdministration.openServerAdmin();
+
+		ServerAdministration.executeScript(
+			language = "Groovy",
+			script = "com.liferay.portal.kernel.service.GroupLocalServiceUtil.getGroup(${siteId});");
+
+		AssertTextEquals.assertPartialText(
+			locator1 = "Message#ERROR",
+			value1 = "No Group exists with the primary key");
+
+		Navigator.openSpecificURL(url = "http://www.able.com:8080");
+
+		Smoke.viewWelcomeContentPage();
+	}
+
+	@priority = 4
+	test NullCacheDoesNotBreakSiteFromAnotherPartitionPSQL {
+		property database.types = "postgresql";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/fileinstall/OSGIConfiguration.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/fileinstall/OSGIConfiguration.testcase
@@ -49,6 +49,29 @@ definition {
 			userEmailAddress = "test@www.able.com");
 	}
 
+	@description = "This is a test for LPS-200501. Verify if virtual instances can be created via OSGI config file with database partitioning enabled."
+	@priority = 5
+	test CanCreatePartitionedVirtualInstanceViaConfigPSQL {
+		property app.server.types = "tomcat";
+		property database.types = "postgresql";
+		property liferay.online.properties = "true";
+		property osgi.module.configuration.file.names = "com.liferay.portal.instances.internal.configuration.PortalInstancesConfiguration~www.able.com.config";
+		property osgi.module.configurations = "mx=\"www.able.com\"${line.separator}virtualHostname=\"www.able.com\"";
+		property portal.acceptance = "true";
+		property test.assert.warning.exceptions = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		PortalInstances.openVirtualInstancesAdmin();
+
+		PortalInstances.viewCP(virtualHost = "www.able.com");
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://www.able.com:8080",
+			userEmailAddress = "test@www.able.com");
+	}
+
 	@description = "This is a test for LPS-173655. Verify if virtual instances can be created via OSGI config file."
 	@priority = 4
 	test CanCreateVirtualInstanceViaConfig {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/logging/CompanyLogging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/logging/CompanyLogging.testcase
@@ -42,9 +42,66 @@ definition {
 		}
 	}
 
+	@description = "Any logs that would appear specifically in company A should never appear in the logs of company B"
+	@priority = 5
+	test AssertCompanyLogsIsolatedPSQL {
+		property database.types = "postgresql";
+		property portal.acceptance = "true";
+		property test.assert.warning.exceptions = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "sequential";
+
+		for (var portalInstanceName : list "www.able.com,www.baker.com") {
+			HeadlessPortalInstanceAPI.addPortalInstance(
+				domain = ${portalInstanceName},
+				portalInstanceId = ${portalInstanceName},
+				virtualHost = ${portalInstanceName});
+
+			CompanyLogging.openServerLogsAdmin();
+
+			CompanyLogging.assertCompanyLogIsolated(portalInstanceName = ${portalInstanceName});
+
+			GoBack();
+		}
+	}
+
 	@description = "If a company log is deleted, it should also be removed from the company logs portlet"
 	@priority = 4
 	test CannotViewDeletedCompanyLog {
+		property test.assert.warning.exceptions = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Given a log exists for a company") {
+			CompanyLogging.openServerLogsAdmin();
+
+			var logName = CompanyLogging.getCompanyLogName(portalInstanceName = "liferay.com");
+
+			AssertElementPresent(
+				key_logName = ${logName},
+				locator1 = "CompanyLogging#COMPANY_LOG_NAME");
+		}
+
+		task ("When the company log is deleted") {
+			var homeDir = PropsUtil.get("liferay.home.dir.name");
+			var companyId = JSONCompany.getCompanyId();
+
+			FileUtil.delete("${homeDir}/logs/companies/${companyId}/${logName}");
+		}
+
+		task ("Then the log is removed from the list in the UI") {
+			Refresh();
+
+			AssertElementNotPresent(
+				key_logName = ${logName},
+				locator1 = "CompanyLogging#COMPANY_LOG_NAME");
+		}
+	}
+
+	@description = "If a company log is deleted, it should also be removed from the company logs portlet"
+	@priority = 4
+	test CannotViewDeletedCompanyLogPSQL {
+		property database.types = "postgresql";
 		property test.assert.warning.exceptions = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
@@ -121,9 +178,100 @@ definition {
 		}
 	}
 
+	@description = "If company.log.enabled=false, there should not be additional logging files created for each company and the UI access point should be unavailable"
+	@priority = 4
+	test CompanyLoggingDisabledPSQL {
+		property custom.properties = "company.log.enabled=false";
+		property database.types = "postgresql";
+
+		task ("Verify the user cannot access the company logs portlet with company logging disabled") {
+			ApplicationsMenuHelper.openApplicationsMenu();
+
+			ApplicationsMenu.gotoPanel(panel = "Control Panel");
+
+			AssertElementNotPresent(
+				key_category = "Security",
+				key_portlet = "Server Logs",
+				locator1 = "ApplicationsMenu#PORTLET");
+		}
+
+		task ("When the user tries navigating directly to the company logs page") {
+			Navigator.openWithAppendToBaseURL(urlAppend = "o/company-log");
+		}
+
+		task ("Then the page cannot be accessed") {
+			AssertElementNotPresent(
+				key_virtualHost = "liferay.com",
+				locator1 = "CompanyLogging#COMPANY_LOG_TITLE");
+
+			AssertLocation.assertPartialLocation(value1 = "web/guest");
+		}
+
+		task ("When the user adds a virtual instance") {
+			HeadlessPortalInstanceAPI.addPortalInstance(
+				domain = "www.able.com",
+				portalInstanceId = "www.able.com",
+				virtualHost = "www.able.com");
+		}
+
+		task ("Then additional company logging files should not be created") {
+			var homeDir = PropsUtil.get("liferay.home.dir.name");
+
+			var companiesFolderExists = FileUtil.exists("${homeDir}/logs/companies");
+
+			if (${companiesFolderExists} == "true") {
+				fail("logs/companies folder exists");
+			}
+		}
+	}
+
 	@description = "An Omniadmin can get log names from all companies and download logs from all companies though the UI"
 	@priority = 4
 	test GetAllCompanyLogs {
+		property test.assert.warning.exceptions = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "sequential";
+
+		task ("Given two new virtual instances are created") {
+			for (var portalInstanceName : list "www.able.com,www.baker.com") {
+				HeadlessPortalInstanceAPI.addPortalInstance(
+					domain = ${portalInstanceName},
+					portalInstanceId = ${portalInstanceName},
+					virtualHost = ${portalInstanceName});
+			}
+		}
+
+		task ("When the Omniadmin navigates to the company logs portlet") {
+			CompanyLogging.openServerLogsAdmin();
+		}
+
+		task ("Then log files are present for all companies") {
+			var portalInstanceNames = JSONCompany.getAllCompanyNames();
+
+			for (var portalInstanceName : list ${portalInstanceNames}) {
+				AssertElementPresent(
+					key_virtualHost = ${portalInstanceName},
+					locator1 = "CompanyLogging#COMPANY_LOG_TITLE");
+			}
+		}
+
+		task ("And the log files can be downloaded and viewed for each company") {
+			for (var portalInstanceName : list ${portalInstanceNames}) {
+				var logContent = CompanyLogging.downloadCompanyLog(portalInstanceName = ${portalInstanceName});
+
+				CompanyLogging.assertCompanyLogContent(
+					logContent = ${logContent},
+					portalInstanceName = ${portalInstanceName});
+
+				GoBack();
+			}
+		}
+	}
+
+	@description = "An Omniadmin can get log names from all companies and download logs from all companies though the UI"
+	@priority = 4
+	test GetAllCompanyLogsPSQL {
+		property database.types = "postgresql";
 		property test.assert.warning.exceptions = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "sequential";
@@ -290,6 +438,134 @@ definition {
 		}
 	}
 
+	@description = "A company admin that tries to directly download the logs of a company they do not have access to should get a permissions error"
+	@priority = 4
+	test GetCompanyAdminLogsFromDifferentCompanyPSQL {
+		property database.types = "postgresql";
+		property test.assert.warning.exceptions = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "sequential";
+
+		task ("Given a new instance is created") {
+			HeadlessPortalInstanceAPI.addPortalInstance(
+				domain = "www.able.com",
+				portalInstanceId = "www.able.com",
+				virtualHost = "www.able.com");
+		}
+
+		task ("And given a company admin user is added for that virtual instance") {
+			User.firstLoginUI(
+				password = "test",
+				specificURL = "http://www.able.com:8080",
+				userEmailAddress = "test@www.able.com");
+
+			JSONUser.addUser(
+				creatorEmailAddress = "test@www.able.com",
+				creatorPassword = "test",
+				portalInstanceName = "www.able.com",
+				specificURL = "http://www.able.com:8080",
+				userEmailAddress = "userea@www.able.com",
+				userFirstName = "userfn",
+				userLastName = "userln",
+				userScreenName = "usersn");
+
+			User.openUsersAdmin(baseURL = "http://www.able.com:8080");
+
+			User.assignRegularRoleCP(
+				roleTitle = "Administrator",
+				userScreenName = "usersn");
+
+			User.editPassword(newPassword = "test");
+		}
+
+		task ("And given the company admin logs in to the virtual instance") {
+			User.logoutPG();
+
+			SignIn._signIn(
+				userEmailAddress = "userea@www.able.com",
+				virtualHostsURL = "http://www.able.com:8080");
+		}
+
+		task ("When the company admin tries to directly download a specific company log from a different company") {
+			var companyId = JSONCompany.getCompanyId();
+			var logName = CompanyLogging.getCompanyLogName(portalInstanceName = "liferay.com");
+
+			Navigator.openWithAppendToBaseURL(urlAppend = "o/company-log/${companyId}/${logName}?download=true");
+		}
+
+		task ("Then a permissions error is shown and no log is downloaded") {
+			AssertTextPresent(
+				locator1 = "//body",
+				value1 = "You don't have authorization to view this page.");
+
+			CompanyLogging.assertNoLogDownloaded(logName = ${logName});
+		}
+	}
+
+	@description = "A company admin should only be able to see the logs from the company they are an admin of"
+	@priority = 5
+	test GetCompanyAdminLogsPSQL {
+		property database.types = "postgresql";
+		property portal.acceptance = "true";
+		property test.assert.warning.exceptions = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "sequential";
+
+		task ("Given a new instance is created") {
+			HeadlessPortalInstanceAPI.addPortalInstance(
+				domain = "www.able.com",
+				portalInstanceId = "www.able.com",
+				virtualHost = "www.able.com");
+		}
+
+		task ("And given a company admin user is added for that virtual instance") {
+			User.firstLoginUI(
+				password = "test",
+				specificURL = "http://www.able.com:8080",
+				userEmailAddress = "test@www.able.com");
+
+			JSONUser.addUser(
+				creatorEmailAddress = "test@www.able.com",
+				creatorPassword = "test",
+				portalInstanceName = "www.able.com",
+				specificURL = "http://www.able.com:8080",
+				userEmailAddress = "userea@www.able.com",
+				userFirstName = "userfn",
+				userLastName = "userln",
+				userScreenName = "usersn");
+
+			User.openUsersAdmin(baseURL = "http://www.able.com:8080");
+
+			User.assignRegularRoleCP(
+				roleTitle = "Administrator",
+				userScreenName = "usersn");
+
+			User.editPassword(newPassword = "test");
+		}
+
+		task ("And given the company admin logs in to the virtual instance") {
+			User.logoutPG();
+
+			SignIn._signIn(
+				userEmailAddress = "userea@www.able.com",
+				virtualHostsURL = "http://www.able.com:8080");
+		}
+
+		task ("When the company admin navigates to the company logs portlet") {
+			CompanyLogging.openServerLogsAdmin(baseURL = "http://www.able.com:8080");
+		}
+
+		task ("Then only logs for that instance are shown") {
+			AssertElementPresent(
+				key_virtualHost = "www.able.com",
+				locator1 = "CompanyLogging#COMPANY_LOG_TITLE");
+
+			AssertElementNotPresent(
+				key_virtualHost = "liferay.com",
+				locator1 = "CompanyLogging#COMPANY_LOG_TITLE");
+		}
+	}
+
 	@description = "A non-administrative user should get a permissions denied error when trying to access company logging information"
 	@priority = 4
 	test GetCompanyLogsAsGuest {
@@ -353,9 +629,96 @@ definition {
 		}
 	}
 
+	@description = "A non-administrative user should get a permissions denied error when trying to access company logging information"
+	@priority = 4
+	test GetCompanyLogsAsGuestPSQL {
+		property custom.properties = "company.security.strangers.verify=false${line.separator}jsonws.web.service.paths.excludes=";
+		property database.types = "postgresql";
+		property test.assert.warning.exceptions = "true";
+
+		task ("Given a non-administrative company user") {
+			JSONUser.addUserWithRole(
+				roleTitle = "Power User",
+				userEmailAddress = "userea@liferay.com",
+				userFirstName = "userfn",
+				userLastName = "userln",
+				userScreenName = "usersn");
+		}
+
+		task ("And given the user can access the company logs portlet") {
+			Permissions.definePermissionViaJSONAPI(
+				resourceAction = "VIEW_CONTROL_PANEL",
+				resourceName = 90,
+				roleTitle = "Power User");
+
+			Permissions.definePermissionViaJSONAPI(
+				resourceAction = "ACCESS_IN_CONTROL_PANEL",
+				resourceName = "com_liferay_portal_company_log_web_internal_portlet_PortalCompanyLogPortlet",
+				roleTitle = "Power User");
+		}
+
+		task ("When the user navigates to the company logs portlet") {
+			User.logoutPG();
+
+			User.firstLoginUI(
+				password = "test",
+				userEmailAddress = "userea@liferay.com");
+
+			CompanyLogging.openServerLogsAdmin();
+		}
+
+		task ("The the user cannot view any company logs") {
+			AssertElementNotPresent(
+				key_virtualHost = "",
+				locator1 = "CompanyLogging#COMPANY_LOG_TITLE");
+		}
+
+		task ("When the user tries to directly download a specific company log") {
+			var companyId = JSONCompany.getCompanyId();
+			var logName = CompanyLogging.getCompanyLogName(portalInstanceName = "liferay.com");
+
+			Navigator.openWithAppendToBaseURL(urlAppend = "o/company-log/${companyId}/${logName}?download=true");
+		}
+
+		task ("Then a permissions error is shown and no log is downloaded") {
+			AssertTextPresent(
+				locator1 = "//body",
+				value1 = "You don't have authorization to view this page.");
+
+			AssertTextPresent(
+				locator1 = "//body",
+				value1 = "HTTP ERROR 403");
+
+			CompanyLogging.assertNoLogDownloaded(logName = ${logName});
+		}
+	}
+
 	@description = "If a user tries to download a logging file or company that doesn’t exist it should fail and throw a suitable error message"
 	@priority = 4
 	test GetInvalidCompanyLogs {
+		task ("When the user tries to download a log via an http request where the log name is invalid") {
+			var companyId = JSONCompany.getCompanyId();
+			var baseURL = PropsUtil.get("portal.url");
+
+			Open.openNoError(value1 = "${baseURL}/o/company-log/${companyId}/invalidLog.log");
+		}
+
+		task ("Then an error message is shown which indicates the log was not found and no log is downloaded") {
+			AssertTextPresent(
+				locator1 = "//body",
+				value1 = "No webpage was found for the web address");
+
+			AssertConsoleTextPresent(value1 = "java.io.FileNotFoundException: Unable to get file invalidLog.log for company ${companyId}");
+
+			CompanyLogging.assertNoLogDownloaded(logName = "invalidLog.log");
+		}
+	}
+
+	@description = "If a user tries to download a logging file or company that doesn’t exist it should fail and throw a suitable error message"
+	@priority = 4
+	test GetInvalidCompanyLogsPSQL {
+		property database.types = "postgresql";
+
 		task ("When the user tries to download a log via an http request where the log name is invalid") {
 			var companyId = JSONCompany.getCompanyId();
 			var baseURL = PropsUtil.get("portal.url");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
@@ -187,4 +187,130 @@ definition {
 			expectedCount = 1);
 	}
 
+	@priority = 4
+	test AutoUpgradeFromLatest7413UpdateWithDBPartitionEnabledAndHeadlessAPIPSQL {
+		property database.types = "postgresql";
+		property liferay.online.properties = "true";
+
+		User.firstLoginPG(
+			password = "test",
+			userEmailAddress = "test@liferay.com",
+			virtualHostsURL = "http://localhost:8080");
+
+		HeadlessPortalInstanceAPI.addPortalInstance(
+			domain = "www.able.com",
+			portalInstanceId = "www.able.com",
+			virtualHost = "www.able.com");
+
+		User.firstLoginPG(
+			password = "test",
+			userEmailAddress = "test@www.able.com",
+			virtualHostsURL = "http://www.able.com:8080");
+
+		ProductMenu.gotoPortlet(
+			category = "Content & Data",
+			panel = "Site Administration",
+			portlet = "Documents and Media");
+
+		DMDocument.addCP(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentFile = "Document_1.doc",
+			dmDocumentTitle = "DM Document Title");
+
+		Upgrade.restoreOriginalBundleAndUpgrade();
+
+		User.firstLoginPG(
+			password = "test",
+			userEmailAddress = "test@www.able.com",
+			virtualHostsURL = "http://www.able.com:8080");
+
+		TestUtils.hardRefresh();
+
+		ContentPages.viewFragmentImage(
+			fragmentName = "image",
+			id = "image-square",
+			image = "tree-png");
+
+		ProductMenu.gotoPortlet(
+			category = "Content & Data",
+			panel = "Site Administration",
+			portlet = "Documents and Media");
+
+		DMNavigator.gotoDocumentCP(dmDocumentTitle = "DM Document Title");
+
+		DMDocument.viewCP(dmDocumentTitle = "DM Document Title");
+
+		SQL.assertPSQLDatabaseCount(
+			databaseFilter = "lpartition%",
+			databaseSubstring = "lpartition",
+			expectedCount = 1);
+	}
+
+	@priority = 4
+	test AutoUpgradeFromLatest7413UpdateWithDBPartitionEnabledPSQL {
+		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
+		property database.types = "postgresql";
+		property liferay.online.properties = "true";
+		property timeout.explicit.wait = "120";
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://localhost:8080",
+			userEmailAddress = "test@liferay.com");
+
+		PortalInstances.openVirtualInstancesAdmin(baseURL = "http://localhost:8080");
+
+		PortalInstances.addCP(
+			mailDomain = "www.able.com",
+			virtualHost = "www.able.com",
+			webId = "www.able.com");
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://www.able.com:8080",
+			userEmailAddress = "test@www.able.com");
+
+		Navigator.openSpecificURL(url = "http://www.able.com:8080");
+
+		ProductMenu.gotoPortlet(
+			category = "Content & Data",
+			panel = "Site Administration",
+			portlet = "Documents and Media");
+
+		DMDocument.addCP(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentFile = "Document_1.doc",
+			dmDocumentTitle = "DM Document Title");
+
+		Upgrade.restoreOriginalBundleAndUpgrade();
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://www.able.com:8080",
+			userEmailAddress = "test@www.able.com");
+
+		TestUtils.hardRefresh();
+
+		ContentPages.viewFragmentImage(
+			fragmentName = "image",
+			id = "image-square",
+			image = "tree-png");
+
+		Navigator.openSpecificURL(url = "http://www.able.com:8080");
+
+		ProductMenu.gotoPortlet(
+			category = "Content & Data",
+			panel = "Site Administration",
+			portlet = "Documents and Media");
+
+		DMNavigator.gotoDocumentCP(dmDocumentTitle = "DM Document Title");
+
+		DMDocument.viewCP(dmDocumentTitle = "DM Document Title");
+
+		SQL.assertPSQLDatabaseCount(
+			databaseFilter = "lpartition%",
+			databaseSubstring = "lpartition",
+			expectedCount = 1);
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
@@ -122,7 +122,7 @@ definition {
 
 		DMDocument.viewCP(dmDocumentTitle = "DM Document Title");
 
-		SQL.assertDatabaseCount(
+		SQL.assertMySQLDatabaseCount(
 			databaseFilter = "lpartition%",
 			databaseSubstring = "lpartition",
 			expectedCount = 1);
@@ -181,7 +181,7 @@ definition {
 
 		DMDocument.viewCP(dmDocumentTitle = "DM Document Title");
 
-		SQL.assertDatabaseCount(
+		SQL.assertMySQLDatabaseCount(
 			databaseFilter = "lpartition%",
 			databaseSubstring = "lpartition",
 			expectedCount = 1);

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/administration/auditing/Audit.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/administration/auditing/Audit.testcase
@@ -94,9 +94,114 @@ definition {
 		}
 	}
 
+	@description = "This is a use case for LPS-176997. TC-1: Verify MALU, APV and Scope are enabled on default instance when a LXC environment is being set up."
+	@priority = 5
+	test AssertAuditHeadersOnDefaultInstancePSQL {
+		property database.types = "postgresql";
+		property liferay.online.properties = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("When: Get HTTP response headers in login state") {
+			var curl = '''http://localhost:8080/web/guest?SM_USER=test@liferay.com -I''';
+
+			var response = JSONCurlUtil.post(${curl});
+		}
+
+		task ("Then: Assert the values of X-Liferay-Request-Company and X-Liferay-Request-Group are companyId and groupId respectively and X-Liferay-Request-Guest-User is false.") {
+			var companyId = JSONCompany.getCompanyId();
+			var groupId = JSONGroupAPI._getGroupIdByName(
+				groupName = "Guest",
+				site = "true");
+
+			TestUtils.assertPartialEquals(
+				actual = ${response},
+				expected = "X-Liferay-Request-Company: ${companyId}");
+
+			TestUtils.assertPartialEquals(
+				actual = ${response},
+				expected = "X-Liferay-Request-Group: ${groupId}");
+
+			TestUtils.assertPartialEquals(
+				actual = ${response},
+				expected = "X-Liferay-Request-Guest-User: false");
+
+			TestUtils.assertPartialEquals(
+				actual = ${response},
+				expected = "X-Liferay-Request-User");
+		}
+
+		task ("And: Verify that the value of X-Liferay-Request-Guest-User is true in the unlogged-in state") {
+			var curl = '''http://localhost:8080/web/guest -I''';
+
+			var response = JSONCurlUtil.post(${curl});
+
+			TestUtils.assertPartialEquals(
+				actual = ${response},
+				expected = "X-Liferay-Request-Guest-User: true");
+		}
+	}
+
 	@description = "This is a use case for LPS-176997. TC-2: Verify MALU, APV and Scope are enabled on virtual instance when a LXC environment is being set up."
 	@priority = 5
 	test AssertAuditHeadersOnVirtualInstance {
+		property liferay.online.properties = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Given: Add a virtual instance") {
+			HeadlessPortalInstanceAPI.addPortalInstance(
+				domain = "www.able.com",
+				portalInstanceId = "www.able.com",
+				virtualHost = "www.able.com");
+
+			var companyId = JSONCompany.getCompanyId(portalInstanceName = "www.able.com");
+			var groupId = JSONGroupAPI._getGroupIdByName(
+				groupName = "Guest",
+				portalInstanceName = "www.able.com",
+				site = "true",
+				specificURL = "http://www.able.com:8080");
+		}
+
+		task ("When: Get HTTP response headers in login state") {
+			var curl = '''http://www.able.com:8080/web/guest?SM_USER=test@www.able.com -I''';
+
+			var response = JSONCurlUtil.post(${curl});
+		}
+
+		task ("Then: Assert the values of X-Liferay-Request-Company and X-Liferay-Request-Group are companyId and groupId respectively and X-Liferay-Request-Guest-User is false.") {
+			TestUtils.assertPartialEquals(
+				actual = ${response},
+				expected = "X-Liferay-Request-Company: ${companyId}");
+
+			TestUtils.assertPartialEquals(
+				actual = ${response},
+				expected = "X-Liferay-Request-Group: ${groupId}");
+
+			TestUtils.assertPartialEquals(
+				actual = ${response},
+				expected = "X-Liferay-Request-Guest-User: false");
+
+			TestUtils.assertPartialEquals(
+				actual = ${response},
+				expected = "X-Liferay-Request-User:");
+		}
+
+		task ("And: Verify that the value of X-Liferay-Request-Guest-User is true in the unlogged-in state") {
+			var curl = '''http://www.able.com:8080/web/guest -I''';
+
+			var response = JSONCurlUtil.post(${curl});
+
+			TestUtils.assertPartialEquals(
+				actual = ${response},
+				expected = "X-Liferay-Request-Guest-User: true");
+		}
+	}
+
+	@description = "This is a use case for LPS-176997. TC-2: Verify MALU, APV and Scope are enabled on virtual instance when a LXC environment is being set up."
+	@priority = 5
+	test AssertAuditHeadersOnVirtualInstancePSQL {
+		property database.types = "postgresql";
 		property liferay.online.properties = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/Clustering.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/Clustering.testcase
@@ -287,6 +287,50 @@ definition {
 			nodePort = 9080);
 	}
 
+	@description = "This is a use case for LPS-170924."
+	@priority = 5
+	test CanCreateVirtualInstanceWithClusterDBPartitioningAndLOLPropertiesPSQL {
+		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.baker.com";
+		property database.partition.enabled = "true";
+		property database.types = "postgresql";
+		property liferay.online.properties = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		Clustering.viewClusterStatusInConsole();
+
+		Page.assertNodePortPG(nodePort = 8080);
+
+		PortalInstances.openVirtualInstancesAdmin();
+
+		PortalInstances.addCP(
+			mailDomain = "www.baker.com",
+			virtualHost = "www.baker.com",
+			webId = "www.baker.com");
+
+		Navigator.openSpecificURL(url = "http://www.baker.com:8080");
+
+		User.firstLoginPG(
+			password = "test",
+			userEmailAddress = "test@www.baker.com",
+			virtualHostsURL = "http://www.baker.com:8080");
+
+		Navigator.openSpecificURL(url = "http://www.baker.com:9080");
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://www.baker.com:9080",
+			userEmailAddress = "test@www.baker.com");
+
+		Clustering.viewTextNotPresentOnSpecificNode(
+			exceptionText = "No default user was found for company",
+			nodePort = 8080);
+
+		Clustering.viewTextNotPresentOnSpecificNode(
+			exceptionText = "No default user was found for company",
+			nodePort = 9080);
+	}
+
 	@description = "This is a use case for LPS-171011."
 	@priority = 5
 	test CanCreateVirtualInstanceWithClustering {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtension.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtension.testcase
@@ -197,6 +197,31 @@ definition {
 		}
 	}
 
+	@description = "LPS-153716. Add Client Extension with DB Partitioning enabled."
+	@priority = 5
+	test CanBeDisplayedWithDBPartitioningPSQL {
+		property database.partition.enabled = "true";
+		property database.types = "postgresql";
+		property portal.acceptance = "true";
+
+		task ("Given Client Extension admin page") {
+			ClientExtensionGeneral.goToRemoteAppsPortlet();
+		}
+
+		task ("When Click Add Button") {
+			ClientExtensionGeneral.addCustomElement(
+				entryHtmlName = "vanilla-counter",
+				entryName = "Vanilla Counter",
+				entryURL = " http://remote-component-test.wincent.com/packages/vanilla-counter/index.js");
+		}
+
+		task ("Then Custom Elements admin page lists the Name and Type") {
+			ClientExtensionGeneral.viewTableEntries(
+				entryName = "Vanilla Counter",
+				entryType = "Custom Element");
+		}
+	}
+
 	@description = "LPS-182184. Verify it's possible to cancel an import."
 	@priority = 4
 	test CanCancelImport {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/sitenavigation/navigationmenu/NavigationMenus.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/sitenavigation/navigationmenu/NavigationMenus.testcase
@@ -1054,6 +1054,60 @@ definition {
 		}
 	}
 
+	@description = "This is a test for LPS-180106. User is Able to edit Navigation Menu even if another portal instance contains a custom object and database partitioning is enabled."
+	@priority = 4
+	test EditNavigationMenuInVirtualInstanceWithDBPartitioningPSQL {
+		property database.partition.enabled = "true";
+		property database.types = "postgresql";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		var labelName = StringUtil.randomString(8);
+
+		var objectName = "A${labelName}";
+
+		task ("Given a user has a custom object in default instance") {
+			ObjectAdmin.addObjectViaAPI(
+				labelName = ${labelName},
+				objectName = ${objectName},
+				pluralLabelName = "${labelName}s");
+
+			ObjectAdmin.addObjectFieldViaAPI(
+				fieldBusinessType = "Text",
+				fieldLabelName = "Name",
+				fieldName = "name",
+				fieldType = "String",
+				isRequired = "false",
+				objectName = ${objectName});
+
+			ObjectAdmin.publishObjectViaAPI(objectName = ${objectName});
+		}
+
+		task ("When the user adds a navigation menu in virtual instance") {
+			HeadlessPortalInstanceAPI.addPortalInstance(
+				domain = "liferay.com",
+				portalInstanceId = "www.able.com",
+				virtualHost = "www.able.com");
+
+			User.firstLoginPG(
+				password = "test",
+				userEmailAddress = "test@liferay.com",
+				virtualHostsURL = "http://www.able.com:8080");
+
+			ProductMenu.gotoPortlet(
+				category = "Site Builder",
+				portlet = "Navigation Menus");
+
+			NavigationMenusAdmin.addMenu(menuName = "Test Navigation Menu Name");
+		}
+
+		task ("Then the user could edit the navigation menu") {
+			NavigationMenusAdmin.addItem(
+				item = "Page",
+				pageNameList = "Home");
+		}
+	}
+
 	@description = "Navigation menus can be marked as Primary Navigation. At any given time, only one navigation menu can be Primary Navigation."
 	@priority = 4
 	test MarkNavigationMenuAsPrimary {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/saas/tests/LiferayOnline.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/saas/tests/LiferayOnline.testcase
@@ -56,9 +56,64 @@ definition {
 		}
 	}
 
+	@description = "This is a test for LPS-154668. I can create a New Virtual Instance of Liferay Site with the initializer"
+	@priority = 4
+	test AddLiferayWelcomeSiteVirtualInstanceWithInitializerPSQL {
+		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
+		property database.types = "postgresql";
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Add virtual instance Liferay Site with the Liferay Site Initializer") {
+			HeadlessPortalInstanceAPI.addPortalInstanceWithVirtualInstanceInitializer(
+				domain = "www.able.com",
+				portalInstanceId = "www.able.com",
+				siteInitializerKey = "com.liferay.site.initializer.welcome",
+				virtualHost = "www.able.com");
+		}
+
+		task ("Go to the new Virtual Instance") {
+			Navigator.openSpecificURL(url = "http://www.able.com:8080");
+		}
+
+		task ("Assert the Liferay Site Initializer Welcome Page") {
+			AssertElementPresent(locator1 = "Home#DEFAULT_LOGO");
+		}
+	}
+
 	@description = "This is a test for LPS-154668. I can create a Site of Liferay Welcome Site with the initializer"
 	@priority = 4
 	test AddLiferayWelcomeSiteWithInitializer {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Go to Sites and add a new one") {
+			Site.openSitesAdmin();
+
+			Site.addSiteTemplateCP(
+				siteName = "Liferay Welcome Site",
+				siteTemplateName = "Welcome");
+		}
+
+		task ("Go to Liferay Welcome Site") {
+			ApplicationsMenu.gotoSite(site = "Liferay Welcome Site");
+		}
+
+		task ("Assert the Liferay Site Initializer Welcome Page") {
+			AssertElementPresent(locator1 = "Home#DEFAULT_LOGO");
+		}
+
+		task ("Delete de Site created") {
+			JSONGroup.deleteGroupByName(groupName = "Liferay Welcome Site");
+		}
+	}
+
+	@description = "This is a test for LPS-154668. I can create a Site of Liferay Welcome Site with the initializer"
+	@priority = 4
+	test AddLiferayWelcomeSiteWithInitializerPSQL {
+		property database.types = "postgresql";
 		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
@@ -111,6 +166,34 @@ definition {
 		}
 	}
 
+	@description = "This is a test for LPS-135077. I can create a Virtual Instance with Default Initializer"
+	@priority = 5
+	test AddVirtualInstanceWithDefaultInitializerPSQL {
+		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.baker.com";
+		property database.types = "postgresql";
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Add virtual instance able.com with a blank Initializer") {
+			HeadlessPortalInstanceAPI.addPortalInstance(
+				domain = "www.baker.com",
+				portalInstanceId = "www.baker.com",
+				virtualHost = "www.baker.com");
+		}
+
+		task ("Go to the new Virtual Instance") {
+			Navigator.openSpecificURL(url = "http://www.baker.com:8080");
+		}
+
+		task ("Assert the default Welcome Page is present") {
+			ContentPages.viewFragmentText(
+				fragmentName = "paragraph",
+				id = "element-text",
+				text = "Welcome to Liferay");
+		}
+	}
+
 	@description = "This is a test for LPS-135077. I can create a New Virtual Instance with the initializer"
 	@priority = 5
 	test AddVirtualInstanceWithInitializer {
@@ -138,9 +221,85 @@ definition {
 		}
 	}
 
+	@description = "This is a test for LPS-135077. I can create a New Virtual Instance with the initializer"
+	@priority = 5
+	test AddVirtualInstanceWithInitializerPSQL {
+		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
+		property database.types = "postgresql";
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Add virtual instance raylife.com with the Masterclass Initializer") {
+			HeadlessPortalInstanceAPI.addPortalInstanceWithVirtualInstanceInitializer(
+				domain = "www.able.com",
+				portalInstanceId = "www.able.com",
+				siteInitializerKey = "com.liferay.site.initializer.masterclass",
+				virtualHost = "www.able.com");
+		}
+
+		task ("Go to the new Virtual Instance") {
+			Navigator.openSpecificURL(url = "http://www.able.com:8080");
+		}
+
+		task ("Assert the Masterclass Welcome Page") {
+			AssertElementPresent(
+				key_title = "Welcome to Masterclass",
+				locator1 = "Masterclass#FRAGMENT_HERO_PRE");
+		}
+	}
+
 	@description = "This is a test for LPS-151826 related with LPS-135077. Raylife AP initializer is not deployed and is not shown on inicializer list"
 	@priority = 4
 	test CannotSelectInitializerWithoutDeployRaylifeAP {
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Go to Gogo Shell Admin and Stop Raylife Module") {
+			GogoShell.openGogoShellAdmin();
+
+			var moduleId = GogoShell.getModuleID(moduleName = "com.liferay.site.initializer.raylife.ap");
+
+			GogoShell.stopModule(moduleId = ${moduleId});
+
+			GogoShell.viewModuleStatus(
+				moduleName = "com.liferay.site.initializer.raylife.ap",
+				moduleStatus = "Resolved");
+		}
+
+		task ("Go to Add a New Virtual Instance and Assert the Raylife Module is Not Present") {
+			PortalInstances.openVirtualInstancesAdmin();
+
+			LexiconEntry.gotoAdd();
+
+			SelectFrame(locator1 = "IFrame#MODAL_BODY");
+
+			Type(
+				locator1 = "TextInput#WEB_ID",
+				value1 = "Test");
+
+			Click(locator1 = "OpenIDConnectLogin#OPENID_CONNECT_DROPDOWN_MENU");
+
+			AssertElementNotPresent(
+				key_providerNname = "Raylife AP",
+				locator1 = "OpenIDConnectLogin#OPENID_CONNECT_DROPDOWN_OPTION");
+		}
+
+		task ("Go to Gogo Shell Admin and Start Raylife Module") {
+			GogoShell.openGogoShellAdmin();
+
+			GogoShell.startModule(moduleId = ${moduleId});
+
+			GogoShell.viewModuleStatus(
+				moduleName = "com.liferay.site.initializer.raylife.ap",
+				moduleStatus = "Active");
+		}
+	}
+
+	@description = "This is a test for LPS-151826 related with LPS-135077. Raylife AP initializer is not deployed and is not shown on inicializer list"
+	@priority = 4
+	test CannotSelectInitializerWithoutDeployRaylifeAPPSQL {
+		property database.types = "postgresql";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -232,10 +391,83 @@ definition {
 		}
 	}
 
+	@description = "This is a test for LPS-135077. Raylife D2C initializer is not deployed and is not shown on inicializer list"
+	@priority = 4
+	test CannotSelectInitializerWithoutDeployRaylifeD2CPSQL {
+		property database.types = "postgresql";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Go to Gogo Shell Admin and Stop Raylife Module") {
+			GogoShell.openGogoShellAdmin();
+
+			var moduleId = GogoShell.getModuleID(moduleName = "com.liferay.site.initializer.raylife.d2c");
+
+			GogoShell.stopModule(moduleId = ${moduleId});
+
+			GogoShell.viewModuleStatus(
+				moduleName = "com.liferay.site.initializer.raylife.d2c",
+				moduleStatus = "Resolved");
+		}
+
+		task ("Go to Add a New Virtual Instance and Assert the Raylife Module is Not Present") {
+			PortalInstances.openVirtualInstancesAdmin();
+
+			LexiconEntry.gotoAdd();
+
+			SelectFrame(locator1 = "IFrame#MODAL_BODY");
+
+			Type(
+				locator1 = "TextInput#WEB_ID",
+				value1 = "Test");
+
+			Click(locator1 = "OpenIDConnectLogin#OPENID_CONNECT_DROPDOWN_MENU");
+
+			AssertElementNotPresent(
+				key_providerNname = "Raylife D2C",
+				locator1 = "OpenIDConnectLogin#OPENID_CONNECT_DROPDOWN_OPTION");
+		}
+
+		task ("Go to Gogo Shell Admin and Start Raylife Module") {
+			GogoShell.openGogoShellAdmin();
+
+			GogoShell.startModule(moduleId = ${moduleId});
+
+			GogoShell.viewModuleStatus(
+				moduleName = "com.liferay.site.initializer.raylife.d2c",
+				moduleStatus = "Active");
+		}
+	}
+
 	@description = "This is a test for LPS-143786. Create a Team Extranet Virtual Instance by API"
 	@priority = 4
 	test CreateTeamExtranetVirtualInstanceByAPI {
 		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Create Virtual Instance by Json") {
+			HeadlessPortalInstanceAPI.addPortalInstanceWithVirtualInstanceInitializer(
+				domain = "www.able.com",
+				portalInstanceId = "www.able.com",
+				siteInitializerKey = "com.liferay.site.initializer.team.extranet",
+				virtualHost = "www.able.com");
+		}
+
+		task ("Go to the Virtual Instance Created and Assert the Team Extranet Logo") {
+			Navigator.openSpecificURL(url = "http://www.able.com:8080");
+
+			AssertElementPresent(
+				key_title = "Welcome to the team!",
+				locator1 = "TeamExtranet#FRAGMENT_HEADER");
+		}
+	}
+
+	@description = "This is a test for LPS-143786. Create a Team Extranet Virtual Instance by API"
+	@priority = 4
+	test CreateTeamExtranetVirtualInstanceByAPIPSQL {
+		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
+		property database.types = "postgresql";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -279,9 +511,58 @@ definition {
 		}
 	}
 
+	@description = "This is a test for LPS-143786. Verify Remote Apps can be created in Liferay Online"
+	@priority = 4
+	test RemoteAppsCanBeCreatedInLiferayOnlinePSQL {
+		property database.types = "postgresql";
+		property portal.acceptance = "true";
+
+		task ("Go to Remote Apps Portlet") {
+			ClientExtensionGeneral.goToRemoteAppsPortlet();
+		}
+
+		task ("Go to Add and Create a New Remote App") {
+			ClientExtensionGeneral.addCustomElement(
+				entryHtmlName = "vanilla-counter",
+				entryName = "Vanilla Counter",
+				entryURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js");
+		}
+
+		task ("On Table Entries, Assert the New Remote App Presence") {
+			ClientExtensionGeneral.viewTableEntries(
+				entryName = "Vanilla Counter",
+				entryType = "Custom Element");
+		}
+	}
+
 	@description = "This is a test for LPS-143786. Verify Remote Apps can be deleted in Liferay Online"
 	@priority = 4
 	test RemoteAppsCanBeDeletedInLiferayOnline {
+		property portal.acceptance = "true";
+
+		task ("Create a New Remote App with JSON") {
+			JSONClientExtension.addIFrameRemoteAppEntry(
+				iFrameURL = "http://www.liferay.com/my_new_remote_app",
+				name = "My New Remote App");
+		}
+
+		task ("Go to Remote Apps Portlet") {
+			ClientExtensionGeneral.goToRemoteAppsPortlet();
+		}
+
+		task ("Delete the Remote App") {
+			ClientExtensionGeneral.deleteRemoteApp(tableEntry = "My New Remote App");
+		}
+
+		task ("Assert the Remote App is Not Present") {
+			ClientExtensionGeneral.viewEmptyRemoteTable();
+		}
+	}
+
+	@description = "This is a test for LPS-143786. Verify Remote Apps can be deleted in Liferay Online"
+	@priority = 4
+	test RemoteAppsCanBeDeletedInLiferayOnlinePSQL {
+		property database.types = "postgresql";
 		property portal.acceptance = "true";
 
 		task ("Create a New Remote App with JSON") {
@@ -341,11 +622,96 @@ definition {
 		}
 	}
 
+	@description = "This is a test for LPS-143786. Verify Remote Apps can be displayed in Liferay Online"
+	@priority = 4
+	test RemoteAppsCanBeDisplayedInLiferayOnlinePSQL {
+		property database.types = "postgresql";
+		property portal.acceptance = "true";
+
+		task ("Add a public page with JSON") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Test Page",
+				type = "content");
+		}
+
+		task ("Create Vanilla Counter as a Custom Element") {
+			ClientExtensionGeneral.goToRemoteAppsPortlet();
+
+			ClientExtensionGeneral.addCustomElement(
+				entryHtmlName = "vanilla-counter",
+				entryName = "Vanilla Counter",
+				entryURL = "http://remote-component-test.wincent.com/packages/vanilla-counter/index.js");
+		}
+
+		task ("Add Vanilla Counter to Test Page") {
+			ContentPagesNavigator.openEditContentPage(
+				pageName = "Test Page",
+				siteName = "Guest");
+
+			PageEditor.addWidget(portletName = "Vanilla Counter");
+
+			PageEditor.publish();
+		}
+
+		task ("Assert Vanilla Counter is displayed") {
+			Navigator.gotoPage(pageName = "Test Page");
+
+			AssertElementPresent(locator1 = "ClientExtension#VANILLA_COUNTER_REMOTE_APP");
+		}
+	}
+
 	@description = "This is a test for LPS-148448. Search bar is available in Team Extranet Virtual instance and it works"
 	@priority = 3
 	test SearchBarWorkingInTeamExtranetVirtualInstanceByAPI {
 		property ci.retries.disabled = "true";
 		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Create Virtual Instance by Json") {
+			HeadlessPortalInstanceAPI.addPortalInstanceWithVirtualInstanceInitializer(
+				domain = "www.able.com",
+				portalInstanceId = "www.able.com",
+				siteInitializerKey = "com.liferay.site.initializer.team.extranet",
+				virtualHost = "www.able.com");
+		}
+
+		task ("Go to the Virtual Instance Created and Assert the Team Extranet Logo") {
+			Navigator.openSpecificURL(url = "http://www.able.com:8080");
+
+			AssertElementPresent(
+				key_title = "Welcome to the team!",
+				locator1 = "TeamExtranet#FRAGMENT_HEADER");
+		}
+
+		task ("Assert the Search Bar presence") {
+			AssertElementPresent(locator1 = "TeamExtranet#EMBEDDED_SEARCH_BAR");
+		}
+
+		task ("Search for Careers in Search Bar to get results") {
+			TeamExtranet.searchEmbedded(searchTerm = "careers");
+
+			SearchResults.viewSearchResults(
+				searchAssetTitle = "Careers",
+				searchAssetType = "Page");
+		}
+
+		task ("Search for texs in Search Bar to not get results") {
+			TeamExtranet.searchEmbedded(searchTerm = "texs");
+
+			AssertTextEquals.assertPartialText(
+				locator1 = "Message#EMPTY_INFO",
+				value1 = "No results were found that matched the keywords");
+		}
+	}
+
+	@description = "This is a test for LPS-148448. Search bar is available in Team Extranet Virtual instance and it works"
+	@priority = 3
+	test SearchBarWorkingInTeamExtranetVirtualInstanceByAPIPSQL {
+		property ci.retries.disabled = "true";
+		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
+		property database.types = "postgresql";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -510,9 +876,151 @@ definition {
 		}
 	}
 
+	@priority = 5
+	test SmokePSQL {
+		property database.types = "postgresql";
+		property liferay.online.smoke = "true";
+		property portal.acceptance = "true";
+
+		AssertConsoleTextPresent(value1 = "Stopping blacklisted bundle");
+
+		HeadlessPortalInstanceAPI.addPortalInstance(
+			domain = "liferay.com",
+			portalInstanceId = "www.able.com",
+			virtualHost = "www.able.com");
+
+		User.firstLoginUI(
+			password = "test",
+			specificURL = "http://www.able.com:8080",
+			userEmailAddress = "test@liferay.com");
+
+		Smoke.viewWelcomeContentPage();
+
+		ProductMenu.gotoPortlet(
+			category = "Site Builder",
+			portlet = "Pages");
+
+		PagesAdmin.addPage(pageName = "Test Page1");
+
+		PagesAdmin.addPage(pageName = "Test Page2");
+
+		PagesAdmin.addPage(pageName = "Test Page3");
+
+		var pageName = "Test Page1";
+		var portletBody = "Please configure this portlet to make it visible to all users.";
+		var portletName = "IFrame";
+
+		task ("Add a '${portletName}' portlet to the page named '${pageName}'") {
+			Navigator.gotoSpecificURLPage(
+				pageName = ${pageName},
+				url = "http://www.able.com:8080");
+
+			Portlet.addPG(
+				i = ${i},
+				portletName = ${portletName});
+
+			Portlet.viewTitle(portletName = ${portletName});
+
+			Portlet.viewBody(
+				portletBody = ${portletBody},
+				portletName = ${portletName});
+
+			Navigator.gotoSpecificURLPage(
+				pageName = ${pageName},
+				url = "http://www.able.com:8080");
+
+			Portlet.viewTitle(portletName = ${portletName});
+
+			Portlet.viewBody(
+				portletBody = ${portletBody},
+				portletName = ${portletName});
+		}
+
+		var collectionName = "Basic Components";
+		var contentPageName = "Test Content Page";
+		var fragmentId = "Heading";
+		var fragmentName = "Heading";
+
+		task ("Add a '${fragmentName}' fragment to the content page named '${contentPageName}'") {
+			task ("Create a Content Page") {
+				Navigator.openSpecificURL(url = "http://www.able.com:8080");
+
+				ProductMenu.gotoPortlet(
+					category = "Site Builder",
+					portlet = "Pages");
+
+				ContentPages.addPage(pageName = ${contentPageName});
+			}
+
+			task ("Add a basic '${fragmentName}' component") {
+				PageEditor.addFragment(
+					collectionName = ${collectionName},
+					fragmentName = ${fragmentName});
+			}
+
+			task ("Publish Content Page") {
+				PageEditor.publish();
+			}
+
+			task ("Navigate to the content page") {
+				Navigator.gotoSpecificURLPage(
+					pageName = ${contentPageName},
+					url = "http://www.able.com:8080");
+			}
+
+			task ("Assert the '${fragmentName}' fragment is present") {
+				AssertElementPresent(locator1 = "//h1[contains(.,'Heading Example')]");
+			}
+		}
+
+		var portlet = "Web Content";
+
+		task ("Navigate to Product Menu > Sites > Content > ${portlet}") {
+			Navigator.openSpecificURL(url = "http://www.able.com:8080");
+
+			ProductMenu.gotoPortlet(
+				category = "Content & Data",
+				portlet = ${portlet});
+
+			SiteAdmin.viewPortletTitle(portletTitle = ${portlet});
+		}
+
+		var webContentContent = "Web Content Content";
+		var webContentTitle = "Web Content Title";
+
+		task ("Add a web content article with '${webContentTitle}' as the title and '${webContentContent}' as the content") {
+			WebContentNavigator.gotoAddCP();
+
+			WebContent.addCP(
+				webContentContent = ${webContentContent},
+				webContentTitle = ${webContentTitle});
+
+			PortletEntry.publish();
+
+			WebContent.viewTitle(webContentTitle = ${webContentTitle});
+		}
+	}
+
 	@description = "This is a test for LPS-143786. Verify Remote Apps presence in Liferay Online"
 	@priority = 5
 	test VerifyRemoteAppsInLiferayOnline {
+		property portal.acceptance = "true";
+
+		task ("Go to Remote Apps Portlet") {
+			ClientExtensionGeneral.goToRemoteAppsPortlet();
+		}
+
+		task ("Assert the Remote Apps Header Presence") {
+			AssertElementPresent(
+				key_header = "Client Extensions",
+				locator1 = "WorkflowSubmissions#DETAIL_PAGE_HEADER");
+		}
+	}
+
+	@description = "This is a test for LPS-143786. Verify Remote Apps presence in Liferay Online"
+	@priority = 5
+	test VerifyRemoteAppsInLiferayOnlinePSQL {
+		property database.types = "postgresql";
 		property portal.acceptance = "true";
 
 		task ("Go to Remote Apps Portlet") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/saas/tests/LiferayOnlineCoverBugs.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/saas/tests/LiferayOnlineCoverBugs.testcase
@@ -66,6 +66,45 @@ definition {
 		}
 	}
 
+	@description = "LPS-142122: Clicking on Masterclass logo opens a page with an error"
+	@priority = 3
+	test ClickMasterclassLogoGoesHomePagePSQL {
+		property database.types = "postgresql";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Assert the Virtual Instance created by Json is present") {
+			PortalInstances.openVirtualInstancesAdmin();
+
+			PortalInstances.viewCP(virtualHost = "www.able.com");
+
+			Navigator.openSpecificURL(url = "http://www.able.com:8080");
+
+			AssertElementPresent(
+				key_title = "Welcome to Masterclass",
+				locator1 = "Masterclass#FRAGMENT_HERO_PRE");
+		}
+
+		task ("Go to Sign In Page") {
+			Click(locator1 = "Masterclass#NAV_TAB");
+		}
+
+		task ("Click Mastercard logo") {
+			Click(locator1 = "Masterclass#MASTERCLASS_LOGO");
+		}
+
+		task ("Assert the default Masterclass Moderns is applied to Home page") {
+			AssertCssValue(
+				key_content = "Read More",
+				key_element = "a",
+				key_id = "hero-button",
+				key_type = "link",
+				locator1 = "StyleBookEditor#CONTRIBUTED_FRAGMENT_INLINE_CONTENT",
+				locator2 = "color",
+				value1 = "rgba(255, 255, 255, 1)");
+		}
+	}
+
 	@description = "Verify if a virtual instance is created using the initializer, showing a different site comparing with the default Liferay bundle"
 	@priority = 4
 	test CreateVirtualInstanceUsingInitializerWithSuccess {
@@ -89,9 +128,57 @@ definition {
 		}
 	}
 
+	@description = "Verify if a virtual instance is created using the initializer, showing a different site comparing with the default Liferay bundle"
+	@priority = 4
+	test CreateVirtualInstanceUsingInitializerWithSuccessPSQL {
+		property database.types = "postgresql";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Go to the Virtual Instance created") {
+			Navigator.openSpecificURL(url = "http://www.able.com:8080");
+		}
+
+		task ("Assert the Default Home Page is not present") {
+			AssertElementNotPresent(
+				key_title = "Welcome to Liferay",
+				locator1 = "Masterclass#FRAGMENT_HEADING");
+		}
+
+		task ("Assert the Masterclass Welcome Page") {
+			AssertElementPresent(
+				key_title = "Welcome to Masterclass",
+				locator1 = "Masterclass#FRAGMENT_HERO_PRE");
+		}
+	}
+
 	@description = "Delete Virtual Instance in Liferay Online"
 	@priority = 4
 	test DeleteVirtualInstance {
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Go to Virtual Instances") {
+			PortalInstances.openVirtualInstancesAdmin();
+		}
+
+		task ("Delete the Virtual Instance created") {
+			PortalInstances.deleteCP(virtualHost = "www.able.com");
+		}
+
+		task ("Assert that the Virtual Instance deleted is not present") {
+			Navigator.openSpecificURL(url = "http://www.able.com:8080");
+
+			AssertElementNotPresent(
+				key_title = "Welcome to Masterclass",
+				locator1 = "Masterclass#FRAGMENT_HERO_PRE");
+		}
+	}
+
+	@description = "Delete Virtual Instance in Liferay Online"
+	@priority = 4
+	test DeleteVirtualInstancePSQL {
+		property database.types = "postgresql";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -151,9 +238,69 @@ definition {
 		}
 	}
 
+	@description = "Verify if a friendly error appears when the user is not able to create the virtual host"
+	@priority = 3
+	test FriendlyErrorAppearsWhenTheUserCantCreateVirtualHostPSQL {
+		property database.types = "postgresql";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Go to Virtual Instances") {
+			PortalInstances.openVirtualInstancesAdmin();
+		}
+
+		task ("Create a new Virtual instance using localhost") {
+			LexiconEntry.gotoAdd();
+
+			SelectFrame(locator1 = "IFrame#MODAL_BODY");
+
+			Type(
+				locator1 = "TextInput#WEB_ID",
+				value1 = "www.baker.com");
+
+			Type(
+				locator1 = "TextInput#VIRTUAL_HOST",
+				value1 = "localhost");
+
+			Type(
+				locator1 = "TextInput#MAIL_DOMAIN",
+				value1 = "www.baker.com");
+
+			SelectFrameTop();
+
+			Button.clickAdd();
+		}
+
+		task ("Assert the error message") {
+			SelectFrame(locator1 = "IFrame#MODAL_BODY");
+
+			Alert.viewErrorMessage(errorMessage = "Please enter a valid virtual host.");
+		}
+	}
+
 	@description = "Create Virtual instance using the Virtual Instance Initializer not works with the curl command."
 	@priority = 4
 	test UserCanCreateVirtualInstance {
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Assert the Virtual Instance created by Json is present") {
+			PortalInstances.openVirtualInstancesAdmin();
+
+			PortalInstances.viewCP(virtualHost = "www.able.com");
+
+			Navigator.openSpecificURL(url = "http://www.able.com:8080");
+
+			AssertElementPresent(
+				key_title = "Welcome to Masterclass",
+				locator1 = "Masterclass#FRAGMENT_HERO_PRE");
+		}
+	}
+
+	@description = "Create Virtual instance using the Virtual Instance Initializer not works with the curl command."
+	@priority = 4
+	test UserCanCreateVirtualInstancePSQL {
+		property database.types = "postgresql";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/test.properties
+++ b/test.properties
@@ -3260,6 +3260,28 @@
         (portal.acceptance == true)
 
     #
+    # Acceptance Functional - Database Partitioning Using PostgreSQL
+    #
+
+    database.partition.enabled[acceptance-functional-db-partition-psql]=true
+    test.batch.dist.app.servers[acceptance-functional-db-partition-psql]=tomcat
+
+    test.batch.names[acceptance-functional-db-partition-psql]=\
+        functional-tomcat90-postgresql153-jdk8
+
+    test.batch.run.property.query[functional-tomcat90-postgresql153-jdk8][acceptance-functional-db-partition-psql]=\
+        (\
+            (app.server.types == null) OR \
+            (app.server.types ~ tomcat)\
+        ) AND \
+        (\
+            (database.types == null) OR \
+            (database.types ~ postgresql)\
+        ) AND \
+        (data.archive.type == null) AND \
+        (portal.acceptance == true)
+
+    #
     # Acceptance Release
     #
 
@@ -4114,6 +4136,34 @@
     test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][db-partition]=\
         (data.archive.type == "data-archive-portal-partition") AND \
         (database.types ~ mysql)
+
+    #
+    # Database Partitioning Using PostgreSQL
+    #
+
+    test.batch.class.names.includes[db-partition-psql]=\
+        **/portal-db-partition-test/**/*Test.java,\
+        **/portal-tools-db-partition*/**/*Test.java,\
+        **/testIntegration/**/*DatabasePartitionUpgrade*Test.java
+
+    test.batch.dist.app.servers[db-partition-psql]=tomcat
+
+    test.batch.names[db-partition-psql]=\
+        functional-tomcat90-postgresql153-jdk8,\
+        functional-upgrade-tomcat90-postgresql153-jdk8,\
+        modules-integration-postgresql153-jdk8
+
+    test.batch.run.property.query[functional-tomcat90-postgresql153-jdk8][db-partition-psql]=\
+        (database.types ~ postgresql) AND \
+        (portal.upstream == true) AND \
+        (\
+            (database.partition.enabled == true) OR \
+            (liferay.online.properties == true)\
+        )
+
+    test.batch.run.property.query[functional-upgrade-tomcat90-postgresql153-jdk8][db-partition-psql]=\
+        (data.archive.type == "data-archive-portal-partition") AND \
+        (database.types ~ postgresql)
 
     #
     # Depot

--- a/test.properties
+++ b/test.properties
@@ -4104,6 +4104,7 @@
         modules-unit-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][db-partition]=\
+        (database.types ~ mysql) AND \
         (portal.upstream == true) AND \
         (\
             (database.partition.enabled == true) OR \
@@ -4111,7 +4112,8 @@
         )
 
     test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][db-partition]=\
-        (data.archive.type == "data-archive-portal-partition")
+        (data.archive.type == "data-archive-portal-partition") AND \
+        (database.types ~ mysql)
 
     #
     # Depot
@@ -4377,6 +4379,10 @@
         unit-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][echo]=\
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
         (portal.upstream == true) AND \
         (\
             (testray.component.name ~ "Page Administration") OR \
@@ -4503,6 +4509,10 @@
         unit-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][echo-acceptance]=\
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
         (portal.acceptance == true) AND \
         (portal.upstream == true) AND \
         (\
@@ -4632,6 +4642,7 @@
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][echo-db-partition]=\
         (database.partition.enabled != false) AND \
+        (database.types ~ mysql) AND \
         (portal.acceptance == true) AND \
         (portal.upstream == true) AND \
         (\
@@ -4948,6 +4959,10 @@
         modules-integration-mysql57-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][frontend-client-extensions]=\
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
         (portal.upstream == true) AND \
         (testray.main.component.name ~ "Client Extensions")
 
@@ -5023,6 +5038,10 @@
         modules-unit-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][frontend]=\
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
         (\
             (portal.acceptance != quarantine) AND \
             (portal.upstream == true)\
@@ -5241,6 +5260,10 @@
         unit-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][headless]=\
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
         (portal.upstream == true) AND \
         (\
             (testray.main.component.name == "Batch Engine") OR \
@@ -5290,6 +5313,10 @@
         unit-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][headless-acceptance]=\
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
         (portal.acceptance == true) AND \
         (portal.upstream == true) AND \
         (\
@@ -5347,6 +5374,10 @@
         modules-unit-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][headless-builder]=\
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
         (portal.acceptance == true) AND \
         (portal.upstream == true) AND \
         (testray.main.component.name == "Headless Builder")
@@ -5359,6 +5390,10 @@
         functional-tomcat90-mysql57-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][headless-builder-functional]=\
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
         (portal.acceptance == true) AND \
         (portal.upstream == true) AND \
         (testray.main.component.name == "Headless Builder")
@@ -5372,6 +5407,10 @@
     test.batch.dist.app.servers[headless-functional]=tomcat
 
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][headless-functional]=\
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
         (portal.upstream == true) AND \
         (\
             (testray.main.component.name == "Batch Engine") OR \
@@ -5608,6 +5647,10 @@
         functional-tomcat90-mysql57-jdk8
 
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][license-cluster]=\
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
         (license.required == true) AND \
         (testray.main.component.name == "Clustering")
 
@@ -5641,9 +5684,17 @@
         functional-upgrade-tomcat90-mysql57-jdk8
 
     test.batch.run.property.query[functional-smoke-tomcat90-mysql57-jdk8][liferay-online]=\
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
         (liferay.online.smoke == "true")
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][liferay-online]=\
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
         (liferay.online.smoke != true) AND \
         (\
             (testray.main.component.name ~ "Liferay Online") OR \
@@ -5653,6 +5704,10 @@
         )
 
     test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][liferay-online]=\
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
         (data.archive.type == "data-archive-portal-partition")
 
     #
@@ -6187,6 +6242,10 @@
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][object]=\
         (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
+        (\
             (portal.acceptance != quarantine) AND \
             (portal.upstream == true)\
         ) AND \
@@ -6213,6 +6272,10 @@
         source-format-current-branch-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][object-functional]=\
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
         (portal.acceptance != quarantine) AND \
         (portal.upstream == true) AND \
         (\
@@ -6270,6 +6333,10 @@
 
     test.batch.run.property.query[functional-jboss*][object-as]=\
         (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
+        (\
             (app.server.types == null) OR \
             (app.server.types ~ jboss)\
         ) AND \
@@ -6298,6 +6365,10 @@
 
     test.batch.run.property.query[functional-weblogic*-mysql57-jdk8][object-as]=\
         (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
+        (\
             (app.server.types == null) OR \
             (app.server.types ~ weblogic)\
         ) AND \
@@ -6305,12 +6376,20 @@
 
     test.batch.run.property.query[functional-websphere90-mysql57-jdk8][object-as]=\
         (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
+        (\
             (app.server.types == null) OR \
             (app.server.types ~ websphere)\
         ) AND \
         (testray.main.component.name == "Object")
 
     test.batch.run.property.query[functional-wildfly*][object-as]=\
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
         (\
             (app.server.types == null) OR \
             (app.server.types ~ wildfly)\
@@ -6559,6 +6638,10 @@
         unit-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][password-policies]=\
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
         (portal.upstream == true) AND \
         (\
             (testray.component.names ~ "Password Policies") OR \
@@ -9176,6 +9259,10 @@
         unit-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][security]=\
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
         (portal.upstream == true) AND \
         (\
             (testray.component.names ~ "Password Policies") OR \


### PR DESCRIPTION
**Background**
Duplicate all existing MySQL DB partition automated testing to cover PostgreSQL to test https://liferay.atlassian.net/browse/LPS-198179. 

- Pay attention to tests that might exist in other product teams. 
- We will run testing on both databases until MySQL is no longer used by LXC.


**Test Plan**

- Appending “PSQL” to test names that are _likely_ to work on PostgreSQL.
- Incompatible tests are due to: 
  a. Calling macros/ant scripts that are using MySQL statements. Will need to modify these calls to use PostgreSQL statements. (1 test)
  b. Upgrade tests that need a database dump to be generated on PostgreSQL. Current DB Partitioning + Upgrade database dumps are generated on MySQL.
- When setting `property liferay.online.properties = "true";`, we are switching the database driver to use MariaDB instead of MySQL. Do not modify the drivers when using PostgreSQL.
- Create a new test suite `ci:test:db-partition-psql` to run DB Partitioning tests on PostgreSQL exclusively.
   a. Runs functional and integration tests on PostgreSQL 15.3.
- Create a new test suite `ci:test:acceptance-functional-db-partition-psql` to run all acceptance functional tests with DB Partitioning and PostgreSQL 15.3.
- Ensure other product teams' MySQL batches tests are only running MySQL tests. Set `(database.types ~ mysql)` in test batches.

**Tested at:** https://github.com/susanchen3/liferay-portal/pull/297
- Tests are setup to run on PSQL, but failed because DB Partitioning is not supported on PSQL yet.


**JIRA Ticket:**
https://liferay.atlassian.net/browse/LPS-199110