### PR TITLE
LPS-198979 Update current usages of the persisted scheduler to use unique job names

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTCollectionDTOConverter.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTCollectionDTOConverter.java
@@ -8,6 +8,7 @@ package com.liferay.change.tracking.rest.internal.dto.v1_0.converter;
 import com.liferay.change.tracking.constants.CTDestinationNames;
 import com.liferay.change.tracking.rest.dto.v1_0.CTCollection;
 import com.liferay.change.tracking.rest.dto.v1_0.Status;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
@@ -76,7 +77,9 @@ public class CTCollectionDTOConverter
 
 		SchedulerResponse schedulerResponse =
 			_schedulerEngineHelper.getScheduledJob(
-				String.valueOf(ctCollection.getCtCollectionId()),
+				StringBundler.concat(
+					ctCollection.getCtCollectionId(), StringPool.AT,
+					ctCollection.getCompanyId()),
 				CTDestinationNames.CT_COLLECTION_SCHEDULED_PUBLISH,
 				StorageType.PERSISTED);
 

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/util/v1_0/PublishUtil.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/util/v1_0/PublishUtil.java
@@ -10,6 +10,8 @@ import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.CTPreferencesLocalService;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.messaging.Message;
@@ -63,7 +65,7 @@ public class PublishUtil {
 
 					schedulerEngineHelper.schedule(
 						triggerFactory.createTrigger(
-							String.valueOf(ctCollectionId),
+							_getSchedulerJobName(ctCollection),
 							_CT_COLLECTION_SCHEDULED_PUBLISH, startDate, null,
 							0, null),
 						StorageType.PERSISTED, String.valueOf(ctCollectionId),
@@ -86,7 +88,16 @@ public class PublishUtil {
 			SchedulerEngineHelper schedulerEngineHelper)
 		throws PortalException {
 
-		String jobName = String.valueOf(ctCollectionId);
+		CTCollection ctCollection = ctCollectionLocalService.fetchCTCollection(
+			ctCollectionId);
+
+		if ((ctCollection == null) ||
+			(ctCollection.getStatus() == WorkflowConstants.STATUS_APPROVED)) {
+
+			return;
+		}
+
+		String jobName = _getSchedulerJobName(ctCollection);
 
 		SchedulerResponse schedulerResponse =
 			schedulerEngineHelper.getScheduledJob(
@@ -97,23 +108,18 @@ public class PublishUtil {
 			return;
 		}
 
-		Message message = schedulerResponse.getMessage();
-
-		CTCollection ctCollection = ctCollectionLocalService.fetchCTCollection(
-			message.getLong("ctCollectionId"));
-
-		if ((ctCollection == null) ||
-			(ctCollection.getStatus() == WorkflowConstants.STATUS_APPROVED)) {
-
-			return;
-		}
-
 		ctCollection.setStatus(WorkflowConstants.STATUS_DRAFT);
 
 		ctCollectionLocalService.updateCTCollection(ctCollection);
 
 		schedulerEngineHelper.delete(
 			jobName, _CT_COLLECTION_SCHEDULED_PUBLISH, StorageType.PERSISTED);
+	}
+
+	private static String _getSchedulerJobName(CTCollection ctCollection) {
+		return StringBundler.concat(
+			ctCollection.getCtCollectionId(), StringPool.AT,
+			ctCollection.getCompanyId());
 	}
 
 	private static final String _CT_COLLECTION_SCHEDULED_PUBLISH =

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/util/v1_0/PublishUtil.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/util/v1_0/PublishUtil.java
@@ -49,13 +49,15 @@ public class PublishUtil {
 
 					ctCollection.setStatus(WorkflowConstants.STATUS_SCHEDULED);
 
-					ctCollectionLocalService.updateCTCollection(ctCollection);
+					ctCollection = ctCollectionLocalService.updateCTCollection(
+						ctCollection);
 
 					ctPreferencesLocalService.resetCTPreferences(
 						ctCollectionId);
 
 					Message message = new Message();
 
+					message.put("companyId", ctCollection.getCompanyId());
 					message.put("ctCollectionId", ctCollectionId);
 					message.put("userId", userId);
 

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTCollectionModelDocumentContributor.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTCollectionModelDocumentContributor.java
@@ -7,6 +7,8 @@ package com.liferay.change.tracking.internal.search.spi.model.index.contributor;
 
 import com.liferay.change.tracking.constants.CTDestinationNames;
 import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
@@ -62,7 +64,9 @@ public class CTCollectionModelDocumentContributor
 		try {
 			SchedulerResponse schedulerResponse =
 				_schedulerEngineHelper.getScheduledJob(
-					String.valueOf(ctCollection.getCtCollectionId()),
+					StringBundler.concat(
+						ctCollection.getCtCollectionId(), StringPool.AT,
+						ctCollection.getCompanyId()),
 					CTDestinationNames.CT_COLLECTION_SCHEDULED_PUBLISH,
 					StorageType.PERSISTED);
 

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/scheduler/PublishScheduler.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/scheduler/PublishScheduler.java
@@ -12,6 +12,8 @@ import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.CTPreferencesLocalService;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.messaging.Message;
@@ -47,7 +49,7 @@ public class PublishScheduler {
 
 		SchedulerResponse schedulerResponse =
 			_schedulerEngineHelper.getScheduledJob(
-				String.valueOf(ctCollection.getCtCollectionId()),
+				_getSchedulerJobName(ctCollection),
 				CTDestinationNames.CT_COLLECTION_SCHEDULED_PUBLISH,
 				StorageType.PERSISTED);
 
@@ -122,7 +124,16 @@ public class PublishScheduler {
 	}
 
 	public void unschedulePublish(long ctCollectionId) throws PortalException {
-		String jobName = String.valueOf(ctCollectionId);
+		CTCollection ctCollection = _ctCollectionLocalService.fetchCTCollection(
+			ctCollectionId);
+
+		if ((ctCollection == null) ||
+			(ctCollection.getStatus() == WorkflowConstants.STATUS_APPROVED)) {
+
+			return;
+		}
+
+		String jobName = _getSchedulerJobName(ctCollection);
 
 		SchedulerResponse schedulerResponse =
 			_schedulerEngineHelper.getScheduledJob(
@@ -130,17 +141,6 @@ public class PublishScheduler {
 				StorageType.PERSISTED);
 
 		if (schedulerResponse == null) {
-			return;
-		}
-
-		Message message = schedulerResponse.getMessage();
-
-		CTCollection ctCollection = _ctCollectionLocalService.fetchCTCollection(
-			message.getLong("ctCollectionId"));
-
-		if ((ctCollection == null) ||
-			(ctCollection.getStatus() == WorkflowConstants.STATUS_APPROVED)) {
-
 			return;
 		}
 
@@ -157,6 +157,12 @@ public class PublishScheduler {
 			StorageType.PERSISTED);
 	}
 
+	private String _getSchedulerJobName(CTCollection ctCollection) {
+		return StringBundler.concat(
+			ctCollection.getCtCollectionId(), StringPool.AT,
+			ctCollection.getCompanyId());
+	}
+
 	private Void _schedulePublish(
 			long ctCollectionId, long userId, Date startDate)
 		throws PortalException {
@@ -170,7 +176,8 @@ public class PublishScheduler {
 
 		ctCollection.setStatus(WorkflowConstants.STATUS_SCHEDULED);
 
-		_ctCollectionLocalService.updateCTCollection(ctCollection);
+		ctCollection = _ctCollectionLocalService.updateCTCollection(
+			ctCollection);
 
 		_ctPreferencesLocalService.resetCTPreferences(ctCollectionId);
 
@@ -182,7 +189,7 @@ public class PublishScheduler {
 
 		_schedulerEngineHelper.schedule(
 			_triggerFactory.createTrigger(
-				String.valueOf(ctCollectionId),
+				_getSchedulerJobName(ctCollection),
 				CTDestinationNames.CT_COLLECTION_SCHEDULED_PUBLISH, startDate,
 				null, 0, null),
 			StorageType.PERSISTED, String.valueOf(ctCollectionId),

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/scheduler/PublishScheduler.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/scheduler/PublishScheduler.java
@@ -176,6 +176,7 @@ public class PublishScheduler {
 
 		Message message = new Message();
 
+		message.put("companyId", ctCollection.getCompanyId());
 		message.put("ctCollectionId", ctCollectionId);
 		message.put("userId", userId);
 

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/timeline/CTCollectionHistoryDataProvider.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/timeline/CTCollectionHistoryDataProvider.java
@@ -84,7 +84,9 @@ public class CTCollectionHistoryDataProvider {
 			try {
 				SchedulerResponse schedulerResponse =
 					SchedulerEngineHelperUtil.getScheduledJob(
-						String.valueOf(_ctCollection.getCtCollectionId()),
+						StringBundler.concat(
+							_ctCollection.getCtCollectionId(), StringPool.AT,
+							_ctCollection.getCompanyId()),
 						CTDestinationNames.CT_COLLECTION_SCHEDULED_PUBLISH,
 						StorageType.PERSISTED);
 

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/helper/DispatchTriggerHelper.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/helper/DispatchTriggerHelper.java
@@ -38,7 +38,7 @@ public class DispatchTriggerHelper {
 		long dispatchTriggerId = dispatchTrigger.getDispatchTriggerId();
 
 		Trigger trigger = _triggerFactory.createTrigger(
-			_getJobName(dispatchTriggerId), _getGroupName(dispatchTriggerId),
+			_getJobName(dispatchTrigger), _getGroupName(dispatchTrigger),
 			dispatchTrigger.getStartDate(), dispatchTrigger.getEndDate(),
 			dispatchTrigger.getCronExpression(),
 			TimeZone.getTimeZone(timeZoneId));
@@ -52,8 +52,7 @@ public class DispatchTriggerHelper {
 		try {
 			_schedulerEngineHelper.schedule(
 				trigger, storageType, null,
-				DispatchConstants.EXECUTOR_DESTINATION_NAME,
-				_getPayload(dispatchTriggerId));
+				DispatchConstants.EXECUTOR_DESTINATION_NAME, message);
 
 			if (_log.isDebugEnabled()) {
 				_log.debug(
@@ -70,11 +69,11 @@ public class DispatchTriggerHelper {
 	}
 
 	public void deleteSchedulerJob(
-		long dispatchTriggerId, StorageType storageType) {
+		DispatchTrigger dispatchTrigger, StorageType storageType) {
 
 		try {
-			String jobName = _getJobName(dispatchTriggerId);
-			String groupName = _getGroupName(dispatchTriggerId);
+			String jobName = _getJobName(dispatchTrigger);
+			String groupName = _getGroupName(dispatchTrigger);
 
 			_schedulerEngineHelper.delete(jobName, groupName, storageType);
 
@@ -90,18 +89,19 @@ public class DispatchTriggerHelper {
 		catch (SchedulerException schedulerException) {
 			_log.error(
 				"Unable to delete scheduler entry for dispatch trigger " +
-					dispatchTriggerId,
+					dispatchTrigger.getDispatchTriggerId(),
 				schedulerException);
 		}
 	}
 
-	public Date getNextFireDate(long dispatchTriggerId, StorageType storageType)
+	public Date getNextFireDate(
+			DispatchTrigger dispatchTrigger, StorageType storageType)
 		throws SchedulerException {
 
 		SchedulerResponse schedulerResponse =
 			_schedulerEngineHelper.getScheduledJob(
-				_getJobName(dispatchTriggerId),
-				_getGroupName(dispatchTriggerId), storageType);
+				_getJobName(dispatchTrigger), _getGroupName(dispatchTrigger),
+				storageType);
 
 		if (schedulerResponse == null) {
 			return null;
@@ -111,13 +111,13 @@ public class DispatchTriggerHelper {
 	}
 
 	public Date getPreviousFireDate(
-			long dispatchTriggerId, StorageType storageType)
+			DispatchTrigger dispatchTrigger, StorageType storageType)
 		throws SchedulerException {
 
 		SchedulerResponse schedulerResponse =
 			_schedulerEngineHelper.getScheduledJob(
-				_getJobName(dispatchTriggerId),
-				_getGroupName(dispatchTriggerId), storageType);
+				_getJobName(dispatchTrigger), _getGroupName(dispatchTrigger),
+				storageType);
 
 		if (schedulerResponse == null) {
 			return null;
@@ -126,12 +126,15 @@ public class DispatchTriggerHelper {
 		return _schedulerEngineHelper.getPreviousFireTime(schedulerResponse);
 	}
 
-	private String _getGroupName(long dispatchTriggerId) {
-		return String.format("DISPATCH_GROUP_%07d", dispatchTriggerId);
+	private String _getGroupName(DispatchTrigger dispatchTrigger) {
+		return String.format(
+			"DISPATCH_GROUP_%07d@%d", dispatchTrigger.getDispatchTriggerId());
 	}
 
-	private String _getJobName(long dispatchTriggerId) {
-		return String.format("DISPATCH_JOB_%07d", dispatchTriggerId);
+	private String _getJobName(DispatchTrigger dispatchTrigger) {
+		return String.format(
+			"DISPATCH_JOB_%07d@%d", dispatchTrigger.getDispatchTriggerId(),
+			dispatchTrigger.getCompanyId());
 	}
 
 	private String _getPayload(long dispatchTriggerId) {

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/helper/DispatchTriggerHelper.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/helper/DispatchTriggerHelper.java
@@ -7,8 +7,10 @@ package com.liferay.dispatch.internal.helper;
 
 import com.liferay.dispatch.constants.DispatchConstants;
 import com.liferay.dispatch.exception.DispatchTriggerSchedulerException;
+import com.liferay.dispatch.model.DispatchTrigger;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerException;
 import com.liferay.portal.kernel.scheduler.StorageType;
@@ -29,14 +31,23 @@ import org.osgi.service.component.annotations.Reference;
 public class DispatchTriggerHelper {
 
 	public void addSchedulerJob(
-			long dispatchTriggerId, String cronExpression, Date startDate,
-			Date endDate, StorageType storageType, String timeZoneId)
+			DispatchTrigger dispatchTrigger, StorageType storageType,
+			String timeZoneId)
 		throws DispatchTriggerSchedulerException {
+
+		long dispatchTriggerId = dispatchTrigger.getDispatchTriggerId();
 
 		Trigger trigger = _triggerFactory.createTrigger(
 			_getJobName(dispatchTriggerId), _getGroupName(dispatchTriggerId),
-			startDate, endDate, cronExpression,
+			dispatchTrigger.getStartDate(), dispatchTrigger.getEndDate(),
+			dispatchTrigger.getCronExpression(),
 			TimeZone.getTimeZone(timeZoneId));
+
+		Message message = new Message();
+
+		message.put("companyId", dispatchTrigger.getCompanyId());
+
+		message.setPayload(_getPayload(dispatchTriggerId));
 
 		try {
 			_schedulerEngineHelper.schedule(

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
@@ -107,8 +107,7 @@ public class DispatchConfigurator {
 					true, dispatchTaskClusterMode)) {
 
 			_dispatchTriggerHelper.deleteSchedulerJob(
-				dispatchTrigger.getDispatchTriggerId(),
-				dispatchTaskClusterMode.getStorageType());
+				dispatchTrigger, dispatchTaskClusterMode.getStorageType());
 		}
 
 		_serviceRegistration.unregister();

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
@@ -86,11 +86,7 @@ public class DispatchConfigurator {
 
 			try {
 				_dispatchTriggerHelper.addSchedulerJob(
-					dispatchTrigger.getDispatchTriggerId(),
-					dispatchTrigger.getCronExpression(),
-					dispatchTrigger.getStartDate(),
-					dispatchTrigger.getEndDate(),
-					dispatchTaskClusterMode.getStorageType(),
+					dispatchTrigger, dispatchTaskClusterMode.getStorageType(),
 					dispatchTrigger.getTimeZoneId());
 			}
 			catch (DispatchTriggerSchedulerException

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
@@ -323,9 +323,8 @@ public class DispatchTriggerLocalServiceImpl
 
 		if (active) {
 			_dispatchTriggerHelper.addSchedulerJob(
-				dispatchTriggerId, cronExpression,
-				dispatchTrigger.getStartDate(), dispatchTrigger.getEndDate(),
-				dispatchTaskClusterMode.getStorageType(), timeZoneId);
+				dispatchTrigger, dispatchTaskClusterMode.getStorageType(),
+				timeZoneId);
 		}
 
 		return dispatchTrigger;

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
@@ -131,8 +131,7 @@ public class DispatchTriggerLocalServiceImpl
 				dispatchTrigger.getDispatchTaskClusterMode());
 
 		_dispatchTriggerHelper.deleteSchedulerJob(
-			dispatchTrigger.getDispatchTriggerId(),
-			dispatchTaskClusterMode.getStorageType());
+			dispatchTrigger, dispatchTaskClusterMode.getStorageType());
 
 		return dispatchTrigger;
 	}
@@ -185,7 +184,7 @@ public class DispatchTriggerLocalServiceImpl
 
 		try {
 			return _dispatchTriggerHelper.getPreviousFireDate(
-				dispatchTriggerId, dispatchTaskClusterMode.getStorageType());
+				dispatchTrigger, dispatchTaskClusterMode.getStorageType());
 		}
 		catch (SchedulerException schedulerException) {
 			if (_log.isWarnEnabled()) {
@@ -238,7 +237,7 @@ public class DispatchTriggerLocalServiceImpl
 				dispatchTrigger.getDispatchTaskClusterMode());
 
 		return _dispatchTriggerHelper.getNextFireDate(
-			dispatchTriggerId, dispatchTaskClusterMode.getStorageType());
+			dispatchTrigger, dispatchTaskClusterMode.getStorageType());
 	}
 
 	@Override
@@ -253,7 +252,7 @@ public class DispatchTriggerLocalServiceImpl
 				dispatchTrigger.getDispatchTaskClusterMode());
 
 		return _dispatchTriggerHelper.getPreviousFireDate(
-			dispatchTriggerId, dispatchTaskClusterMode.getStorageType());
+			dispatchTrigger, dispatchTaskClusterMode.getStorageType());
 	}
 
 	@Override
@@ -319,7 +318,7 @@ public class DispatchTriggerLocalServiceImpl
 		dispatchTrigger = dispatchTriggerPersistence.update(dispatchTrigger);
 
 		_dispatchTriggerHelper.deleteSchedulerJob(
-			dispatchTriggerId, dispatchTaskClusterMode.getStorageType());
+			dispatchTrigger, dispatchTaskClusterMode.getStorageType());
 
 		if (active) {
 			_dispatchTriggerHelper.addSchedulerJob(

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
@@ -274,8 +274,9 @@ public class DispatchTriggerLocalServiceTest {
 			Assert.assertNull(
 				_schedulerEngineHelper.getScheduledJob(
 					String.format(
-						"DISPATCH_JOB_%07d",
-						dispatchTrigger.getDispatchTriggerId()),
+						"DISPATCH_JOB_%07d@%d",
+						dispatchTrigger.getDispatchTriggerId(),
+						dispatchTrigger.getCompanyId()),
 					String.format(
 						"DISPATCH_GROUP_%07d",
 						dispatchTrigger.getDispatchTriggerId()),

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMailingListLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMailingListLocalServiceImpl.java
@@ -227,7 +227,8 @@ public class MBMailingListLocalServiceImpl
 	private String _getSchedulerGroupName(MBMailingList mailingList) {
 		return StringBundler.concat(
 			DestinationNames.MESSAGE_BOARDS_MAILING_LIST, StringPool.SLASH,
-			mailingList.getMailingListId());
+			mailingList.getMailingListId(), StringPool.AT,
+			mailingList.getCompanyId());
 	}
 
 	private void _scheduleMailingList(MBMailingList mailingList)

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/build.gradle
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compileOnly project(":apps:portal-scheduler:portal-scheduler")
 	compileOnly project(":apps:static:portal:portal-profile-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
+	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-string")
 
 	testImplementation project(":core:petra:petra-lang")

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzSchedulerEngine.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzSchedulerEngine.java
@@ -787,7 +787,7 @@ public class QuartzSchedulerEngine implements SchedulerEngine {
 	private Props _props;
 
 	@Reference(
-		target = "(&(release.bundle.symbolic.name=com.liferay.portal.scheduler.quartz)(release.schema.version=1.0.0))"
+		target = "(&(release.bundle.symbolic.name=com.liferay.portal.scheduler.quartz)(release.schema.version=2.0.0))"
 	)
 	private Release _release;
 

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/registry/QuartzServiceUpgradeStepRegistrator.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/registry/QuartzServiceUpgradeStepRegistrator.java
@@ -5,11 +5,13 @@
 
 package com.liferay.portal.scheduler.quartz.internal.upgrade.registry;
 
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.scheduler.quartz.internal.upgrade.schema.SchemaCreationUpgradeStep;
-import com.liferay.portal.scheduler.quartz.internal.upgrade.v1_0_0.QuartzUpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Akos Thurzo
@@ -25,7 +27,21 @@ public class QuartzServiceUpgradeStepRegistrator
 		registry.registerReleaseCreationUpgradeSteps(
 			new SchemaCreationUpgradeStep());
 
-		registry.register("0.0.1", "1.0.0", new QuartzUpgradeProcess());
+		registry.register(
+			"0.0.1", "1.0.0",
+			new com.liferay.portal.scheduler.quartz.internal.upgrade.v1_0_0.
+				QuartzUpgradeProcess());
+
+		registry.register(
+			"1.0.0", "2.0.0",
+			new com.liferay.portal.scheduler.quartz.internal.upgrade.v2_0_0.
+				QuartzUpgradeProcess(_companyLocalService, _jsonFactory));
 	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private JSONFactory _jsonFactory;
 
 }

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v2_0_0/QuartzUpgradeProcess.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v2_0_0/QuartzUpgradeProcess.java
@@ -1,0 +1,197 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.scheduler.quartz.internal.upgrade.v2_0_0;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.scheduler.SchedulerEngine;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.quartz.JobDataMap;
+
+/**
+ * @author Kevin Lee
+ */
+public class QuartzUpgradeProcess extends UpgradeProcess {
+
+	public QuartzUpgradeProcess(
+		CompanyLocalService companyLocalService, JSONFactory jsonFactory) {
+
+		_companyLocalService = companyLocalService;
+		_jsonFactory = jsonFactory;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		Map<String, Long> jobCompanyIds = new HashMap<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select job_name, job_data from QUARTZ_JOB_DETAILS where " +
+					"job_name not like '%@%'");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				JobDataMap jobDataMap = _deserializeJobData(
+					resultSet.getBinaryStream("job_data"));
+
+				_fetchCompanyId(
+					jobCompanyIds, resultSet.getString("job_name"), jobDataMap);
+			}
+		}
+
+		_updateTables(
+			jobCompanyIds, "job_name",
+			new String[] {
+				"QUARTZ_FIRED_TRIGGERS", "QUARTZ_JOB_DETAILS", "QUARTZ_TRIGGERS"
+			});
+
+		_updateTables(
+			jobCompanyIds, "trigger_name",
+			new String[] {
+				"QUARTZ_BLOB_TRIGGERS", "QUARTZ_CRON_TRIGGERS",
+				"QUARTZ_FIRED_TRIGGERS", "QUARTZ_SIMPLE_TRIGGERS",
+				"QUARTZ_SIMPROP_TRIGGERS", "QUARTZ_TRIGGERS"
+			});
+	}
+
+	private boolean _containsColumnId(
+			String tableName, String columnId, long columnValue)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select 1 from ", tableName, " where ", columnId, " = ",
+					columnValue));
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			return resultSet.next();
+		}
+	}
+
+	private JobDataMap _deserializeJobData(InputStream inputStream)
+		throws Exception {
+
+		try (ObjectInputStream objectInputStream = new ObjectInputStream(
+				inputStream)) {
+
+			return (JobDataMap)objectInputStream.readObject();
+		}
+	}
+
+	private void _fetchCompanyId(
+			Map<String, Long> jobCompanyIds, String jobName,
+			JobDataMap jobDataMap)
+		throws Exception {
+
+		String destinationName = jobDataMap.getString(
+			SchedulerEngine.DESTINATION_NAME);
+
+		if (destinationName.equals(_LAYOUTS_LOCAL_PUBLISHER) ||
+			destinationName.equals(_LAYOUTS_REMOTE_PUBLISHER)) {
+
+			return;
+		}
+
+		Message message = (Message)_jsonFactory.deserialize(
+			jobDataMap.getString(SchedulerEngine.MESSAGE));
+
+		if (message.contains("companyId")) {
+			jobCompanyIds.put(jobName, message.getLong("companyId"));
+
+			return;
+		}
+
+		_companyLocalService.forEachCompanyId(
+			companyId -> {
+				if (jobCompanyIds.containsKey(jobName)) {
+					return;
+				}
+
+				if (destinationName.equals(_CT_COLLECTION_SCHEDULED_PUBLISH)) {
+					long ctCollectionId = message.getLong("ctCollectionId");
+
+					if (_containsColumnId(
+							"CTCollection", "ctCollectionId", ctCollectionId)) {
+
+						jobCompanyIds.put(jobName, companyId);
+					}
+				}
+				else if (destinationName.equals(_DISPATCH_EXECUTOR)) {
+					JSONObject jsonObject = _jsonFactory.createJSONObject(
+						(String)message.getPayload());
+
+					long dispatchTriggerId = jsonObject.getLong(
+						"dispatchTriggerId");
+
+					if (_containsColumnId(
+							"DispatchTrigger", "dispatchTriggerId",
+							dispatchTriggerId)) {
+
+						jobCompanyIds.put(jobName, companyId);
+					}
+				}
+			});
+	}
+
+	private void _updateTables(
+			Map<String, Long> jobCompanyIds, String columnName,
+			String[] tableNames)
+		throws Exception {
+
+		for (String tableName : tableNames) {
+			try (PreparedStatement preparedStatement =
+					AutoBatchPreparedStatementUtil.autoBatch(
+						connection,
+						StringBundler.concat(
+							"update ", tableName, " set ", columnName,
+							" = ? where ", columnName, " = ?"))) {
+
+				for (Map.Entry<String, Long> entry : jobCompanyIds.entrySet()) {
+					preparedStatement.setString(
+						1,
+						StringBundler.concat(
+							entry.getKey(), StringPool.AT, entry.getValue()));
+
+					preparedStatement.setString(2, entry.getKey());
+
+					preparedStatement.addBatch();
+				}
+
+				preparedStatement.executeBatch();
+			}
+		}
+	}
+
+	private static final String _CT_COLLECTION_SCHEDULED_PUBLISH =
+		"liferay/ct_collection_scheduled_publish";
+
+	private static final String _DISPATCH_EXECUTOR =
+		"liferay/dispatch/executor";
+
+	private static final String _LAYOUTS_LOCAL_PUBLISHER =
+		"liferay/layouts_local_publisher";
+
+	private static final String _LAYOUTS_REMOTE_PUBLISHER =
+		"liferay/layouts_remote_publisher";
+
+	private final CompanyLocalService _companyLocalService;
+	private final JSONFactory _jsonFactory;
+
+}

--- a/modules/apps/portal-scheduler/source-formatter-suppressions.xml
+++ b/modules/apps/portal-scheduler/source-formatter-suppressions.xml
@@ -5,6 +5,7 @@
 		<suppress checks="MethodNameCheck" files="portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngineConfigurator\.java" />
 	</checkstyle>
 	<source-check>
+		<suppress checks="JavaDeserializationSecurityCheck" files="portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_1/QuartzUpgradeProcess\.java" />
 		<suppress checks="JavaVerifyUpgradeConnectionCheck" files="portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/schema/SchemaCreationUpgradeStep\.java" />
 	</source-check>
 </suppressions>

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-api/src/main/java/com/liferay/portal/workflow/kaleo/runtime/util/SchedulerUtil.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-api/src/main/java/com/liferay/portal/workflow/kaleo/runtime/util/SchedulerUtil.java
@@ -14,10 +14,12 @@ import com.liferay.portal.workflow.kaleo.runtime.constants.KaleoRuntimeDestinati
  */
 public class SchedulerUtil {
 
-	public static String getGroupName(long kaleoTimerInstanceTokenId) {
+	public static String getGroupName(
+		long companyId, long kaleoTimerInstanceTokenId) {
+
 		return StringBundler.concat(
 			KaleoRuntimeDestinationNames.WORKFLOW_TIMER, StringPool.SLASH,
-			kaleoTimerInstanceTokenId);
+			kaleoTimerInstanceTokenId, StringPool.AT, companyId);
 	}
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/timer/messaging/TimerMessageListener.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/timer/messaging/TimerMessageListener.java
@@ -5,7 +5,6 @@
 
 package com.liferay.portal.workflow.kaleo.runtime.internal.timer.messaging;
 
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
@@ -40,22 +39,19 @@ public class TimerMessageListener extends BaseMessageListener {
 
 	@Override
 	protected void doReceive(Message message) throws Exception {
-		long kaleoTimerInstanceTokenId = message.getLong(
-			"kaleoTimerInstanceTokenId");
+		KaleoTimerInstanceToken kaleoTimerInstanceToken =
+			_getKaleoTimerInstanceToken(message);
+
+		Map<String, Serializable> workflowContext = WorkflowContextUtil.convert(
+			kaleoTimerInstanceToken.getWorkflowContext());
+
+		ServiceContext serviceContext = (ServiceContext)workflowContext.get(
+			WorkflowConstants.CONTEXT_SERVICE_CONTEXT);
 
 		try {
-			KaleoTimerInstanceToken kaleoTimerInstanceToken =
-				_getKaleoTimerInstanceToken(message);
-
-			Map<String, Serializable> workflowContext =
-				WorkflowContextUtil.convert(
-					kaleoTimerInstanceToken.getWorkflowContext());
-
-			ServiceContext serviceContext = (ServiceContext)workflowContext.get(
-				WorkflowConstants.CONTEXT_SERVICE_CONTEXT);
-
 			_workflowEngine.executeTimerWorkflowInstance(
-				kaleoTimerInstanceTokenId, serviceContext, workflowContext);
+				kaleoTimerInstanceToken.getKaleoTimerInstanceTokenId(),
+				serviceContext, workflowContext);
 		}
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {
@@ -66,13 +62,15 @@ public class TimerMessageListener extends BaseMessageListener {
 			}
 
 			SchedulerEngineHelperUtil.delete(
-				SchedulerUtil.getGroupName(kaleoTimerInstanceTokenId),
+				SchedulerUtil.getGroupName(
+					kaleoTimerInstanceToken.getCompanyId(),
+					kaleoTimerInstanceToken.getKaleoTimerInstanceTokenId()),
 				StorageType.PERSISTED);
 		}
 	}
 
 	private KaleoTimerInstanceToken _getKaleoTimerInstanceToken(Message message)
-		throws PortalException {
+		throws Exception {
 
 		long kaleoTimerInstanceTokenId = message.getLong(
 			"kaleoTimerInstanceTokenId");

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoTimerInstanceTokenLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoTimerInstanceTokenLocalServiceImpl.java
@@ -279,6 +279,7 @@ public class KaleoTimerInstanceTokenLocalServiceImpl
 		KaleoTimerInstanceToken kaleoTimerInstanceToken) {
 
 		return SchedulerUtil.getGroupName(
+			kaleoTimerInstanceToken.getCompanyId(),
 			kaleoTimerInstanceToken.getKaleoTimerInstanceTokenId());
 	}
 

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-service/src/main/java/com/liferay/portal/reports/engine/console/service/impl/EntryLocalServiceImpl.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-service/src/main/java/com/liferay/portal/reports/engine/console/service/impl/EntryLocalServiceImpl.java
@@ -200,7 +200,7 @@ public class EntryLocalServiceImpl extends EntryLocalServiceBaseImpl {
 
 		if (entry.isRepeating()) {
 			_schedulerEngineHelper.delete(
-				entry.getJobName(), entry.getSchedulerRequestName(),
+				_getSchedulerJobName(entry), entry.getSchedulerRequestName(),
 				StorageType.PERSISTED);
 		}
 
@@ -356,7 +356,7 @@ public class EntryLocalServiceImpl extends EntryLocalServiceBaseImpl {
 		entry = entryPersistence.update(entry);
 
 		_schedulerEngineHelper.delete(
-			entry.getJobName(), entry.getSchedulerRequestName(),
+			_getSchedulerJobName(entry), entry.getSchedulerRequestName(),
 			StorageType.PERSISTED);
 	}
 
@@ -433,6 +433,11 @@ public class EntryLocalServiceImpl extends EntryLocalServiceBaseImpl {
 			ReportsGroupServiceEmailConfiguration.class,
 			new GroupServiceSettingsLocator(
 				groupId, ReportsEngineConsoleConstants.SERVICE_NAME));
+	}
+
+	private String _getSchedulerJobName(Entry entry) {
+		return StringBundler.concat(
+			entry.getJobName(), StringPool.AT, entry.getCompanyId());
 	}
 
 	private byte[] _getTemplateFileBytes(
@@ -561,7 +566,7 @@ public class EntryLocalServiceImpl extends EntryLocalServiceBaseImpl {
 		throws PortalException {
 
 		Trigger trigger = _triggerFactory.createTrigger(
-			entry.getJobName(), entry.getSchedulerRequestName(),
+			_getSchedulerJobName(entry), entry.getSchedulerRequestName(),
 			entry.getStartDate(), entry.getEndDate(), entry.getRecurrence());
 
 		Message message = new Message();

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.DestinationNames;
+import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
@@ -1068,10 +1069,16 @@ public class LayoutServiceImpl extends LayoutServiceBaseImpl {
 						TYPE_SCHEDULED_PUBLISH_LAYOUT_LOCAL,
 					publishLayoutLocalSettingsMap);
 
+		Message message = new Message();
+
+		message.put("companyId", exportImportConfiguration.getCompanyId());
+
+		message.setPayload(
+			exportImportConfiguration.getExportImportConfigurationId());
+
 		SchedulerEngineHelperUtil.schedule(
 			trigger, StorageType.PERSISTED, description,
-			DestinationNames.LAYOUTS_LOCAL_PUBLISHER,
-			exportImportConfiguration.getExportImportConfigurationId());
+			DestinationNames.LAYOUTS_LOCAL_PUBLISHER, message);
 	}
 
 	/**
@@ -1140,10 +1147,16 @@ public class LayoutServiceImpl extends LayoutServiceBaseImpl {
 						TYPE_SCHEDULED_PUBLISH_LAYOUT_REMOTE,
 					publishLayoutRemoteSettingsMap);
 
+		Message message = new Message();
+
+		message.put("companyId", exportImportConfiguration.getCompanyId());
+
+		message.setPayload(
+			exportImportConfiguration.getExportImportConfigurationId());
+
 		SchedulerEngineHelperUtil.schedule(
 			trigger, StorageType.PERSISTED, description,
-			DestinationNames.LAYOUTS_REMOTE_PUBLISHER,
-			exportImportConfiguration.getExportImportConfigurationId());
+			DestinationNames.LAYOUTS_REMOTE_PUBLISHER, message);
 	}
 
 	/**


### PR DESCRIPTION
__Ticket:__ <https://liferay.atlassian.net/browse/LPS-198979>

This PR updates modules so that they use unique names when scheduling persisted jobs. To make the job names unique, I appended the `companyId` since a `companyId` is (most likely) unique. Additionally, I created an upgrade process to update the names of previously stored jobs if possible using the `companyId`.

Let me know if I am missing anything.