### PR TITLE
LPS-201362 When executing the upgrade tool look for the dir app server folder without the version too

### DIFF
--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
@@ -18,26 +18,25 @@ public class AppServer {
 
 	public static AppServer getJBossEAPAppServer() {
 		return new AppServer(
-			"../../jboss-eap-7.1.0", _getJBossExtraLibDirNames(),
+			"jboss-eap", _getJBossExtraLibDirNames(),
 			"/modules/com/liferay/portal/main",
 			"/standalone/deployments/ROOT.war", "jboss");
 	}
 
 	public static AppServer getTomcatAppServer() {
 		return new AppServer(
-			"../../tomcat-9.0.83", "/bin", "/lib", "/webapps/ROOT", "tomcat");
+			"tomcat", "/bin", "/lib", "/webapps/ROOT", "tomcat");
 	}
 
 	public static AppServer getWebLogicAppServer() {
 		return new AppServer(
-			"../../weblogic-12.2.1", "/wlserver/modules",
-			"/domains/liferay/lib", "/domains/liferay/autodeploy/ROOT",
-			"weblogic");
+			"weblogic", "/wlserver/modules", "/domains/liferay/lib",
+			"/domains/liferay/autodeploy/ROOT", "weblogic");
 	}
 
 	public static AppServer getWebSphereAppServer() {
 		return new AppServer(
-			"../../websphere-9.0.0.0", "", "/lib",
+			"websphere", "", "/lib",
 			"/profiles/liferay/installedApps/liferay-cell/liferay-portal.ear" +
 				"/liferay-portal.war",
 			"websphere");
@@ -45,7 +44,7 @@ public class AppServer {
 
 	public static AppServer getWildFlyAppServer() {
 		return new AppServer(
-			"../../wildfly-16.0.0", _getJBossExtraLibDirNames(),
+			"wildfly", _getJBossExtraLibDirNames(),
 			"/modules/com/liferay/portal/main",
 			"/standalone/deployments/ROOT.war", "wildfly");
 	}

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
@@ -23,13 +23,6 @@ public class AppServer {
 			"/standalone/deployments/ROOT.war", "jboss");
 	}
 
-	public static AppServer getTCServerAppServer() {
-		return new AppServer(
-			"../../../../tc-server-4.0.2",
-			"/runtimes/tomcat-9.0.10.A.RELEASE/lib", "/instances/liferay/lib",
-			"/instances/liferay/webapps/ROOT", "tomcat");
-	}
-
 	public static AppServer getTomcatAppServer() {
 		return new AppServer(
 			"../../tomcat-9.0.83", "/bin", "/lib", "/webapps/ROOT", "tomcat");

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.tools.db.upgrade.client;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import java.util.ArrayList;
@@ -170,9 +171,14 @@ public class AppServer {
 								if (!_dir.isAbsolute()) {
 									_dir = _dir.getCanonicalFile();
 								}
+								if(!_dir.exists()){
+									throw new FileNotFoundException(
+										"No directory found at " + _dir.getCanonicalPath());
+								}
 							}
 							catch (IOException ioException) {
 								ioException.printStackTrace();
+								System.exit(0);
 							}
 						}
 					}
@@ -186,9 +192,15 @@ public class AppServer {
 				if (!_dir.isAbsolute()) {
 					_dir = _dir.getCanonicalFile();
 				}
+
+				if(!_dir.exists()){
+					throw new FileNotFoundException(
+						"No directory found at " + _dir.getCanonicalPath());
+				}
 			}
 			catch (IOException ioException) {
 				ioException.printStackTrace();
+				System.exit(0);
 			}
 		}
 	}

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
@@ -156,15 +156,48 @@ public class AppServer {
 	}
 
 	private void _setDirName(String dirName) {
-		try {
-			_dir = new File(dirName);
+		if (DBUpgradeClient.getAppServerDir(
+			).isEmpty()) {
 
-			if (!_dir.isAbsolute()) {
-				_dir = _dir.getCanonicalFile();
+			File liferayHome = new File(DBUpgradeClient.getLiferayHome());
+
+			if (liferayHome.isDirectory()) {
+				File[] folders = liferayHome.listFiles();
+
+				if (folders != null) {
+					for (File file : folders) {
+						if (file.isDirectory() &&
+							file.getName(
+							).contains(
+								dirName
+							)) {
+
+							try {
+								_dir = file;
+
+								if (!_dir.isAbsolute()) {
+									_dir = _dir.getCanonicalFile();
+								}
+							}
+							catch (IOException ioException) {
+								ioException.printStackTrace();
+							}
+						}
+					}
+				}
 			}
 		}
-		catch (IOException ioException) {
-			ioException.printStackTrace();
+		else {
+			try {
+				_dir = new File(dirName);
+
+				if (!_dir.isAbsolute()) {
+					_dir = _dir.getCanonicalFile();
+				}
+			}
+			catch (IOException ioException) {
+				ioException.printStackTrace();
+			}
 		}
 	}
 

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
@@ -161,7 +161,7 @@ public class AppServer {
 					for (File file : folders) {
 						if (file.isDirectory() &&
 							file.getName(
-							).contains(
+							).startsWith(
 								dirName
 							)) {
 

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
@@ -297,10 +297,9 @@ public class DBUpgradeClient {
 		}
 
 		try {
+			_verifyPortalUpgradeExtProperties();
 			_verifyAppServerProperties();
 			_verifyPortalUpgradeDatabaseProperties();
-			_verifyPortalUpgradeExtProperties();
-
 			_saveProperties();
 		}
 		catch (IOException ioException) {

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
@@ -49,6 +49,27 @@ import org.apache.commons.cli.ParseException;
  */
 public class DBUpgradeClient {
 
+	public static String getAppServerDir() {
+		String dir = _appServerProperties.getProperty("dir");
+
+		if (dir != null) {
+			return dir;
+		}
+
+		return "";
+	}
+
+	public static String getLiferayHome() {
+		String liferayHome = _portalUpgradeExtProperties.getProperty(
+			"liferay.home");
+
+		if (liferayHome != null) {
+			return liferayHome;
+		}
+
+		return "";
+	}
+
 	public static void main(String[] args) {
 		Options options = _getOptions();
 
@@ -760,6 +781,7 @@ public class DBUpgradeClient {
 
 	private static final String _JAVA_HOME = System.getenv("JAVA_HOME");
 
+	private static Properties _appServerProperties = new Properties();
 	private static final Map<String, AppServer> _appServers =
 		new LinkedHashMap<String, AppServer>() {
 		};
@@ -778,6 +800,7 @@ public class DBUpgradeClient {
 	private static final Pattern _gogoShellAddressPattern = Pattern.compile(
 		"^([^\\:]+):([0-9]{1,5})$");
 	private static File _jarDir;
+	private static Properties _portalUpgradeExtProperties = new Properties();
 
 	static {
 		ProtectionDomain protectionDomain =
@@ -800,7 +823,6 @@ public class DBUpgradeClient {
 	}
 
 	private AppServer _appServer;
-	private final Properties _appServerProperties;
 	private final File _appServerPropertiesFile;
 	private final ConsoleReader _consoleReader = new ConsoleReader();
 	private final FileOutputStream _fileOutputStream;
@@ -808,7 +830,6 @@ public class DBUpgradeClient {
 	private final File _logFile;
 	private final Properties _portalUpgradeDatabaseProperties;
 	private final File _portalUpgradeDatabasePropertiesFile;
-	private final Properties _portalUpgradeExtProperties;
 	private final File _portalUpgradeExtPropertiesFile;
 	private final boolean _shell;
 

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
@@ -393,6 +393,14 @@ public class DBUpgradeClient {
 		return sb.toString();
 	}
 
+	private void _initAppServers() {
+		_appServers.put("jboss", AppServer.getJBossEAPAppServer());
+		_appServers.put("tomcat", AppServer.getTomcatAppServer());
+		_appServers.put("weblogic", AppServer.getWebLogicAppServer());
+		_appServers.put("websphere", AppServer.getWebSphereAppServer());
+		_appServers.put("wildfly", AppServer.getWildFlyAppServer());
+	}
+
 	private GogoShellClient _initGogoShellClient() throws IOException {
 		String value = _portalUpgradeExtProperties.getProperty(
 			"module.framework.properties.osgi.console");
@@ -492,6 +500,8 @@ public class DBUpgradeClient {
 	}
 
 	private void _verifyAppServerProperties() throws IOException {
+		_initAppServers();
+
 		String value = _appServerProperties.getProperty(
 			"server.detector.server.id");
 
@@ -752,14 +762,6 @@ public class DBUpgradeClient {
 
 	private static final Map<String, AppServer> _appServers =
 		new LinkedHashMap<String, AppServer>() {
-			{
-				put("jboss", AppServer.getJBossEAPAppServer());
-				put("tcserver", AppServer.getTCServerAppServer());
-				put("tomcat", AppServer.getTomcatAppServer());
-				put("weblogic", AppServer.getWebLogicAppServer());
-				put("websphere", AppServer.getWebSphereAppServer());
-				put("wildfly", AppServer.getWildFlyAppServer());
-			}
 		};
 	private static final Map<String, Database> _databases =
 		new LinkedHashMap<String, Database>() {

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
@@ -561,6 +561,8 @@ public class DBUpgradeClient {
 			response = _consoleReader.readLine();
 
 			if (!response.isEmpty()) {
+				_appServerProperties.setProperty("dir", response);
+
 				_appServer.setDirName(response);
 			}
 


### PR DESCRIPTION
Ticket:
[LPS-201362](https://liferay.atlassian.net/browse/LPS-201362)
_Subtask:[LPS-205138](https://liferay.atlassian.net/browse/LPS-205138)_

Issue:
With the new Liferay Directory Structure changes for different releases,  the app server directory may or may not have a version listed in the name of the directory.

Prior to this change, we would explicitly look for the folder with that specific name when using the DBTool. (e.g. tomcat-9.0.83)

With the new changes, we'll need to scan for either a folder with only the name of the app server or with the versioning appended to it.
(e.g tomcat or tomcat-9.0.83)

In the case where the portal-property for the app server is already set,  the directory won't be scanned for and the path listed will be used(valid or not)

Additional Changes:
TCServer was remove due to it not being compatible in Liferay 7.4.

The last Liferay version this app server is compatible with is Liferay DXP 7.1.

