### PR TITLE
LPS-201338 Add custom logic for Virtual Instance Migration to handle migrating Quartz data

### DIFF
--- a/modules/apps/portal-scheduler/source-formatter-suppressions.xml
+++ b/modules/apps/portal-scheduler/source-formatter-suppressions.xml
@@ -5,7 +5,6 @@
 		<suppress checks="MethodNameCheck" files="portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngineConfigurator\.java" />
 	</checkstyle>
 	<source-check>
-		<suppress checks="JavaDeserializationSecurityCheck" files="portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_1/QuartzUpgradeProcess\.java" />
 		<suppress checks="JavaVerifyUpgradeConnectionCheck" files="portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/schema/SchemaCreationUpgradeStep\.java" />
 	</source-check>
 </suppressions>

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -734,6 +734,12 @@ public class DBPartitionUtil {
 
 							companyIdControlTableNames.add(tableName);
 						}
+						else if (_isQuartzTable(tableName)) {
+							_copyData(
+								tableName, _getSchemaName(companyId),
+								_defaultSchemaName, statement,
+								StringPool.BLANK);
+						}
 
 						statement.executeUpdate(
 							_getDropTableSQL(companyId, tableName));
@@ -773,6 +779,10 @@ public class DBPartitionUtil {
 		}
 
 		_companyIds.add(companyId);
+	}
+
+	private static boolean _isQuartzTable(String tableName) {
+		return StringUtil.startsWith(tableName, _QUARTZ_TABLE_NAME_PREFIX);
 	}
 
 	private static boolean _isSkip(Connection connection, String tableName)
@@ -890,6 +900,10 @@ public class DBPartitionUtil {
 	private static final boolean _DATABASE_PARTITION_THREAD_POOL_ENABLED =
 		GetterUtil.getBoolean(
 			PropsUtil.get("database.partition.thread.pool.enabled"), true);
+
+	private static final String _QUARTZ_TABLE_NAME_PREFIX = GetterUtil.get(
+		PropsUtil.get("persisted.scheduler.org.quartz.jobStore.tablePrefix"),
+		"QUARTZ_");
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DBPartitionUtil.class);

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -295,11 +295,35 @@ public class DBPartitionUtil {
 			Statement statement, String whereClause)
 		throws Exception {
 
-		statement.executeUpdate(
-			StringBundler.concat(
-				"insert ", toSchemaName, StringPool.PERIOD, tableName,
-				" select * from ", fromSchemaName, StringPool.PERIOD, tableName,
-				whereClause));
+		_copyData(
+			tableName, fromSchemaName, toSchemaName, statement, whereClause,
+			false);
+	}
+
+	private static void _copyData(
+			String tableName, String fromSchemaName, String toSchemaName,
+			Statement statement, String whereClause,
+			boolean ignoreDuplicateRows)
+		throws Exception {
+
+		StringBundler sb = new StringBundler(10);
+
+		sb.append("insert ");
+
+		if (ignoreDuplicateRows) {
+			sb.append("ignore ");
+		}
+
+		sb.append(toSchemaName);
+		sb.append(StringPool.PERIOD);
+		sb.append(tableName);
+		sb.append(" select * from ");
+		sb.append(fromSchemaName);
+		sb.append(StringPool.PERIOD);
+		sb.append(tableName);
+		sb.append(whereClause);
+
+		statement.executeUpdate(sb.toString());
 	}
 
 	private static void _deleteCompanyData(
@@ -737,8 +761,8 @@ public class DBPartitionUtil {
 						else if (_isQuartzTable(tableName)) {
 							_copyData(
 								tableName, _getSchemaName(companyId),
-								_defaultSchemaName, statement,
-								StringPool.BLANK);
+								_defaultSchemaName, statement, StringPool.BLANK,
+								true);
 						}
 
 						statement.executeUpdate(


### PR DESCRIPTION
__Ticket:__ <https://liferay.atlassian.net/browse/LPS-201338>

This PR changes `DBPartitionUtil.java` so that Quartz jobs are copied to the default schema's Quartz tables from the virtual instance migration. Since it is technically possible for jobs to have duplicate names, I modified `_copyData()` so that it can ignore duplicate key errors. We should be able to support this on both MySQL and Postgres (see here: <https://www.postgresql.org/docs/current/sql-insert.html>).