### PR TITLE
LPS-205471 delete the entry instead of updating if it already exists

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeListTypeTypeTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeListTypeTypeTest.java
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.v7_4_x.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.service.ListTypeLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.v7_4_x.UpgradeListTypeType;
+import com.liferay.portal.util.PortalInstances;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jorge Avalos
+ */
+@RunWith(Arquillian.class)
+public class UpgradeListTypeTypeTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws PortalException {
+		long companyId = PortalInstances.getDefaultCompanyId();
+
+		_listTypeLocalService.addListType(
+			companyId, _LIST_TYPE_NAME, _LIST_TYPE_TYPE);
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess = new UpgradeListTypeType();
+
+		upgradeProcess.upgrade();
+	}
+
+	private static final String _LIST_TYPE_NAME = "intranet";
+
+	private static final String _LIST_TYPE_TYPE =
+		"com.liferay.account.model.AccountEntry.address";
+
+	@Inject
+	private ListTypeLocalService _listTypeLocalService;
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeListTypeType.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeListTypeType.java
@@ -60,6 +60,8 @@ public class UpgradeListTypeType extends UpgradeProcess {
 
 					preparedStatement2.executeUpdate();
 				}
+
+				return;
 			}
 
 			try (PreparedStatement preparedStatement3 =

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeListTypeType.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeListTypeType.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.util.PortalInstances;
 
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 
 /**
  * @author Luis Ortiz
@@ -35,18 +36,46 @@ public class UpgradeListTypeType extends UpgradeProcess {
 	}
 
 	private void _updateListType(long companyId, String name) throws Exception {
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				"update ListType set type_ = ? where companyId = ? and name " +
-					"= ? and type_ = ?")) {
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"Select 1 from ListType where companyId = ? and name = ? and " +
+					"type_ = ?")) {
 
-			preparedStatement.setString(
-				1, "com.liferay.portal.kernel.model.Company.website");
-			preparedStatement.setLong(2, companyId);
-			preparedStatement.setString(3, name);
-			preparedStatement.setString(
-				4, "com.liferay.account.model.AccountEntry.address");
+			preparedStatement1.setLong(1, companyId);
+			preparedStatement1.setString(2, name);
+			preparedStatement1.setString(
+				3, "com.liferay.portal.kernel.model.Company.website");
 
-			preparedStatement.executeUpdate();
+			ResultSet resultSet = preparedStatement1.executeQuery();
+
+			if (resultSet.next()) {
+				try (PreparedStatement preparedStatement2 =
+						connection.prepareStatement(
+							"DELETE FROM ListType where companyId = ? and  " +
+								"name = ? and type_ = ?")) {
+
+					preparedStatement2.setLong(1, companyId);
+					preparedStatement2.setString(2, name);
+					preparedStatement2.setString(
+						3, "com.liferay.account.model.AccountEntry.address");
+
+					preparedStatement2.executeUpdate();
+				}
+			}
+
+			try (PreparedStatement preparedStatement3 =
+					connection.prepareStatement(
+						"update ListType set type_ = ? where companyId = ?  " +
+							"and name = ? and type_ = ?")) {
+
+				preparedStatement3.setString(
+					1, "com.liferay.portal.kernel.model.Company.website");
+				preparedStatement3.setLong(2, companyId);
+				preparedStatement3.setString(3, name);
+				preparedStatement3.setString(
+					4, "com.liferay.account.model.AccountEntry.address");
+
+				preparedStatement3.executeUpdate();
+			}
 		}
 	}
 


### PR DESCRIPTION
Ticket:
[LPS-205471](https://liferay.atlassian.net/browse/LPS-205471)

Issue:
If the customer is coming from a certain baseline, then they will both the correct and incorrect entry for ListType.
This causes the upgrade to fail.

Notes:
I was able to test the issue by using U92,U96, and U101 and upgrading to master.

Test was added for constraint violation.