### PR TITLE
LPS-206169 use OracleDB getIndexResultSet

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -15,6 +15,7 @@ import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.kernel.configuration.Filter;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.Index;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
@@ -1255,6 +1256,8 @@ public abstract class BaseDB implements DB {
 
 		DatabaseMetaData databaseMetaData = connection.getMetaData();
 
+		DB db = DBManagerUtil.getDB();
+
 		DBInspector dbInspector = new DBInspector(connection);
 
 		String catalog = dbInspector.getCatalog();
@@ -1281,9 +1284,8 @@ public abstract class BaseDB implements DB {
 				normalizedTableName = dbInspector.normalizeName(
 					tableResultSet.getString("TABLE_NAME"), databaseMetaData);
 
-				try (ResultSet indexResultSet = databaseMetaData.getIndexInfo(
-						catalog, schema, normalizedTableName, onlyUnique,
-						false)) {
+				try (ResultSet indexResultSet = db.getIndexResultSet(
+						connection, normalizedTableName)) {
 
 					boolean unique = false;
 


### PR DESCRIPTION
Ticket:
[LPS-206169](https://liferay.atlassian.net/browse/LPS-206169)

Issue:
If a customer has locked the statistics for a table(Oracle Only) then the indexeResultSet cannot be aquired.
This was already handled in [LPS-141855](https://liferay.atlassian.net/browse/LPS-141855).  

This ticket just applies the fix in BaseDB.

Wanted to send this up to review while writing the test.
