### PR TITLE
LPS-201338 Add custom logic for virtual instance migration to handle migrating Quartz data

### DIFF
--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzSchedulerEngine.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzSchedulerEngine.java
@@ -787,7 +787,7 @@ public class QuartzSchedulerEngine implements SchedulerEngine {
 	private Props _props;
 
 	@Reference(
-		target = "(&(release.bundle.symbolic.name=com.liferay.portal.scheduler.quartz)(release.schema.version=1.0.1))"
+		target = "(&(release.bundle.symbolic.name=com.liferay.portal.scheduler.quartz)(release.schema.version=1.0.2))"
 	)
 	private Release _release;
 

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/BaseQuartzRenameJobsUpgradeProcess.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/BaseQuartzRenameJobsUpgradeProcess.java
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.scheduler.quartz.internal.upgrade;
+
+import com.liferay.petra.io.ProtectedObjectInputStream;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.io.InputStream;
+
+import java.sql.PreparedStatement;
+
+import java.util.Map;
+
+import org.quartz.JobDataMap;
+
+/**
+ * @author Kevin Lee
+ */
+public abstract class BaseQuartzRenameJobsUpgradeProcess
+	extends UpgradeProcess {
+
+	protected JobDataMap deserializeJobData(InputStream inputStream)
+		throws Exception {
+
+		try (ProtectedObjectInputStream protectedObjectInputStream =
+				new ProtectedObjectInputStream(inputStream)) {
+
+			return (JobDataMap)protectedObjectInputStream.readObject();
+		}
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		Map<String, String> jobNamesMap = getJobNamesMap();
+
+		_updateTables(
+			jobNamesMap, "job_name",
+			new String[] {
+				"QUARTZ_FIRED_TRIGGERS", "QUARTZ_JOB_DETAILS", "QUARTZ_TRIGGERS"
+			});
+
+		_updateTables(
+			jobNamesMap, "trigger_name",
+			new String[] {
+				"QUARTZ_BLOB_TRIGGERS", "QUARTZ_CRON_TRIGGERS",
+				"QUARTZ_FIRED_TRIGGERS", "QUARTZ_SIMPLE_TRIGGERS",
+				"QUARTZ_SIMPROP_TRIGGERS", "QUARTZ_TRIGGERS"
+			});
+	}
+
+	protected abstract Map<String, String> getJobNamesMap() throws Exception;
+
+	private void _updateTables(
+			Map<String, String> jobNamesMap, String columnName,
+			String[] tableNames)
+		throws Exception {
+
+		for (String tableName : tableNames) {
+			try (PreparedStatement preparedStatement =
+					AutoBatchPreparedStatementUtil.autoBatch(
+						connection,
+						StringBundler.concat(
+							"update ", tableName, " set ", columnName,
+							" = ? where ", columnName, " = ?"))) {
+
+				for (Map.Entry<String, String> entry : jobNamesMap.entrySet()) {
+					preparedStatement.setString(1, entry.getValue());
+					preparedStatement.setString(2, entry.getKey());
+					preparedStatement.addBatch();
+				}
+
+				preparedStatement.executeBatch();
+			}
+		}
+	}
+
+}

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/registry/QuartzServiceUpgradeStepRegistrator.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/registry/QuartzServiceUpgradeStepRegistrator.java
@@ -36,6 +36,11 @@ public class QuartzServiceUpgradeStepRegistrator
 			"1.0.0", "1.0.1",
 			new com.liferay.portal.scheduler.quartz.internal.upgrade.v1_0_1.
 				QuartzUpgradeProcess(_companyLocalService, _jsonFactory));
+
+		registry.register(
+			"1.0.1", "1.0.2",
+			new com.liferay.portal.scheduler.quartz.internal.upgrade.v1_0_2.
+				QuartzUpgradeProcess(_jsonFactory));
 	}
 
 	@Reference

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_1/QuartzUpgradeProcess.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_1/QuartzUpgradeProcess.java
@@ -5,18 +5,14 @@
 
 package com.liferay.portal.scheduler.quartz.internal.upgrade.v1_0_1;
 
-import com.liferay.petra.io.ProtectedObjectInputStream;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.scheduler.SchedulerEngine;
 import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-
-import java.io.InputStream;
+import com.liferay.portal.scheduler.quartz.internal.upgrade.BaseQuartzRenameJobsUpgradeProcess;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -29,7 +25,7 @@ import org.quartz.JobDataMap;
 /**
  * @author Kevin Lee
  */
-public class QuartzUpgradeProcess extends UpgradeProcess {
+public class QuartzUpgradeProcess extends BaseQuartzRenameJobsUpgradeProcess {
 
 	public QuartzUpgradeProcess(
 		CompanyLocalService companyLocalService, JSONFactory jsonFactory) {
@@ -39,8 +35,8 @@ public class QuartzUpgradeProcess extends UpgradeProcess {
 	}
 
 	@Override
-	protected void doUpgrade() throws Exception {
-		Map<String, Long> companyIds = new HashMap<>();
+	protected Map<String, String> getJobNamesMap() throws Exception {
+		Map<String, String> jobNamesMap = new HashMap<>();
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select job_name, job_data from QUARTZ_JOB_DETAILS where " +
@@ -48,27 +44,15 @@ public class QuartzUpgradeProcess extends UpgradeProcess {
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			while (resultSet.next()) {
-				JobDataMap jobDataMap = _deserializeJobData(
+				JobDataMap jobDataMap = deserializeJobData(
 					resultSet.getBinaryStream("job_data"));
 
-				_loadCompanyIds(
-					companyIds, resultSet.getString("job_name"), jobDataMap);
+				_loadJobNames(
+					jobNamesMap, resultSet.getString("job_name"), jobDataMap);
 			}
 		}
 
-		_updateTables(
-			companyIds, "job_name",
-			new String[] {
-				"QUARTZ_FIRED_TRIGGERS", "QUARTZ_JOB_DETAILS", "QUARTZ_TRIGGERS"
-			});
-
-		_updateTables(
-			companyIds, "trigger_name",
-			new String[] {
-				"QUARTZ_BLOB_TRIGGERS", "QUARTZ_CRON_TRIGGERS",
-				"QUARTZ_FIRED_TRIGGERS", "QUARTZ_SIMPLE_TRIGGERS",
-				"QUARTZ_SIMPROP_TRIGGERS", "QUARTZ_TRIGGERS"
-			});
+		return jobNamesMap;
 	}
 
 	private boolean _containsColumnId(
@@ -85,18 +69,9 @@ public class QuartzUpgradeProcess extends UpgradeProcess {
 		}
 	}
 
-	private JobDataMap _deserializeJobData(InputStream inputStream)
-		throws Exception {
-
-		try (ProtectedObjectInputStream protectedObjectInputStream =
-				new ProtectedObjectInputStream(inputStream)) {
-
-			return (JobDataMap)protectedObjectInputStream.readObject();
-		}
-	}
-
-	private void _loadCompanyIds(
-			Map<String, Long> companyIds, String jobName, JobDataMap jobDataMap)
+	private void _loadJobNames(
+			Map<String, String> jobNamesMap, String jobName,
+			JobDataMap jobDataMap)
 		throws Exception {
 
 		String destinationName = jobDataMap.getString(
@@ -112,14 +87,16 @@ public class QuartzUpgradeProcess extends UpgradeProcess {
 			jobDataMap.getString(SchedulerEngine.MESSAGE));
 
 		if (message.contains("companyId")) {
-			companyIds.put(jobName, message.getLong("companyId"));
+			jobNamesMap.put(
+				jobName,
+				jobName.concat(StringPool.AT + message.getLong("companyId")));
 
 			return;
 		}
 
 		_companyLocalService.forEachCompanyId(
 			companyId -> {
-				if (companyIds.containsKey(jobName)) {
+				if (jobNamesMap.containsKey(jobName)) {
 					return;
 				}
 
@@ -131,7 +108,10 @@ public class QuartzUpgradeProcess extends UpgradeProcess {
 					if (_containsColumnId(
 							"CTCollection", "ctCollectionId", ctCollectionId)) {
 
-						companyIds.put(jobName, companyId);
+						jobNamesMap.put(
+							jobName,
+							jobName.concat(
+								StringPool.AT + message.getLong("companyId")));
 					}
 				}
 				else if (destinationName.equals("liferay/dispatch/executor")) {
@@ -145,39 +125,13 @@ public class QuartzUpgradeProcess extends UpgradeProcess {
 							"DispatchTrigger", "dispatchTriggerId",
 							dispatchTriggerId)) {
 
-						companyIds.put(jobName, companyId);
+						jobNamesMap.put(
+							jobName,
+							jobName.concat(
+								StringPool.AT + message.getLong("companyId")));
 					}
 				}
 			});
-	}
-
-	private void _updateTables(
-			Map<String, Long> companyIds, String columnName,
-			String[] tableNames)
-		throws Exception {
-
-		for (String tableName : tableNames) {
-			try (PreparedStatement preparedStatement =
-					AutoBatchPreparedStatementUtil.autoBatch(
-						connection,
-						StringBundler.concat(
-							"update ", tableName, " set ", columnName,
-							" = ? where ", columnName, " = ?"))) {
-
-				for (Map.Entry<String, Long> entry : companyIds.entrySet()) {
-					preparedStatement.setString(
-						1,
-						StringBundler.concat(
-							entry.getKey(), StringPool.AT, entry.getValue()));
-
-					preparedStatement.setString(2, entry.getKey());
-
-					preparedStatement.addBatch();
-				}
-
-				preparedStatement.executeBatch();
-			}
-		}
 	}
 
 	private final CompanyLocalService _companyLocalService;

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_2/QuartzUpgradeProcess.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_2/QuartzUpgradeProcess.java
@@ -1,0 +1,125 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.scheduler.quartz.internal.upgrade.v1_0_2;
+
+import com.liferay.petra.io.ProtectedObjectInputStream;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.scheduler.SchedulerEngine;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.io.InputStream;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.quartz.JobDataMap;
+
+/**
+ * @author Kevin Lee
+ */
+public class QuartzUpgradeProcess extends UpgradeProcess {
+
+	public QuartzUpgradeProcess(JSONFactory jsonFactory) {
+		_jsonFactory = jsonFactory;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		Map<String, Long> companyIds = new HashMap<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select job_name, job_data from QUARTZ_JOB_DETAILS where " +
+					"job_name not like '%@%'");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				JobDataMap jobDataMap = _deserializeJobData(
+					resultSet.getBinaryStream("job_data"));
+
+				String destinationName = jobDataMap.getString(
+					SchedulerEngine.DESTINATION_NAME);
+
+				if (!destinationName.equals(
+						"liferay/layouts_local_publisher") &&
+					!destinationName.equals(
+						"liferay/layouts_remote_publisher")) {
+
+					continue;
+				}
+
+				Message message = (Message)_jsonFactory.deserialize(
+					jobDataMap.getString(SchedulerEngine.MESSAGE));
+
+				companyIds.put(
+					resultSet.getString("job_name"),
+					message.getLong("companyId"));
+			}
+		}
+
+		_updateTables(
+			companyIds, "job_name",
+			new String[] {
+				"QUARTZ_FIRED_TRIGGERS", "QUARTZ_JOB_DETAILS", "QUARTZ_TRIGGERS"
+			});
+
+		_updateTables(
+			companyIds, "trigger_name",
+			new String[] {
+				"QUARTZ_BLOB_TRIGGERS", "QUARTZ_CRON_TRIGGERS",
+				"QUARTZ_FIRED_TRIGGERS", "QUARTZ_SIMPLE_TRIGGERS",
+				"QUARTZ_SIMPROP_TRIGGERS", "QUARTZ_TRIGGERS"
+			});
+	}
+
+	private JobDataMap _deserializeJobData(InputStream inputStream)
+		throws Exception {
+
+		try (ProtectedObjectInputStream protectedObjectInputStream =
+				new ProtectedObjectInputStream(inputStream)) {
+
+			return (JobDataMap)protectedObjectInputStream.readObject();
+		}
+	}
+
+	private void _updateTables(
+			Map<String, Long> companyIds, String columnName,
+			String[] tableNames)
+		throws Exception {
+
+		for (String tableName : tableNames) {
+			try (PreparedStatement preparedStatement =
+					AutoBatchPreparedStatementUtil.autoBatch(
+						connection,
+						StringBundler.concat(
+							"update ", tableName, " set ", columnName,
+							" = ? where ", columnName, " = ?"))) {
+
+				for (Map.Entry<String, Long> entry : companyIds.entrySet()) {
+					preparedStatement.setString(
+						1,
+						StringBundler.concat(
+							entry.getKey(), StringPool.AT, entry.getValue()));
+
+					preparedStatement.setString(2, entry.getKey());
+
+					preparedStatement.addBatch();
+				}
+
+				preparedStatement.executeBatch();
+			}
+		}
+	}
+
+	private final JSONFactory _jsonFactory;
+
+}

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_2/QuartzUpgradeProcess.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_2/QuartzUpgradeProcess.java
@@ -5,16 +5,11 @@
 
 package com.liferay.portal.scheduler.quartz.internal.upgrade.v1_0_2;
 
-import com.liferay.petra.io.ProtectedObjectInputStream;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.scheduler.SchedulerEngine;
-import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-
-import java.io.InputStream;
+import com.liferay.portal.scheduler.quartz.internal.upgrade.BaseQuartzRenameJobsUpgradeProcess;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -27,15 +22,15 @@ import org.quartz.JobDataMap;
 /**
  * @author Kevin Lee
  */
-public class QuartzUpgradeProcess extends UpgradeProcess {
+public class QuartzUpgradeProcess extends BaseQuartzRenameJobsUpgradeProcess {
 
 	public QuartzUpgradeProcess(JSONFactory jsonFactory) {
 		_jsonFactory = jsonFactory;
 	}
 
 	@Override
-	protected void doUpgrade() throws Exception {
-		Map<String, Long> companyIds = new HashMap<>();
+	protected Map<String, String> getJobNamesMap() throws Exception {
+		Map<String, String> jobNamesMap = new HashMap<>();
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select job_name, job_data from QUARTZ_JOB_DETAILS where " +
@@ -43,7 +38,7 @@ public class QuartzUpgradeProcess extends UpgradeProcess {
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			while (resultSet.next()) {
-				JobDataMap jobDataMap = _deserializeJobData(
+				JobDataMap jobDataMap = deserializeJobData(
 					resultSet.getBinaryStream("job_data"));
 
 				String destinationName = jobDataMap.getString(
@@ -60,64 +55,16 @@ public class QuartzUpgradeProcess extends UpgradeProcess {
 				Message message = (Message)_jsonFactory.deserialize(
 					jobDataMap.getString(SchedulerEngine.MESSAGE));
 
-				companyIds.put(
-					resultSet.getString("job_name"),
-					message.getLong("companyId"));
+				String jobName = resultSet.getString("job_name");
+
+				jobNamesMap.put(
+					jobName,
+					jobName.concat(
+						StringPool.AT + message.getLong("companyId")));
 			}
 		}
 
-		_updateTables(
-			companyIds, "job_name",
-			new String[] {
-				"QUARTZ_FIRED_TRIGGERS", "QUARTZ_JOB_DETAILS", "QUARTZ_TRIGGERS"
-			});
-
-		_updateTables(
-			companyIds, "trigger_name",
-			new String[] {
-				"QUARTZ_BLOB_TRIGGERS", "QUARTZ_CRON_TRIGGERS",
-				"QUARTZ_FIRED_TRIGGERS", "QUARTZ_SIMPLE_TRIGGERS",
-				"QUARTZ_SIMPROP_TRIGGERS", "QUARTZ_TRIGGERS"
-			});
-	}
-
-	private JobDataMap _deserializeJobData(InputStream inputStream)
-		throws Exception {
-
-		try (ProtectedObjectInputStream protectedObjectInputStream =
-				new ProtectedObjectInputStream(inputStream)) {
-
-			return (JobDataMap)protectedObjectInputStream.readObject();
-		}
-	}
-
-	private void _updateTables(
-			Map<String, Long> companyIds, String columnName,
-			String[] tableNames)
-		throws Exception {
-
-		for (String tableName : tableNames) {
-			try (PreparedStatement preparedStatement =
-					AutoBatchPreparedStatementUtil.autoBatch(
-						connection,
-						StringBundler.concat(
-							"update ", tableName, " set ", columnName,
-							" = ? where ", columnName, " = ?"))) {
-
-				for (Map.Entry<String, Long> entry : companyIds.entrySet()) {
-					preparedStatement.setString(
-						1,
-						StringBundler.concat(
-							entry.getKey(), StringPool.AT, entry.getValue()));
-
-					preparedStatement.setString(2, entry.getKey());
-
-					preparedStatement.addBatch();
-				}
-
-				preparedStatement.executeBatch();
-			}
-		}
+		return jobNamesMap;
 	}
 
 	private final JSONFactory _jsonFactory;

--- a/modules/apps/portal-scheduler/source-formatter-suppressions.xml
+++ b/modules/apps/portal-scheduler/source-formatter-suppressions.xml
@@ -5,7 +5,6 @@
 		<suppress checks="MethodNameCheck" files="portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngineConfigurator\.java" />
 	</checkstyle>
 	<source-check>
-		<suppress checks="JavaDeserializationSecurityCheck" files="portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_1/QuartzUpgradeProcess\.java" />
 		<suppress checks="JavaVerifyUpgradeConnectionCheck" files="portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/schema/SchemaCreationUpgradeStep\.java" />
 	</source-check>
 </suppressions>

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -307,10 +307,20 @@ public class DBPartitionUtil {
 			Statement statement)
 		throws Exception {
 
+		_deleteData(
+			tableName, schemaName, statement,
+			" where companyId = " + companyId);
+	}
+
+	private static void _deleteData(
+			String tableName, String schemaName, Statement statement,
+			String whereClause)
+		throws Exception {
+
 		statement.executeUpdate(
 			StringBundler.concat(
 				"delete from ", schemaName, StringPool.PERIOD, tableName,
-				" where companyId = ", companyId));
+				whereClause));
 	}
 
 	private static void _dropDBPartition(long companyId)
@@ -332,13 +342,21 @@ public class DBPartitionUtil {
 				while (resultSet.next()) {
 					String tableName = resultSet.getString("TABLE_NAME");
 
-					if (dbInspector.isControlTable(
-							_getCompanyIds(), tableName) &&
-						dbInspector.hasColumn(tableName, "companyId")) {
+					if (!dbInspector.isControlTable(
+							_getCompanyIds(), tableName)) {
 
+						continue;
+					}
+
+					if (dbInspector.hasColumn(tableName, "companyId")) {
 						_deleteCompanyData(
 							companyId, tableName, _defaultSchemaName,
 							statement);
+					}
+					else if (_isQuartzTable(tableName)) {
+						_deleteData(
+							tableName, _defaultSchemaName, statement,
+							_getQuartzWhereClauseSQL(companyId, tableName));
 					}
 				}
 
@@ -428,6 +446,12 @@ public class DBPartitionUtil {
 			_moveCompanyData(
 				companyId, tableName, _defaultSchemaName,
 				_getSchemaName(companyId), statement);
+		}
+
+		if (_isQuartzTable(tableName)) {
+			_moveData(
+				tableName, _defaultSchemaName, _getSchemaName(companyId),
+				statement, _getQuartzWhereClauseSQL(companyId, tableName));
 		}
 		else {
 			_copyData(
@@ -659,6 +683,16 @@ public class DBPartitionUtil {
 			StringPool.PERIOD, viewName);
 	}
 
+	private static String _getQuartzWhereClauseSQL(
+		long companyId, String tableName) {
+
+		if (StringUtil.endsWith(tableName, "JOB_DETAILS")) {
+			return " where job_name like '%@" + companyId + "'";
+		}
+
+		return " where trigger_name like '%@" + companyId + "'";
+	}
+
 	private static String _getSchemaName(long companyId) {
 		if ((companyId == CompanyConstants.SYSTEM) ||
 			(companyId == _defaultCompanyId)) {
@@ -704,7 +738,7 @@ public class DBPartitionUtil {
 	private static void _insertDBPartition(long companyId)
 		throws PortalException {
 
-		List<String> companyIdControlTableNames = new ArrayList<>();
+		List<String> copiedTableNames = new ArrayList<>();
 
 		Connection connection = CurrentConnectionUtil.getConnection(
 			InfrastructureUtil.getDataSource());
@@ -721,44 +755,59 @@ public class DBPartitionUtil {
 				while (resultSet.next()) {
 					String tableName = resultSet.getString("TABLE_NAME");
 
-					if (dbInspector.isControlTable(
+					if (!dbInspector.isControlTable(
 							_getCompanyIds(), tableName)) {
 
-						if (dbInspector.hasColumn(tableName, "companyId")) {
-							_copyData(
-								tableName, _getSchemaName(companyId),
-								_defaultSchemaName, statement,
-								" where companyId = " + companyId);
-
-							companyIdControlTableNames.add(tableName);
-						}
-
-						statement.executeUpdate(
-							_getDropTableSQL(companyId, tableName));
-
-						statement.executeUpdate(
-							_getCreateViewSQL(companyId, tableName));
+						continue;
 					}
+
+					if (dbInspector.hasColumn(tableName, "companyId")) {
+						_copyData(
+							tableName, _getSchemaName(companyId),
+							_defaultSchemaName, statement,
+							" where companyId = " + companyId);
+
+						copiedTableNames.add(tableName);
+					}
+					else if (_isQuartzTable(tableName)) {
+						_copyData(
+							tableName, _getSchemaName(companyId),
+							_defaultSchemaName, statement,
+							_getQuartzWhereClauseSQL(companyId, tableName));
+
+						copiedTableNames.add(tableName);
+					}
+
+					statement.executeUpdate(
+						_getDropTableSQL(companyId, tableName));
+
+					statement.executeUpdate(
+						_getCreateViewSQL(companyId, tableName));
 				}
 			}
 		}
 		catch (Exception exception1) {
 			try (Statement statement = connection.createStatement()) {
-				for (String companyIdControlTable :
-						companyIdControlTableNames) {
-
-					_deleteCompanyData(
-						companyId, companyIdControlTable, _defaultSchemaName,
-						statement);
+				for (String copiedTableName : copiedTableNames) {
+					if (_isQuartzTable(copiedTableName)) {
+						_deleteData(
+							copiedTableName, _defaultSchemaName, statement,
+							_getQuartzWhereClauseSQL(
+								companyId, copiedTableName));
+					}
+					else {
+						_deleteCompanyData(
+							companyId, copiedTableName, _defaultSchemaName,
+							statement);
+					}
 				}
 			}
 			catch (Exception exception2) {
 				throw new PortalException(
 					StringBundler.concat(
 						"Unable to roll back the data inserted into the ",
-						"default schema for tables ",
-						companyIdControlTableNames, " and company ID ",
-						companyId),
+						"default schema for tables ", copiedTableNames,
+						" and company ID ", companyId),
 					exception2);
 			}
 
@@ -771,6 +820,17 @@ public class DBPartitionUtil {
 		}
 
 		_companyIds.add(companyId);
+	}
+
+	private static boolean _isQuartzTable(String tableName) {
+		if (StringUtil.startsWith(tableName, _QUARTZ_TABLE_PREFIX) &&
+			(StringUtil.endsWith(tableName, "JOB_DETAILS") ||
+			 StringUtil.endsWith(tableName, "TRIGGERS"))) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private static boolean _isSkip(Connection connection, String tableName)
@@ -800,11 +860,20 @@ public class DBPartitionUtil {
 			String toSchemaName, Statement statement)
 		throws Exception {
 
-		_copyData(
+		_moveData(
 			tableName, fromSchemaName, toSchemaName, statement,
 			" where companyId = " + companyId);
+	}
 
-		_deleteCompanyData(companyId, tableName, fromSchemaName, statement);
+	private static void _moveData(
+			String tableName, String fromSchemaName, String toSchemaName,
+			Statement statement, String whereClause)
+		throws Exception {
+
+		_copyData(
+			tableName, fromSchemaName, toSchemaName, statement, whereClause);
+
+		_deleteData(tableName, fromSchemaName, statement, whereClause);
 	}
 
 	private static void _restoreTable(
@@ -816,6 +885,11 @@ public class DBPartitionUtil {
 			_moveCompanyData(
 				companyId, tableName, _getSchemaName(companyId),
 				_defaultSchemaName, statement);
+		}
+		else if (_isQuartzTable(tableName)) {
+			_moveData(
+				tableName, _getSchemaName(companyId), _defaultSchemaName,
+				statement, _getQuartzWhereClauseSQL(companyId, tableName));
 		}
 
 		statement.executeUpdate(_getDropTableSQL(companyId, tableName));
@@ -888,6 +962,10 @@ public class DBPartitionUtil {
 	private static final boolean _DATABASE_PARTITION_THREAD_POOL_ENABLED =
 		GetterUtil.getBoolean(
 			PropsUtil.get("database.partition.thread.pool.enabled"), true);
+
+	private static final String _QUARTZ_TABLE_PREFIX = GetterUtil.get(
+		PropsUtil.get("persisted.scheduler.org.quartz.jobStore.tablePrefix"),
+		"QUARTZ_");
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DBPartitionUtil.class);

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -336,11 +336,9 @@ public class DBPartitionUtil {
 							_getCompanyIds(), tableName) &&
 						dbInspector.hasColumn(tableName, "companyId")) {
 
-						statement.executeUpdate(
-							StringBundler.concat(
-								"delete from ", _defaultSchemaName,
-								StringPool.PERIOD, tableName,
-								" where companyId = ", companyId));
+						_deleteCompanyData(
+							companyId, tableName, _defaultSchemaName,
+							statement);
 					}
 				}
 

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -353,7 +353,7 @@ public class DBPartitionUtil {
 							companyId, tableName, _defaultSchemaName,
 							statement);
 					}
-					else if (_isQuartzTable(tableName)) {
+					else if (_isQuartzTableToCopy(tableName)) {
 						_deleteData(
 							tableName, _defaultSchemaName, statement,
 							_getQuartzWhereClauseSQL(companyId, tableName));
@@ -448,7 +448,7 @@ public class DBPartitionUtil {
 				_getSchemaName(companyId), statement);
 		}
 
-		if (_isQuartzTable(tableName)) {
+		if (_isQuartzTableToCopy(tableName)) {
 			_moveData(
 				tableName, _defaultSchemaName, _getSchemaName(companyId),
 				statement, _getQuartzWhereClauseSQL(companyId, tableName));
@@ -769,7 +769,7 @@ public class DBPartitionUtil {
 
 						copiedTableNames.add(tableName);
 					}
-					else if (_isQuartzTable(tableName)) {
+					else if (_isQuartzTableToCopy(tableName)) {
 						_copyData(
 							tableName, _getSchemaName(companyId),
 							_defaultSchemaName, statement,
@@ -789,7 +789,7 @@ public class DBPartitionUtil {
 		catch (Exception exception1) {
 			try (Statement statement = connection.createStatement()) {
 				for (String copiedTableName : copiedTableNames) {
-					if (_isQuartzTable(copiedTableName)) {
+					if (_isQuartzTableToCopy(copiedTableName)) {
 						_deleteData(
 							copiedTableName, _defaultSchemaName, statement,
 							_getQuartzWhereClauseSQL(
@@ -822,7 +822,7 @@ public class DBPartitionUtil {
 		_companyIds.add(companyId);
 	}
 
-	private static boolean _isQuartzTable(String tableName) {
+	private static boolean _isQuartzTableToCopy(String tableName) {
 		if (StringUtil.startsWith(tableName, _QUARTZ_TABLE_PREFIX) &&
 			(StringUtil.endsWith(tableName, "JOB_DETAILS") ||
 			 StringUtil.endsWith(tableName, "TRIGGERS"))) {
@@ -886,7 +886,7 @@ public class DBPartitionUtil {
 				companyId, tableName, _getSchemaName(companyId),
 				_defaultSchemaName, statement);
 		}
-		else if (_isQuartzTable(tableName)) {
+		else if (_isQuartzTableToCopy(tableName)) {
 			_moveData(
 				tableName, _getSchemaName(companyId), _defaultSchemaName,
 				statement, _getQuartzWhereClauseSQL(companyId, tableName));

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
@@ -11,6 +11,7 @@ import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalService;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCachable;
@@ -1064,12 +1065,6 @@ public class LayoutServiceImpl extends LayoutServiceBaseImpl {
 		GroupPermissionUtil.check(
 			getPermissionChecker(), targetGroupId, ActionKeys.PUBLISH_STAGING);
 
-		Trigger trigger = TriggerFactoryUtil.createTrigger(
-			PortalUUIDUtil.generate(), groupName, schedulerStartDate,
-			schedulerEndDate, cronText,
-			TimeZone.getTimeZone(
-				MapUtil.getString(parameterMap, "timeZoneId")));
-
 		User user = _userPersistence.findByPrimaryKey(getUserId());
 
 		Map<String, Serializable> publishLayoutLocalSettingsMap =
@@ -1086,9 +1081,18 @@ public class LayoutServiceImpl extends LayoutServiceBaseImpl {
 						TYPE_SCHEDULED_PUBLISH_LAYOUT_LOCAL,
 					publishLayoutLocalSettingsMap);
 
+		long companyId = exportImportConfiguration.getCompanyId();
+
+		Trigger trigger = TriggerFactoryUtil.createTrigger(
+			StringBundler.concat(
+				PortalUUIDUtil.generate(), StringPool.AT, companyId),
+			groupName, schedulerStartDate, schedulerEndDate, cronText,
+			TimeZone.getTimeZone(
+				MapUtil.getString(parameterMap, "timeZoneId")));
+
 		Message message = new Message();
 
-		message.put("companyId", exportImportConfiguration.getCompanyId());
+		message.put("companyId", companyId);
 
 		message.setPayload(
 			exportImportConfiguration.getExportImportConfigurationId());
@@ -1140,12 +1144,6 @@ public class LayoutServiceImpl extends LayoutServiceBaseImpl {
 		GroupPermissionUtil.check(
 			getPermissionChecker(), sourceGroupId, ActionKeys.PUBLISH_STAGING);
 
-		Trigger trigger = TriggerFactoryUtil.createTrigger(
-			PortalUUIDUtil.generate(), groupName, schedulerStartDate,
-			schedulerEndDate, cronText,
-			TimeZone.getTimeZone(
-				MapUtil.getString(parameterMap, "timeZoneId")));
-
 		User user = _userPersistence.findByPrimaryKey(getUserId());
 
 		Map<String, Serializable> publishLayoutRemoteSettingsMap =
@@ -1164,9 +1162,18 @@ public class LayoutServiceImpl extends LayoutServiceBaseImpl {
 						TYPE_SCHEDULED_PUBLISH_LAYOUT_REMOTE,
 					publishLayoutRemoteSettingsMap);
 
+		long companyId = exportImportConfiguration.getCompanyId();
+
+		Trigger trigger = TriggerFactoryUtil.createTrigger(
+			StringBundler.concat(
+				PortalUUIDUtil.generate(), StringPool.AT, companyId),
+			groupName, schedulerStartDate, schedulerEndDate, cronText,
+			TimeZone.getTimeZone(
+				MapUtil.getString(parameterMap, "timeZoneId")));
+
 		Message message = new Message();
 
-		message.put("companyId", exportImportConfiguration.getCompanyId());
+		message.put("companyId", companyId);
 
 		message.setPayload(
 			exportImportConfiguration.getExportImportConfigurationId());


### PR DESCRIPTION
__Ticket:__ <https://liferay.atlassian.net/browse/LPS-201338>

This PR allows `DBPartitionUtil` to handle migrating Quartz data during virtual instance migration. For now, we only extract/insert Quartz data tied to the virtual instance's company, using the naming format (i.e. `<job name>@<company ID>`). We do not have to worry about migrating persisted system jobs since all of them are managed by the system itself and are scheduled during portal runtime and unscheduled during portal shutdown.

Also, for commit 54c89418c8ba81ac5e3289d0e0eb35198dc7b421, I added an upgrade process.