### PR TITLE
LPS-206492 Enforce usage of DB.getIndexResult()

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/DatabaseMetaDataCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/DatabaseMetaDataCheck.java
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.checkstyle.check;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author Kevin Lee
+ */
+public class DatabaseMetaDataCheck extends BaseCheck {
+
+	@Override
+	public int[] getDefaultTokens() {
+		return new int[] {TokenTypes.METHOD_CALL};
+	}
+
+	@Override
+	protected void doVisitToken(DetailAST detailAST) {
+		List<String> importNames = getImportNames(detailAST);
+
+		if (!importNames.contains("java.sql.DatabaseMetaData") ||
+			!Objects.equals(getMethodName(detailAST), "getIndexInfo")) {
+
+			return;
+		}
+
+		String variableName = getVariableName(detailAST);
+
+		if (variableName == null) {
+			return;
+		}
+
+		DetailAST variableDefinitionDetailAST = getVariableDefinitionDetailAST(
+			detailAST, variableName);
+
+		if (variableDefinitionDetailAST == null) {
+			return;
+		}
+
+		if (Objects.equals(
+				getVariableTypeName(
+					variableDefinitionDetailAST, variableName, false),
+				"DatabaseMetaData")) {
+
+			log(detailAST, _MSG_REPLACE_GET_INDEX_INFO, variableName);
+		}
+	}
+
+	private static final String _MSG_REPLACE_GET_INDEX_INFO =
+		"replace.get.index.info";
+
+}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/DatabaseMetaDataCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/DatabaseMetaDataCheck.java
@@ -23,6 +23,14 @@ public class DatabaseMetaDataCheck extends BaseCheck {
 
 	@Override
 	protected void doVisitToken(DetailAST detailAST) {
+		String absolutePath = getAbsolutePath();
+
+		if (absolutePath.contains("/com/liferay/portal/dao/db/") &&
+			absolutePath.endsWith("DB.java")) {
+
+			return;
+		}
+
 		List<String> importNames = getImportNames(detailAST);
 
 		if (!importNames.contains("java.sql.DatabaseMetaData") ||

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -337,6 +337,11 @@
 			<message key="builder.use" value="Use ''{0}'' ({1}, {2})" />
 			<message key="builder.use.instead" value="Use ''{0}'' instead of new instance of ''{1}''" />
 		</module>
+		<module name="com.liferay.source.formatter.checkstyle.check.DatabaseMetaDataCheck">
+			<property name="category" value="Bug Prevention" />
+			<property name="description" value="Checks usages of `java.sql.DatabaseMetaData`." />
+			<message key="replace.get.index.info" value="Use the method ''com.liferay.portal.kernel.dao.db.DB#getIndexResult()'' instead of ''{0}.getIndexInfo()''" />
+		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.DeprecatedAPICheck">
 			<property name="category" value="Bug Prevention" />
 			<property name="description" value="Finds calls to deprecated classes, constructors, fields or methods." />

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
@@ -60,6 +60,7 @@ ContractionsCheck | [Styling](styling_checks.markdown#styling-checks) | .java, .
 [CopyrightCheck](check/copyright_check.markdown#copyrightcheck) | [Styling](styling_checks.markdown#styling-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Validates `copyright` header. |
 [CreationMenuBuilderCheck](check/builder_check.markdown#buildercheck) | [Miscellaneous](miscellaneous_checks.markdown#miscellaneous-checks) | .java | Checks that `CreationMenuBuilder` is used when possible. |
 DTOEnumCreationCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Checks the creation of DTO enum. |
+DatabaseMetaDataCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Checks usages of `java.sql.DatabaseMetaData`. |
 [DefaultComesLastCheck](https://checkstyle.sourceforge.io/checks/coding/defaultcomeslast.html) | [Styling](styling_checks.markdown#styling-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks that the `default` is after all the cases in a `switch` statement. |
 DeprecatedAPICheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Finds calls to deprecated classes, constructors, fields or methods. |
 DockerfileEmptyLinesCheck | [Styling](styling_checks.markdown#styling-checks) | Dockerfile | Finds missing and unnecessary empty lines. |

--- a/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.markdown
@@ -30,6 +30,7 @@ ComponentAnnotationCheck | .java | Performs several checks on classes with @Comp
 [ComponentExposureCheck](check/component_exposure_check.markdown#componentexposurecheck) | .java | Avoid exposing static component. |
 ConsumerTypeAnnotationCheck | .java | Performs several checks on classes with @ConsumerType annotation. |
 DTOEnumCreationCheck | .java | Checks the creation of DTO enum. |
+DatabaseMetaDataCheck | .java | Checks usages of `java.sql.DatabaseMetaData`. |
 DeprecatedAPICheck | .java | Finds calls to deprecated classes, constructors, fields or methods. |
 EmptyConstructorCheck | .java | Finds unnecessary empty constructors. |
 ExceptionPrintStackTraceCheck | .java | Avoid using printStackTrace. |

--- a/modules/util/source-formatter/src/main/resources/documentation/check/database_metadata_check.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/check/database_metadata_check.markdown
@@ -1,0 +1,43 @@
+## DatabaseMetaDataCheck
+
+Using `java.sql.DatabaseMetaData#getIndexInfo()` can lead to unexpected errors
+and bugs depending on the current database. Instead, use
+`com.liferay.portal.kernel.dao.db.DB#getIndexResultSet()` to obtain database
+index information.
+
+### Example
+
+Incorrect:
+
+```java
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+
+...
+
+DatabaseMetaData databaseMetaData = connection.getMetaData();
+
+try (ResultSet indexResultSet = databaseMetaData.getIndexInfo(
+        catalog, schema, tableName, onlyUnique, false)) {
+	
+    doSomething(indexResultSet);
+}
+```
+
+Correct:
+
+```java
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+
+import java.sql.ResultSet;
+
+...
+
+DB db = DBManagerUtil.getDB();
+
+try (ResultSet indexResultSet = db.getIndexResultSet(
+        connection, tableName)) {
+
+    doSomething(indexResultSet);
+}
+```

--- a/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.markdown
@@ -28,6 +28,7 @@ ContractionsCheck | [Styling](styling_checks.markdown#styling-checks) | Finds co
 [CopyrightCheck](check/copyright_check.markdown#copyrightcheck) | [Styling](styling_checks.markdown#styling-checks) | Validates `copyright` header. |
 [CreationMenuBuilderCheck](check/builder_check.markdown#buildercheck) | [Miscellaneous](miscellaneous_checks.markdown#miscellaneous-checks) | Checks that `CreationMenuBuilder` is used when possible. |
 DTOEnumCreationCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Checks the creation of DTO enum. |
+DatabaseMetaDataCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Checks usages of `java.sql.DatabaseMetaData`. |
 [DefaultComesLastCheck](https://checkstyle.sourceforge.io/checks/coding/defaultcomeslast.html) | [Styling](styling_checks.markdown#styling-checks) | Checks that the `default` is after all the cases in a `switch` statement. |
 DeprecatedAPICheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds calls to deprecated classes, constructors, fields or methods. |
 EmptyCollectionCheck | [Styling](styling_checks.markdown#styling-checks) | Checks that there are no calls to `Collections.EMPTY_LIST`, `Collections.EMPTY_MAP` or `Collections.EMPTY_SET`. |


### PR DESCRIPTION
__Ticket:__ <https://liferay.atlassian.net/browse/LPS-206492>

This SF rule prevents direct usage of `java.sql.DatabaseMetaData#getIndexInfo()` and enforces `com.liferay.portal.kernel.dao.db.DB#getIndexResultSet()`. This is to prevent bugs like this: <https://liferay.atlassian.net/browse/LPS-206169>.

For now, I have not applied the SF rule (the changes will be applied here: <https://github.com/liferay-uniform/liferay-portal/pull/1699>).

Let me know if I need to make any changes.