### PR TITLE
LPD-1589 Use OracleDB getIndexResultSet

### DIFF
--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/upgrade/v1_1_0/CommercePriceEntryUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/upgrade/v1_1_0/CommercePriceEntryUpgradeProcess.java
@@ -10,6 +10,8 @@ import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPInstance;
 import com.liferay.commerce.product.service.CPDefinitionLocalService;
 import com.liferay.commerce.product.service.CPInstanceLocalService;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -18,7 +20,6 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 
-import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -119,10 +120,10 @@ public class CommercePriceEntryUpgradeProcess extends UpgradeProcess {
 	private boolean _tableHasIndex(String tableName, String indexName)
 		throws Exception {
 
-		DatabaseMetaData metadata = connection.getMetaData();
+		DB db = DBManagerUtil.getDB();
 
-		try (ResultSet resultSet = metadata.getIndexInfo(
-				null, null, tableName, false, false)) {
+		try (ResultSet resultSet = db.getIndexResultSet(
+				connection, tableName)) {
 
 			while (resultSet.next()) {
 				String curIndexName = resultSet.getString("index_name");

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v2_1_0/CPDAvailabilityEstimateUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v2_1_0/CPDAvailabilityEstimateUpgradeProcess.java
@@ -8,6 +8,8 @@ package com.liferay.commerce.internal.upgrade.v2_1_0;
 import com.liferay.commerce.model.impl.CPDAvailabilityEstimateModelImpl;
 import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.service.CPDefinitionLocalService;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -16,7 +18,6 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 
-import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -101,10 +102,10 @@ public class CPDAvailabilityEstimateUpgradeProcess extends UpgradeProcess {
 	private boolean _tableHasIndex(String tableName, String indexName)
 		throws Exception {
 
-		DatabaseMetaData metadata = connection.getMetaData();
+		DB db = DBManagerUtil.getDB();
 
-		try (ResultSet resultSet = metadata.getIndexInfo(
-				null, null, tableName, false, false)) {
+		try (ResultSet resultSet = db.getIndexResultSet(
+				connection, tableName)) {
 
 			while (resultSet.next()) {
 				String curIndexName = resultSet.getString("index_name");

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v2_1_0/CommerceOrderItemUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v2_1_0/CommerceOrderItemUpgradeProcess.java
@@ -10,6 +10,8 @@ import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPInstance;
 import com.liferay.commerce.product.service.CPDefinitionLocalService;
 import com.liferay.commerce.product.service.CPInstanceLocalService;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -18,7 +20,6 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 
-import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -108,10 +109,10 @@ public class CommerceOrderItemUpgradeProcess extends UpgradeProcess {
 	private boolean _tableHasIndex(String tableName, String indexName)
 		throws Exception {
 
-		DatabaseMetaData metadata = connection.getMetaData();
+		DB db = DBManagerUtil.getDB();
 
-		try (ResultSet resultSet = metadata.getIndexInfo(
-				null, null, tableName, false, false)) {
+		try (ResultSet resultSet = db.getIndexResultSet(
+				connection, tableName)) {
 
 			while (resultSet.next()) {
 				String curIndexName = resultSet.getString("index_name");

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v2_1_0/CommerceSubscriptionEntryUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v2_1_0/CommerceSubscriptionEntryUpgradeProcess.java
@@ -10,6 +10,8 @@ import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPInstance;
 import com.liferay.commerce.product.service.CPDefinitionLocalService;
 import com.liferay.commerce.product.service.CPInstanceLocalService;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -18,7 +20,6 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 
-import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -119,10 +120,10 @@ public class CommerceSubscriptionEntryUpgradeProcess extends UpgradeProcess {
 	private boolean _tableHasIndex(String tableName, String indexName)
 		throws Exception {
 
-		DatabaseMetaData metadata = connection.getMetaData();
+		DB db = DBManagerUtil.getDB();
 
-		try (ResultSet resultSet = metadata.getIndexInfo(
-				null, null, tableName, false, false)) {
+		try (ResultSet resultSet = db.getIndexResultSet(
+				connection, tableName)) {
 
 			while (resultSet.next()) {
 				String curIndexName = resultSet.getString("index_name");

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -611,7 +611,9 @@ public class DBTest {
 			_connection, _TABLE_NAME_1, "typeVarchar", false);
 
 		for (IndexMetadata indexMetadata : indexMetadatas) {
-			Assert.assertEquals("IX_TEMP", indexMetadata.getIndexName());
+			Assert.assertEquals(
+				_dbInspector.normalizeName("IX_TEMP"),
+				indexMetadata.getIndexName());
 		}
 	}
 

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -600,6 +600,22 @@ public class DBTest {
 	}
 
 	@Test
+	public void testGetIndexes() throws Exception {
+		_addIndex(new String[] {"typeVarchar", "typeBoolean"});
+
+		List<IndexMetadata> indexMetadatas = ReflectionTestUtil.invoke(
+			_db, "getIndexes",
+			new Class<?>[] {
+				Connection.class, String.class, String.class, boolean.class
+			},
+			_connection, _TABLE_NAME_1, "typeVarchar", false);
+
+		for (IndexMetadata indexMetadata : indexMetadatas) {
+			Assert.assertEquals("IX_TEMP", indexMetadata.getIndexName());
+		}
+	}
+
+	@Test
 	public void testGetPrimaryKeyColumnNames() throws Exception {
 		_db.runSQL(_SQL_CREATE_TABLE_2);
 

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/OracleDBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/OracleDBTest.java
@@ -1,0 +1,136 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.dao.db.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.dao.db.IndexMetadata;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.AssumeTestRule;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jorge Avalos
+ */
+@RunWith(Arquillian.class)
+public class OracleDBTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
+
+	public static void assume() {
+		_db = DBManagerUtil.getDB();
+
+		Assume.assumeTrue(_db.getDBType() == DBType.ORACLE);
+	}
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_connection = DataAccess.getConnection();
+
+		_db = DBManagerUtil.getDB();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		DataAccess.cleanUp(_connection);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_createTestTable(_TABLE_NAME_1);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_db.runSQL("DROP_TABLE_IF_EXISTS(" + _TABLE_NAME_1 + ")");
+	}
+
+	@Test
+	public void testGetIndexesWithLockedStatisticsTable() throws Exception {
+		_addIndex(new String[] {"typeVarchar", "typeBoolean"});
+
+		try (Statement statement = _connection.createStatement()) {
+			statement.execute(
+				StringBundler.concat(
+					"CALL dbms_stats.lock_table_stats(ownname => '",
+					_connection.getSchema(), "', tabname => '", _TABLE_NAME_1,
+					"')"));
+
+			List<IndexMetadata> indexMetadatas = ReflectionTestUtil.invoke(
+				_db, "getIndexes",
+				new Class<?>[] {
+					Connection.class, String.class, String.class, boolean.class
+				},
+				_connection, _TABLE_NAME_1, "typeVarchar", false);
+
+			for (IndexMetadata indexMetadata : indexMetadatas) {
+				Assert.assertEquals("IX_TEMP", indexMetadata.getIndexName());
+			}
+
+			statement.execute(
+				StringBundler.concat(
+					"CALL dbms_stats.unlock_table_stats(ownname => '",
+					_connection.getSchema(), "', tabname => '", _TABLE_NAME_1,
+					"')"));
+		}
+	}
+
+	private void _addIndex(String[] columnNames) {
+		List<IndexMetadata> indexMetadatas = Arrays.asList(
+			new IndexMetadata(_INDEX_NAME, _TABLE_NAME_1, false, columnNames));
+
+		ReflectionTestUtil.invoke(
+			_db, "addIndexes", new Class<?>[] {Connection.class, List.class},
+			_connection, indexMetadatas);
+	}
+
+	private void _createTestTable(String tableName) throws Exception {
+		_db.runSQL(
+			StringBundler.concat(
+				"create table ", tableName, " (id LONG not null primary key, ",
+				"notNilColumn VARCHAR(75) not null, nilColumn VARCHAR(75) ",
+				"null , typeBlob BLOB, typeBoolean BOOLEAN, typeDate DATE ",
+				"null, typeDouble DOUBLE, typeInteger INTEGER, typeLong LONG ",
+				"null, typeLongDefault LONG default 10 not null, typeSBlob ",
+				"SBLOB, typeString STRING null, typeText TEXT null, ",
+				"typeVarchar VARCHAR(75) null, typeVarcharDefault VARCHAR(10) ",
+				"default 'testValue' not null);"));
+	}
+
+	private static final String _INDEX_NAME = "IX_TEMP";
+
+	private static final String _TABLE_NAME_1 = "DBTest1";
+
+	private static Connection _connection;
+	private static DB _db;
+
+}

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/OracleDBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/OracleDBTest.java
@@ -8,6 +8,7 @@ package com.liferay.portal.dao.db.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
@@ -48,6 +49,8 @@ public class OracleDBTest {
 
 	public static void assume() {
 		_db = DBManagerUtil.getDB();
+
+		_dbInspector = new DBInspector(_connection);
 
 		Assume.assumeTrue(_db.getDBType() == DBType.ORACLE);
 	}
@@ -93,7 +96,9 @@ public class OracleDBTest {
 				_connection, _TABLE_NAME_1, "typeVarchar", false);
 
 			for (IndexMetadata indexMetadata : indexMetadatas) {
-				Assert.assertEquals("IX_TEMP", indexMetadata.getIndexName());
+				Assert.assertEquals(
+					_dbInspector.normalizeName("IX_TEMP"),
+					indexMetadata.getIndexName());
 			}
 
 			statement.execute(
@@ -132,5 +137,6 @@ public class OracleDBTest {
 
 	private static Connection _connection;
 	private static DB _db;
+	private static DBInspector _dbInspector;
 
 }

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -15,6 +15,7 @@ import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.configuration.Filter;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.Index;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
@@ -1260,6 +1261,8 @@ public abstract class BaseDB implements DB {
 
 		DatabaseMetaData databaseMetaData = connection.getMetaData();
 
+		DB db = DBManagerUtil.getDB();
+
 		DBInspector dbInspector = new DBInspector(connection);
 
 		String catalog = dbInspector.getCatalog();
@@ -1286,9 +1289,8 @@ public abstract class BaseDB implements DB {
 				normalizedTableName = dbInspector.normalizeName(
 					tableResultSet.getString("TABLE_NAME"), databaseMetaData);
 
-				try (ResultSet indexResultSet = databaseMetaData.getIndexInfo(
-						catalog, schema, normalizedTableName, onlyUnique,
-						false)) {
+				try (ResultSet indexResultSet = db.getIndexResultSet(
+						connection, normalizedTableName)) {
 
 					boolean unique = false;
 

--- a/test.properties
+++ b/test.properties
@@ -10024,10 +10024,12 @@
     #
 
     test.batch.class.names.includes[upgrade]=\
+        **/portal-dao-test/**/*Test.java,\
         **/portal-db-partition-test/**/*Test.java,\
         **/portal-tools-db-partition*/**/*Test.java,\
         **/portal-upgrade-impl/**/*Test.java,\
-        **/portal-upgrade-test/**/*Test.java
+        **/portal-upgrade-test/**/*Test.java,\
+        **/testIntegration/**/upgrade/**/Release*Test.java
 
     test.batch.dist.app.servers[upgrade]=tomcat
 


### PR DESCRIPTION
Ticket:
[LPD-1589](https://liferay.atlassian.net/browse/LPD-1589)
Issue:
If a customer has locked the statistics for a table(Oracle Only) then the indexeResultSet cannot be aquired.
This was already handled in LPS-141855.

This fix just applies the same method in places where the old method was used.

A source format rule was added here:
https://liferay.atlassian.net/browse/LPS-206492

A test was added for getIndexResultSet.