### PR TITLE
LPD-4218 Support app server dir with and without version

### DIFF
--- a/modules/util/portal-tools-db-upgrade-client/properties/portal-upgrade-database.properties
+++ b/modules/util/portal-tools-db-upgrade-client/properties/portal-upgrade-database.properties
@@ -51,12 +51,3 @@
     #jdbc.default.url=jdbc:sqlserver://localhost;databaseName=lportal;useBulkCopyForBatchInsert=true
     #jdbc.default.username=sa
     #jdbc.default.password=
-
-##
-## Sybase
-##
-
-    #jdbc.default.driverClassName=com.sybase.jdbc4.jdbc.SybDriver
-    #jdbc.default.url=jdbc:sybase:Tds:localhost:5000/lportal
-    #jdbc.default.username=sa
-    #jdbc.default.password=

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
@@ -18,26 +18,25 @@ public class AppServer {
 
 	public static AppServer getJBossEAPAppServer() {
 		return new AppServer(
-			"../../jboss-eap-7.1.0", _getJBossExtraLibDirNames(),
+			"jboss-eap", _getJBossExtraLibDirNames(),
 			"/modules/com/liferay/portal/main",
 			"/standalone/deployments/ROOT.war", "jboss");
 	}
 
 	public static AppServer getTomcatAppServer() {
 		return new AppServer(
-			"../../tomcat-9.0.83", "/bin", "/lib", "/webapps/ROOT", "tomcat");
+			"tomcat", "/bin", "/lib", "/webapps/ROOT", "tomcat");
 	}
 
 	public static AppServer getWebLogicAppServer() {
 		return new AppServer(
-			"../../weblogic-12.2.1", "/wlserver/modules",
-			"/domains/liferay/lib", "/domains/liferay/autodeploy/ROOT",
-			"weblogic");
+			"weblogic", "/wlserver/modules", "/domains/liferay/lib",
+			"/domains/liferay/autodeploy/ROOT", "weblogic");
 	}
 
 	public static AppServer getWebSphereAppServer() {
 		return new AppServer(
-			"../../websphere-9.0.0.0", "", "/lib",
+			"websphere", "", "/lib",
 			"/profiles/liferay/installedApps/liferay-cell/liferay-portal.ear" +
 				"/liferay-portal.war",
 			"websphere");
@@ -45,7 +44,7 @@ public class AppServer {
 
 	public static AppServer getWildFlyAppServer() {
 		return new AppServer(
-			"../../wildfly-16.0.0", _getJBossExtraLibDirNames(),
+			"wildfly", _getJBossExtraLibDirNames(),
 			"/modules/com/liferay/portal/main",
 			"/standalone/deployments/ROOT.war", "wildfly");
 	}

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
@@ -141,13 +141,13 @@ public class AppServer {
 	private static String _getAppServerDirName(
 		String basePath, String dirName) {
 
-		File basePathFolder = new File(basePath);
+		File baseDir = new File(basePath);
 
-		if (basePathFolder.isDirectory()) {
-			File[] folders = basePathFolder.listFiles();
+		if (baseDir.isDirectory()) {
+			File[] files = baseDir.listFiles();
 
-			if (folders != null) {
-				for (File file : folders) {
+			if (files != null) {
+				for (File file : files) {
 					if (file.isDirectory() &&
 						(Objects.equals(file.getName(), dirName) ||
 						 file.getName(

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
@@ -8,15 +8,6 @@ package com.liferay.portal.tools.db.upgrade.client;
 import java.io.File;
 import java.io.IOException;
 
-import java.net.URISyntaxException;
-import java.net.URL;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
-import java.security.CodeSource;
-import java.security.ProtectionDomain;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -146,10 +137,6 @@ public class AppServer {
 
 		File basePathFolder = new File(basePath);
 
-		if (!basePathFolder.isAbsolute()) {
-			basePathFolder = new File(_jarDir, basePath);
-		}
-
 		if (basePathFolder.isDirectory()) {
 			File[] folders = basePathFolder.listFiles();
 
@@ -204,28 +191,6 @@ public class AppServer {
 		}
 		catch (IOException ioException) {
 			ioException.printStackTrace();
-		}
-	}
-
-	private static File _jarDir;
-
-	static {
-		ProtectionDomain protectionDomain =
-			AppServer.class.getProtectionDomain();
-
-		CodeSource codeSource = protectionDomain.getCodeSource();
-
-		URL url = codeSource.getLocation();
-
-		try {
-			Path path = Paths.get(url.toURI());
-
-			File jarFile = path.toFile();
-
-			_jarDir = jarFile.getParentFile();
-		}
-		catch (URISyntaxException uriSyntaxException) {
-			throw new ExceptionInInitializerError(uriSyntaxException);
 		}
 	}
 

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
@@ -17,39 +17,45 @@ import java.util.Objects;
  */
 public class AppServer {
 
-	public static AppServer getJBossEAPAppServer() {
-		return new AppServer(
-			_getAppServerDirName("../../", "jboss-eap"),
-			_getJBossExtraLibDirNames(), "/modules/com/liferay/portal/main",
-			"/standalone/deployments/ROOT.war", "jboss");
-	}
+	public static AppServer getAppServer(
+		String liferayHomeDir, String appServerName) {
 
-	public static AppServer getTomcatAppServer() {
-		return new AppServer(
-			_getAppServerDirName("../../", "tomcat"), "/bin", "/lib",
-			"/webapps/ROOT", "tomcat");
-	}
+		if (appServerName.equals("jboss")) {
+			return new AppServer(
+				_getAppServerDirName(liferayHomeDir, "jboss-eap"),
+				_getJBossExtraLibDirNames(), "/modules/com/liferay/portal/main",
+				"/standalone/deployments/ROOT.war", appServerName);
+		}
 
-	public static AppServer getWebLogicAppServer() {
-		return new AppServer(
-			_getAppServerDirName("../../", "weblogic"), "/wlserver/modules",
-			"/domains/liferay/lib", "/domains/liferay/autodeploy/ROOT",
-			"weblogic");
-	}
+		if (appServerName.equals("tomcat")) {
+			return new AppServer(
+				_getAppServerDirName(liferayHomeDir, "tomcat"), "/bin", "/lib",
+				"/webapps/ROOT", appServerName);
+		}
 
-	public static AppServer getWebSphereAppServer() {
-		return new AppServer(
-			_getAppServerDirName("../../", "websphere"), "", "/lib",
-			"/profiles/liferay/installedApps/liferay-cell/liferay-portal.ear" +
-				"/liferay-portal.war",
-			"websphere");
-	}
+		if (appServerName.equals("weblogic")) {
+			return new AppServer(
+				_getAppServerDirName(liferayHomeDir, "weblogic"),
+				"/wlserver/modules", "/domains/liferay/lib",
+				"/domains/liferay/autodeploy/ROOT", appServerName);
+		}
 
-	public static AppServer getWildFlyAppServer() {
-		return new AppServer(
-			_getAppServerDirName("../../", "wildfly"),
-			_getJBossExtraLibDirNames(), "/modules/com/liferay/portal/main",
-			"/standalone/deployments/ROOT.war", "wildfly");
+		if (appServerName.equals("websphere")) {
+			return new AppServer(
+				_getAppServerDirName(liferayHomeDir, "websphere"), "", "/lib",
+				"/profiles/liferay/installedApps/liferay-cell" +
+					"/liferay-portal.ear/liferay-portal.war",
+				appServerName);
+		}
+
+		if (appServerName.equals("wildfly")) {
+			return new AppServer(
+				_getAppServerDirName(liferayHomeDir, "wildfly"),
+				_getJBossExtraLibDirNames(), "/modules/com/liferay/portal/main",
+				"/standalone/deployments/ROOT.war", appServerName);
+		}
+
+		return null;
 	}
 
 	public AppServer(

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
@@ -23,13 +23,6 @@ public class AppServer {
 			"/standalone/deployments/ROOT.war", "jboss");
 	}
 
-	public static AppServer getTCServerAppServer() {
-		return new AppServer(
-			"../../../../tc-server-4.0.2",
-			"/runtimes/tomcat-9.0.10.A.RELEASE/lib", "/instances/liferay/lib",
-			"/instances/liferay/webapps/ROOT", "tomcat");
-	}
-
 	public static AppServer getTomcatAppServer() {
 		return new AppServer(
 			"../../tomcat-9.0.83", "/bin", "/lib", "/webapps/ROOT", "tomcat");

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/AppServer.java
@@ -8,8 +8,18 @@ package com.liferay.portal.tools.db.upgrade.client;
 import java.io.File;
 import java.io.IOException;
 
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author David Truong
@@ -18,25 +28,27 @@ public class AppServer {
 
 	public static AppServer getJBossEAPAppServer() {
 		return new AppServer(
-			"jboss-eap", _getJBossExtraLibDirNames(),
-			"/modules/com/liferay/portal/main",
+			_getAppServerDirName("../../", "jboss-eap"),
+			_getJBossExtraLibDirNames(), "/modules/com/liferay/portal/main",
 			"/standalone/deployments/ROOT.war", "jboss");
 	}
 
 	public static AppServer getTomcatAppServer() {
 		return new AppServer(
-			"tomcat", "/bin", "/lib", "/webapps/ROOT", "tomcat");
+			_getAppServerDirName("../../", "tomcat"), "/bin", "/lib",
+			"/webapps/ROOT", "tomcat");
 	}
 
 	public static AppServer getWebLogicAppServer() {
 		return new AppServer(
-			"weblogic", "/wlserver/modules", "/domains/liferay/lib",
-			"/domains/liferay/autodeploy/ROOT", "weblogic");
+			_getAppServerDirName("../../", "weblogic"), "/wlserver/modules",
+			"/domains/liferay/lib", "/domains/liferay/autodeploy/ROOT",
+			"weblogic");
 	}
 
 	public static AppServer getWebSphereAppServer() {
 		return new AppServer(
-			"websphere", "", "/lib",
+			_getAppServerDirName("../../", "websphere"), "", "/lib",
 			"/profiles/liferay/installedApps/liferay-cell/liferay-portal.ear" +
 				"/liferay-portal.war",
 			"websphere");
@@ -44,8 +56,8 @@ public class AppServer {
 
 	public static AppServer getWildFlyAppServer() {
 		return new AppServer(
-			"wildfly", _getJBossExtraLibDirNames(),
-			"/modules/com/liferay/portal/main",
+			_getAppServerDirName("../../", "wildfly"),
+			_getJBossExtraLibDirNames(), "/modules/com/liferay/portal/main",
 			"/standalone/deployments/ROOT.war", "wildfly");
 	}
 
@@ -129,6 +141,41 @@ public class AppServer {
 		_portalDirName = portalDirName;
 	}
 
+	private static String _getAppServerDirName(
+		String basePath, String dirName) {
+
+		File basePathFolder = new File(basePath);
+
+		if (!basePathFolder.isAbsolute()) {
+			basePathFolder = new File(_jarDir, basePath);
+		}
+
+		if (basePathFolder.isDirectory()) {
+			File[] folders = basePathFolder.listFiles();
+
+			if (folders != null) {
+				for (File file : folders) {
+					if (file.isDirectory() &&
+						(Objects.equals(file.getName(), dirName) ||
+						 file.getName(
+						 ).startsWith(
+							 dirName + "-"
+						 ))) {
+
+						try {
+							return file.getCanonicalPath();
+						}
+						catch (IOException ioException) {
+							ioException.printStackTrace();
+						}
+					}
+				}
+			}
+		}
+
+		return dirName;
+	}
+
 	private static String _getJBossExtraLibDirNames() {
 		StringBuilder sb = new StringBuilder();
 
@@ -157,6 +204,28 @@ public class AppServer {
 		}
 		catch (IOException ioException) {
 			ioException.printStackTrace();
+		}
+	}
+
+	private static File _jarDir;
+
+	static {
+		ProtectionDomain protectionDomain =
+			AppServer.class.getProtectionDomain();
+
+		CodeSource codeSource = protectionDomain.getCodeSource();
+
+		URL url = codeSource.getLocation();
+
+		try {
+			Path path = Paths.get(url.toURI());
+
+			File jarFile = path.toFile();
+
+			_jarDir = jarFile.getParentFile();
+		}
+		catch (URISyntaxException uriSyntaxException) {
+			throw new ExceptionInInitializerError(uriSyntaxException);
 		}
 	}
 

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
@@ -29,10 +29,8 @@ import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -622,7 +620,7 @@ public class DBUpgradeClient {
 		while (dataSource == null) {
 			System.out.print("[ ");
 
-			for (String database : _databases.keySet()) {
+			for (String database : _databases) {
 				System.out.print(database + " ");
 			}
 
@@ -636,7 +634,7 @@ public class DBUpgradeClient {
 				response = "mysql";
 			}
 
-			dataSource = _databases.get(response);
+			dataSource = Database.getDatabase(response);
 
 			if (dataSource == null) {
 				System.err.println(response + " is an unsupported database.");
@@ -760,18 +758,10 @@ public class DBUpgradeClient {
 
 	private static final Set<String> _appServers = new LinkedHashSet<>(
 		Arrays.asList("jboss", "tomcat", "weblogic", "websphere", "wildfly"));
-	private static final Map<String, Database> _databases =
-		new LinkedHashMap<String, Database>() {
-			{
-				put("db2", Database.getDB2Database());
-				put("mariadb", Database.getMariaDBDatabase());
-				put("mysql", Database.getMySQLDatabase());
-				put("oracle", Database.getOracleDataSource());
-				put("postgresql", Database.getPostgreSQLDatabase());
-				put("sqlserver", Database.getSQLServerDatabase());
-				put("sybase", Database.getSybaseDatabase());
-			}
-		};
+	private static final Set<String> _databases = new LinkedHashSet<>(
+		Arrays.asList(
+			"db2", "mariadb", "mysql", "oracle", "postgresql", "sqlserver",
+			"sybase"));
 	private static final Pattern _gogoShellAddressPattern = Pattern.compile(
 		"^([^\\:]+):([0-9]{1,5})$");
 	private static File _jarDir;

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
@@ -693,13 +693,13 @@ public class DBUpgradeClient {
 		}
 
 		System.out.println(
-			"Please enter your database name (" + dataSource.getDatabaseName() +
+			"Please enter your database name (" + dataSource.getSchemaName() +
 				"): ");
 
 		response = _consoleReader.readLine();
 
 		if (!response.isEmpty()) {
-			dataSource.setDatabaseName(response);
+			dataSource.setSchemaName(response);
 		}
 
 		System.out.println("Please enter your database username: ");

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
@@ -755,7 +755,6 @@ public class DBUpgradeClient {
 		new LinkedHashMap<String, AppServer>() {
 			{
 				put("jboss", AppServer.getJBossEAPAppServer());
-				put("tcserver", AppServer.getTCServerAppServer());
 				put("tomcat", AppServer.getTomcatAppServer());
 				put("weblogic", AppServer.getWebLogicAppServer());
 				put("websphere", AppServer.getWebSphereAppServer());

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
@@ -760,8 +760,7 @@ public class DBUpgradeClient {
 		Arrays.asList("jboss", "tomcat", "weblogic", "websphere", "wildfly"));
 	private static final Set<String> _databases = new LinkedHashSet<>(
 		Arrays.asList(
-			"db2", "mariadb", "mysql", "oracle", "postgresql", "sqlserver",
-			"sybase"));
+			"db2", "mariadb", "mysql", "oracle", "postgresql", "sqlserver"));
 	private static final Pattern _gogoShellAddressPattern = Pattern.compile(
 		"^([^\\:]+):([0-9]{1,5})$");
 	private static File _jarDir;

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
@@ -27,10 +27,13 @@ import java.security.CodeSource;
 import java.security.ProtectionDomain;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -297,9 +300,11 @@ public class DBUpgradeClient {
 		}
 
 		try {
-			_verifyAppServerProperties();
-			_verifyPortalUpgradeDatabaseProperties();
 			_verifyPortalUpgradeExtProperties();
+
+			_verifyAppServerProperties();
+
+			_verifyPortalUpgradeDatabaseProperties();
 
 			_saveProperties();
 		}
@@ -502,7 +507,7 @@ public class DBUpgradeClient {
 			while (_appServer == null) {
 				System.out.print("[ ");
 
-				for (String appServer : _appServers.keySet()) {
+				for (String appServer : _appServers) {
 					System.out.print(appServer + " ");
 				}
 
@@ -516,7 +521,9 @@ public class DBUpgradeClient {
 					response = "tomcat";
 				}
 
-				_appServer = _appServers.get(response);
+				_appServer = AppServer.getAppServer(
+					_portalUpgradeExtProperties.getProperty("liferay.home"),
+					response);
 
 				if (_appServer == null) {
 					System.err.println(
@@ -751,16 +758,8 @@ public class DBUpgradeClient {
 
 	private static final String _JAVA_HOME = System.getenv("JAVA_HOME");
 
-	private static final Map<String, AppServer> _appServers =
-		new LinkedHashMap<String, AppServer>() {
-			{
-				put("jboss", AppServer.getJBossEAPAppServer());
-				put("tomcat", AppServer.getTomcatAppServer());
-				put("weblogic", AppServer.getWebLogicAppServer());
-				put("websphere", AppServer.getWebSphereAppServer());
-				put("wildfly", AppServer.getWildFlyAppServer());
-			}
-		};
+	private static final Set<String> _appServers = new LinkedHashSet<>(
+		Arrays.asList("jboss", "tomcat", "weblogic", "websphere", "wildfly"));
 	private static final Map<String, Database> _databases =
 		new LinkedHashMap<String, Database>() {
 			{

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/Database.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/Database.java
@@ -10,54 +10,58 @@ package com.liferay.portal.tools.db.upgrade.client;
  */
 public class Database {
 
-	public static Database getDB2Database() {
-		return new Database(
-			"com.ibm.db2.jcc.DB2Driver", "jdbc:db2://", "localhost", 50000,
-			"lportal",
-			":deferPrepares=false;fullyMaterializeInputStreams=true;" +
-				"fullyMaterializeLobData=true;progresssiveLocators=2;" +
-					"progressiveStreaming=2;");
-	}
+	public static Database getDatabase(String databaseName) {
+		if (databaseName.equals("db2")) {
+			return new Database(
+				"com.ibm.db2.jcc.DB2Driver", "jdbc:db2://", "localhost", 50000,
+				"lportal",
+				":deferPrepares=false;fullyMaterializeInputStreams=true;" +
+					"fullyMaterializeLobData=true;progresssiveLocators=2;" +
+						"progressiveStreaming=2;");
+		}
 
-	public static Database getMariaDBDatabase() {
-		return new Database(
-			"org.mariadb.jdbc.Driver", "jdbc:mariadb://", "localhost", 0,
-			"lportal",
-			"?useUnicode=true&characterEncoding=UTF-8" +
-				"&useFastDateParsing=false");
-	}
+		if (databaseName.equals("mariadb")) {
+			return new Database(
+				"org.mariadb.jdbc.Driver", "jdbc:mariadb://", "localhost", 0,
+				"lportal",
+				"?useUnicode=true&characterEncoding=UTF-8" +
+					"&useFastDateParsing=false");
+		}
 
-	public static Database getMySQLDatabase() {
-		return new Database(
-			"com.mysql.cj.jdbc.Driver", "jdbc:mysql://", "localhost", 0,
-			"lportal",
-			"?characterEncoding=UTF-8&dontTrackOpenResources=true" +
-				"&holdResultsOpenOverStatementClose=true&serverTimezone=GMT" +
-					"&useFastDateParsing=false&useUnicode=true");
-	}
+		if (databaseName.equals("mysql")) {
+			return new Database(
+				"com.mysql.cj.jdbc.Driver", "jdbc:mysql://", "localhost", 0,
+				"lportal",
+				"?characterEncoding=UTF-8&dontTrackOpenResources=true" +
+					"&holdResultsOpenOverStatementClose=true&serverTimezone=" +
+						"GMT&useFastDateParsing=false&useUnicode=true");
+		}
 
-	public static Database getOracleDataSource() {
-		return new Database(
-			"oracle.jdbc.OracleDriver", "jdbc:oracle:thin:@", "localhost", 1521,
-			"xe", "");
-	}
+		if (databaseName.equals("oracle")) {
+			return new Database(
+				"oracle.jdbc.OracleDriver", "jdbc:oracle:thin:@", "localhost",
+				1521, "xe", "");
+		}
 
-	public static Database getPostgreSQLDatabase() {
-		return new Database(
-			"org.postgresql.Driver", "jdbc:postgresql://", "localhost", 5432,
-			"lportal", "");
-	}
+		if (databaseName.equals("postgresql")) {
+			return new Database(
+				"org.postgresql.Driver", "jdbc:postgresql://", "localhost",
+				5432, "lportal", "");
+		}
 
-	public static Database getSQLServerDatabase() {
-		return new Database(
-			"com.microsoft.sqlserver.jdbc.SQLServerDriver", "jdbc:sqlserver://",
-			"localhost", 0, "lportal", "");
-	}
+		if (databaseName.equals("sqlserver")) {
+			return new Database(
+				"com.microsoft.sqlserver.jdbc.SQLServerDriver",
+				"jdbc:sqlserver://", "localhost", 0, "lportal", "");
+		}
 
-	public static Database getSybaseDatabase() {
-		return new Database(
-			"com.sybase.jdbc4.jdbc.SybDriver", "jdbc:sybase:Tds:", "localhost",
-			5000, "lportal", "");
+		if (databaseName.equals("sybase")) {
+			return new Database(
+				"com.sybase.jdbc4.jdbc.SybDriver", "jdbc:sybase:Tds:",
+				"localhost", 5000, "lportal", "");
+		}
+
+		return null;
 	}
 
 	public String getClassName() {

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/Database.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/Database.java
@@ -55,12 +55,6 @@ public class Database {
 				"jdbc:sqlserver://", "localhost", 0, "lportal", "");
 		}
 
-		if (databaseName.equals("sybase")) {
-			return new Database(
-				"com.sybase.jdbc4.jdbc.SybDriver", "jdbc:sybase:Tds:",
-				"localhost", 5000, "lportal", "");
-		}
-
 		return null;
 	}
 

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/Database.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/Database.java
@@ -68,10 +68,6 @@ public class Database {
 		return _className;
 	}
 
-	public String getDatabaseName() {
-		return _databaseName;
-	}
-
 	public String getHost() {
 		return _host;
 	}
@@ -82,6 +78,10 @@ public class Database {
 
 	public String getProtocol() {
 		return _protocol;
+	}
+
+	public String getSchemaName() {
+		return _schemaName;
 	}
 
 	public String getURL() {
@@ -105,7 +105,7 @@ public class Database {
 			sb.append("/");
 		}
 
-		sb.append(_databaseName);
+		sb.append(_schemaName);
 		sb.append(_params);
 
 		return sb.toString();
@@ -113,10 +113,6 @@ public class Database {
 
 	public void setClassName(String className) {
 		_className = className;
-	}
-
-	public void setDatabaseName(String databaseName) {
-		_databaseName = databaseName;
 	}
 
 	public void setHost(String host) {
@@ -135,6 +131,10 @@ public class Database {
 		_protocol = protocol;
 	}
 
+	public void setSchemaName(String schemaName) {
+		_schemaName = schemaName;
+	}
+
 	private Database(
 		String className, String protocol, String host, int port,
 		String databaseName, String params) {
@@ -143,15 +143,16 @@ public class Database {
 		_protocol = protocol;
 		_host = host;
 		_port = port;
-		_databaseName = databaseName;
 		_params = params;
+
+		_schemaName = databaseName;
 	}
 
 	private String _className;
-	private String _databaseName;
 	private String _host;
 	private String _params;
 	private int _port;
 	private String _protocol;
+	private String _schemaName;
 
 }

--- a/modules/util/portal-tools-db-upgrade-client/src/test/java/com/liferay/portal/tools/db/upgrade/client/util/AppServerTest.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/test/java/com/liferay/portal/tools/db/upgrade/client/util/AppServerTest.java
@@ -54,10 +54,10 @@ public class AppServerTest {
 
 	@Test
 	public void testNewAppServer() {
-		File dirFile = new File(
+		File dir = new File(
 			temporaryFolder.getRoot(), RandomTestUtil.randomString());
 
-		dirFile.mkdir();
+		dir.mkdir();
 
 		String extraDirLibName = RandomTestUtil.randomString();
 		String globalDirLibName = RandomTestUtil.randomString();
@@ -65,30 +65,30 @@ public class AppServerTest {
 		String serverDetectorServerId = RandomTestUtil.randomString();
 
 		AppServer appServer = new AppServer(
-			dirFile.getAbsolutePath(), extraDirLibName, globalDirLibName,
+			dir.getAbsolutePath(), extraDirLibName, globalDirLibName,
 			portalDirName, serverDetectorServerId);
 
 		_assertAppServer(
-			appServer, dirFile, extraDirLibName, globalDirLibName,
-			portalDirName, serverDetectorServerId);
+			appServer, dir, extraDirLibName, globalDirLibName, portalDirName,
+			serverDetectorServerId);
 
-		dirFile = new File(
+		dir = new File(
 			temporaryFolder.getRoot(), RandomTestUtil.randomString());
 
-		dirFile.mkdir();
+		dir.mkdir();
 
 		extraDirLibName = RandomTestUtil.randomString();
 		globalDirLibName = RandomTestUtil.randomString();
 		portalDirName = RandomTestUtil.randomString();
 
-		appServer.setDirName(dirFile.getAbsolutePath());
+		appServer.setDirName(dir.getAbsolutePath());
 		appServer.setPortalDirName(portalDirName);
 		appServer.setExtraLibDirNames(extraDirLibName);
 		appServer.setGlobalLibDirName(globalDirLibName);
 
 		_assertAppServer(
-			appServer, dirFile, extraDirLibName, globalDirLibName,
-			portalDirName, serverDetectorServerId);
+			appServer, dir, extraDirLibName, globalDirLibName, portalDirName,
+			serverDetectorServerId);
 	}
 
 	private void _assertAppServer(

--- a/modules/util/portal-tools-db-upgrade-client/src/test/java/com/liferay/portal/tools/db/upgrade/client/util/AppServerTest.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/test/java/com/liferay/portal/tools/db/upgrade/client/util/AppServerTest.java
@@ -1,0 +1,148 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.tools.db.upgrade.client.util;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.tools.db.upgrade.client.AppServer;
+
+import java.io.File;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * @author Jorge Avalos
+ */
+public class AppServerTest {
+
+	@ClassRule
+	public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@BeforeClass
+	public static void setUpClass() {
+		File jarLocation = new File(
+			temporaryFolder.getRoot(), "tools/upgradeclient");
+
+		jarLocation.mkdirs();
+
+		ReflectionTestUtil.setFieldValue(
+			AppServer.class, "_jarDir", jarLocation);
+	}
+
+	@Test
+	public void testGetCustomAppServer() {
+		File dirFile = new File(
+			temporaryFolder.getRoot(), RandomTestUtil.randomString());
+
+		dirFile.mkdir();
+
+		String extraDirLibNames = RandomTestUtil.randomString();
+		String globalDirLibNames = RandomTestUtil.randomString();
+		String portalDirName = RandomTestUtil.randomString();
+		String serverDetectorServerId = RandomTestUtil.randomString();
+
+		AppServer appServer = new AppServer(
+			dirFile.getAbsolutePath(), extraDirLibNames, globalDirLibNames,
+			portalDirName, serverDetectorServerId);
+
+		_assert(
+			appServer, dirFile, extraDirLibNames, globalDirLibNames,
+			portalDirName, serverDetectorServerId);
+
+		dirFile = new File(
+			temporaryFolder.getRoot(), RandomTestUtil.randomString());
+
+		dirFile.mkdir();
+
+		extraDirLibNames = RandomTestUtil.randomString();
+		globalDirLibNames = RandomTestUtil.randomString();
+		portalDirName = RandomTestUtil.randomString();
+
+		appServer.setDirName(dirFile.getAbsolutePath());
+		appServer.setPortalDirName(portalDirName);
+		appServer.setExtraLibDirNames(extraDirLibNames);
+		appServer.setGlobalLibDirName(globalDirLibNames);
+
+		_assert(
+			appServer, dirFile, extraDirLibNames, globalDirLibNames,
+			portalDirName, serverDetectorServerId);
+	}
+
+	@Test
+	public void testGetTomcatAppServer() {
+		File dirFile = new File(temporaryFolder.getRoot(), "tomcat");
+
+		dirFile.mkdir();
+
+		AppServer appServer = AppServer.getTomcatAppServer();
+
+		_assert(
+			appServer, dirFile, "bin", "lib",
+			"webapps" + File.separator + "ROOT", "tomcat");
+
+		dirFile.delete();
+
+		dirFile = new File(temporaryFolder.getRoot(), "tomcat-9.0.80");
+
+		dirFile.mkdirs();
+
+		appServer = AppServer.getTomcatAppServer();
+
+		_assert(
+			appServer, dirFile, "bin", "lib",
+			"webapps" + File.separator + "ROOT", "tomcat");
+	}
+
+	private void _assert(
+		AppServer appServer, File dirFile, String extraDirLibName,
+		String globalDirLibName, String portalDirName,
+		String serverDetectorServerId) {
+
+		Assert.assertEquals(dirFile, appServer.getDir());
+
+		File portalDir = new File(dirFile, portalDirName);
+
+		Assert.assertEquals(portalDir, appServer.getPortalDir());
+
+		File portalClassesDir = new File(
+			portalDir, "WEB-INF" + File.separator + "classes");
+
+		Assert.assertEquals(portalClassesDir, appServer.getPortalClassesDir());
+
+		File portalLibDir = new File(
+			portalDir, "WEB-INF" + File.separator + "lib");
+
+		Assert.assertEquals(portalLibDir, appServer.getPortalLibDir());
+
+		File portalShieldContainerLibDir = new File(
+			portalDir, "WEB-INF" + File.separator + "shielded-container-lib");
+
+		Assert.assertEquals(
+			portalShieldContainerLibDir,
+			appServer.getPortalShieldedContainerLibDir());
+
+		File extraLibDir = new File(dirFile, extraDirLibName);
+
+		Assert.assertEquals(
+			extraLibDir,
+			appServer.getExtraLibDirs(
+			).get(
+				0
+			));
+
+		File globalLibDir = new File(dirFile, globalDirLibName);
+
+		Assert.assertEquals(globalLibDir, appServer.getGlobalLibDir());
+
+		Assert.assertEquals(
+			serverDetectorServerId, appServer.getServerDetectorServerId());
+	}
+
+}

--- a/modules/util/portal-tools-db-upgrade-client/src/test/java/com/liferay/portal/tools/db/upgrade/client/util/AppServerTest.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/test/java/com/liferay/portal/tools/db/upgrade/client/util/AppServerTest.java
@@ -24,23 +24,52 @@ public class AppServerTest {
 	public static TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	@Test
-	public void testGetCustomAppServer() {
+	public void testGetAppServer() throws Exception {
+		File tempFile = temporaryFolder.getRoot();
+
+		File dirFile = new File(tempFile, "tomcat");
+
+		dirFile.mkdir();
+
+		AppServer appServer = AppServer.getAppServer(
+			tempFile.getCanonicalPath(), "tomcat");
+
+		_assertAppServer(
+			appServer, dirFile, "bin", "lib",
+			"webapps" + File.separator + "ROOT", "tomcat");
+
+		dirFile.delete();
+
+		dirFile = new File(tempFile, "tomcat-9.0.80");
+
+		dirFile.mkdirs();
+
+		appServer = AppServer.getAppServer(
+			tempFile.getCanonicalPath(), "tomcat");
+
+		_assertAppServer(
+			appServer, dirFile, "bin", "lib",
+			"webapps" + File.separator + "ROOT", "tomcat");
+	}
+
+	@Test
+	public void testNewAppServer() {
 		File dirFile = new File(
 			temporaryFolder.getRoot(), RandomTestUtil.randomString());
 
 		dirFile.mkdir();
 
-		String extraDirLibNames = RandomTestUtil.randomString();
-		String globalDirLibNames = RandomTestUtil.randomString();
+		String extraDirLibName = RandomTestUtil.randomString();
+		String globalDirLibName = RandomTestUtil.randomString();
 		String portalDirName = RandomTestUtil.randomString();
 		String serverDetectorServerId = RandomTestUtil.randomString();
 
 		AppServer appServer = new AppServer(
-			dirFile.getAbsolutePath(), extraDirLibNames, globalDirLibNames,
+			dirFile.getAbsolutePath(), extraDirLibName, globalDirLibName,
 			portalDirName, serverDetectorServerId);
 
-		_assert(
-			appServer, dirFile, extraDirLibNames, globalDirLibNames,
+		_assertAppServer(
+			appServer, dirFile, extraDirLibName, globalDirLibName,
 			portalDirName, serverDetectorServerId);
 
 		dirFile = new File(
@@ -48,46 +77,21 @@ public class AppServerTest {
 
 		dirFile.mkdir();
 
-		extraDirLibNames = RandomTestUtil.randomString();
-		globalDirLibNames = RandomTestUtil.randomString();
+		extraDirLibName = RandomTestUtil.randomString();
+		globalDirLibName = RandomTestUtil.randomString();
 		portalDirName = RandomTestUtil.randomString();
 
 		appServer.setDirName(dirFile.getAbsolutePath());
 		appServer.setPortalDirName(portalDirName);
-		appServer.setExtraLibDirNames(extraDirLibNames);
-		appServer.setGlobalLibDirName(globalDirLibNames);
+		appServer.setExtraLibDirNames(extraDirLibName);
+		appServer.setGlobalLibDirName(globalDirLibName);
 
-		_assert(
-			appServer, dirFile, extraDirLibNames, globalDirLibNames,
+		_assertAppServer(
+			appServer, dirFile, extraDirLibName, globalDirLibName,
 			portalDirName, serverDetectorServerId);
 	}
 
-	@Test
-	public void testGetTomcatAppServer() {
-		File dirFile = new File(temporaryFolder.getRoot(), "tomcat");
-
-		dirFile.mkdir();
-
-		AppServer appServer = AppServer.getAppServer("../../", "tomcat");
-
-		_assert(
-			appServer, dirFile, "bin", "lib",
-			"webapps" + File.separator + "ROOT", "tomcat");
-
-		dirFile.delete();
-
-		dirFile = new File(temporaryFolder.getRoot(), "tomcat-9.0.80");
-
-		dirFile.mkdirs();
-
-		appServer = AppServer.getAppServer("../../", "tomcat");
-
-		_assert(
-			appServer, dirFile, "bin", "lib",
-			"webapps" + File.separator + "ROOT", "tomcat");
-	}
-
-	private void _assert(
+	private void _assertAppServer(
 		AppServer appServer, File dirFile, String extraDirLibName,
 		String globalDirLibName, String portalDirName,
 		String serverDetectorServerId) {

--- a/modules/util/portal-tools-db-upgrade-client/src/test/java/com/liferay/portal/tools/db/upgrade/client/util/AppServerTest.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/test/java/com/liferay/portal/tools/db/upgrade/client/util/AppServerTest.java
@@ -81,7 +81,7 @@ public class AppServerTest {
 
 		dirFile.mkdir();
 
-		AppServer appServer = AppServer.getTomcatAppServer();
+		AppServer appServer = AppServer.getAppServer("../../", "tomcat");
 
 		_assert(
 			appServer, dirFile, "bin", "lib",
@@ -93,7 +93,7 @@ public class AppServerTest {
 
 		dirFile.mkdirs();
 
-		appServer = AppServer.getTomcatAppServer();
+		appServer = AppServer.getAppServer("../../", "tomcat");
 
 		_assert(
 			appServer, dirFile, "bin", "lib",

--- a/modules/util/portal-tools-db-upgrade-client/src/test/java/com/liferay/portal/tools/db/upgrade/client/util/AppServerTest.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/test/java/com/liferay/portal/tools/db/upgrade/client/util/AppServerTest.java
@@ -5,14 +5,12 @@
 
 package com.liferay.portal.tools.db.upgrade.client.util;
 
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.tools.db.upgrade.client.AppServer;
 
 import java.io.File;
 
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -24,17 +22,6 @@ public class AppServerTest {
 
 	@ClassRule
 	public static TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-	@BeforeClass
-	public static void setUpClass() {
-		File jarLocation = new File(
-			temporaryFolder.getRoot(), "tools/upgradeclient");
-
-		jarLocation.mkdirs();
-
-		ReflectionTestUtil.setFieldValue(
-			AppServer.class, "_jarDir", jarLocation);
-	}
 
 	@Test
 	public void testGetCustomAppServer() {

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-properties-none-set.expect
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-properties-none-set.expect
@@ -2,6 +2,10 @@
 
 spawn [db.upgrade.client.home]/db_upgrade_client[file.suffix.bat]
 
+expect "Please enter your Liferay home" {
+	send "\r"
+}
+
 expect "Please enter your application server" {
 	send "\r"
 }
@@ -52,10 +56,6 @@ expect "Please enter your database username" {
 
 expect "Please enter your database password" {
 	send "[database.password]\r"
-}
-
-expect "Please enter your Liferay home" {
-	send "\r"
 }
 
 set timeout 900


### PR DESCRIPTION
Hi @javalosjr96,

Your approach in [here](https://github.com/liferay-uniform/liferay-portal/pull/1693) was the proper one but this [change](https://github.com/liferay-uniform/liferay-portal/pull/1693/commits/e26b978a26c1fe4ad296b7e827e5c6e9c31a8afe#diff-870308f852df8a4006aa9e06f917e7eb784e911cdb0332c1b6d031642f631381R162) is not correct because:
- AppServer class is a DTO so should not have dependencies
- We are creating a circular dependency between DBUpgradeClient and AppServer

For that reason, we had to refactor to use the liferay.home as base dir in another way, please see:
https://github.com/liferay-uniform/liferay-portal/pull/1713/commits/f19d286703c9344f99ffd8828899a3e30f0aa2ed

It is also important this [commit](https://github.com/liferay-uniform/liferay-portal/pull/1713/commits/0c81e0d172628d1d403402bd076d47b08a1178a3) since now we have to maintain functional tests.

The rest of the changes are minor.

Thanks.

cc/@luisortiz89