### PR TITLE
LPP-52455 ServiceTrackerMap does not account for classNames in additional instances when is DBPartition is enabled

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/template/TemplateHandlerRegistryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/template/TemplateHandlerRegistryImpl.java
@@ -13,6 +13,7 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
 import com.liferay.portal.kernel.language.Language;
@@ -95,8 +96,15 @@ public class TemplateHandlerRegistryImpl implements TemplateHandlerRegistry {
 					TemplateHandler templateHandler = bundleContext.getService(
 						serviceReference);
 
-					emitter.emit(
-						_portal.getClassNameId(templateHandler.getClassName()));
+					try {
+						DBPartitionUtil.forEachCompanyId(
+							companyId -> emitter.emit(
+								_portal.getClassNameId(
+									templateHandler.getClassName())));
+					}
+					catch (Exception exception) {
+						throw new RuntimeException(exception);
+					}
 
 					bundleContext.ungetService(serviceReference);
 				});


### PR DESCRIPTION
This is intended to be a workaround for the LPP, as a complete solution requires further analysis and face some challenges that are not easy to solve.