### PR TITLE
LPD-17671 dropIndexes when columns are dropped

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -178,6 +178,8 @@ public abstract class BaseDB implements DB {
 			Connection connection, String tableName, String columnName)
 		throws Exception {
 
+		dropIndexes(connection, tableName, columnName);
+
 		StringBundler sb = new StringBundler(4);
 
 		sb.append("alter table ");


### PR DESCRIPTION
Issue:
In some cases, the indexes prevent the column from being dropped.  
I was not able to reproduce the issue from a stock database, but using the customer's database and running the drop column queries manually did not throw errors unlike the portal.

Solution:
Drop indexes before column drop,  the index is usually dropped alongside the column.
