### PR TITLE
LPD-17898 Do not enable db partition at runtime in tests, startup being enabled

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -2364,6 +2364,7 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 	<macrodef name="run-modules-integration-test">
 		<attribute default="tomcat" name="app.server.type" />
 		<attribute default="" name="aws.store.enabled" />
+		<attribute default="" name="database.partition.enabled" />
 		<attribute name="database.type" />
 		<attribute default="${database.@{database.type}.version}" name="database.version" />
 		<attribute default="" name="refreshdependencies" />
@@ -2396,6 +2397,7 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 
 							<antcall if:set="env.JENKINS_HOME" inheritAll="false" target="prepare-portal-ext-properties">
 								<param name="aws.store.enabled" value="@{aws.store.enabled}" />
+								<param name="database.partition.enabled" value="@{database.partition.enabled}" />
 								<param name="database.type" value="@{database.type}" />
 							</antcall>
 
@@ -6821,6 +6823,14 @@ information. Make sure to commit in all format-javadoc results.
 			test.portal.bundle.war.url="${test.portal.bundle.war.url}"
 			test.portal.bundle.zip.url="${test.portal.bundle.zip.url}"
 			test.sql.zip.url="${test.sql.zip.url}"
+		/>
+	</target>
+
+	<target name="modules-integration-db-partition-mysql57-jdk8">
+		<run-modules-integration-test
+			database.partition.enabled="true"
+			database.type="mysql"
+			database.version="5.7"
 		/>
 	</target>
 

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -6834,6 +6834,14 @@ information. Make sure to commit in all format-javadoc results.
 		/>
 	</target>
 
+	<target name="modules-integration-db-partition-postgresql153-jdk8">
+		<run-modules-integration-test
+			database.partition.enabled="true"
+			database.type="postgresql"
+			database.version="15.3"
+		/>
+	</target>
+
 	<target name="modules-integration-db2111-jdk8">
 		<run-modules-integration-test database.type="db2" />
 	</target>

--- a/build-test.xml
+++ b/build-test.xml
@@ -11815,7 +11815,20 @@ ${update.properties}</echo>
 			</then>
 		</if>
 
-		<get-testcase-property property.name="database.partition.enabled" />
+		<propertycopy from="database.partition.enabled[${env.CI_TEST_SUITE}]" name="database.partition.enabled" override="true" silent="true" />
+
+		<if>
+			<or>
+				<equals arg1="database.partition.enabled" arg2="" />
+				<not>
+					<isset property="database.partition.enabled" />
+				</not>
+			</or>
+			<then>
+				<get-testcase-property property.name="database.partition.enabled" />
+			</then>
+		</if>
+
 		<get-testcase-property property.name="liferay.online.properties" />
 		<get-testcase-property property.name="portal.version" />
 
@@ -11823,7 +11836,7 @@ ${update.properties}</echo>
 			<and>
 				<isset property="portal.version" />
 				<or>
-					<isset property="database.partition.enabled" />
+					<equals arg1="database.partition.enabled" arg2="true" />
 					<isset property="liferay.online.properties" />
 				</or>
 			</and>
@@ -12065,9 +12078,6 @@ upgrade.report.enabled=true</echo>
 				</replace>
 			</then>
 		</if>
-
-		<get-testcase-property property.name="database.partition.enabled" />
-		<propertycopy from="database.partition.enabled[${env.CI_TEST_SUITE}]" name="database.partition.enabled" silent="true" />
 
 		<if>
 			<equals arg1="${database.partition.enabled}" arg2="true" />

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
@@ -79,7 +79,7 @@ public class CompanyLocalServiceDBPartitionTest
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		enableDBPartition();
+		BaseDBPartitionTestCase.setUpClass();
 
 		_defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
 
@@ -91,8 +91,6 @@ public class CompanyLocalServiceDBPartitionTest
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
-		disableDBPartition();
-
 		_regenerateResourceActions();
 	}
 

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.scheduler.StorageType;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
-import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -126,14 +125,14 @@ public class CompanyLocalServiceDBPartitionTest
 
 		AopInvocationHandler aopInvocationHandler =
 			ProxyUtil.fetchInvocationHandler(
-				_companyLocalService, AopInvocationHandler.class);
+				companyLocalService, AopInvocationHandler.class);
 
 		try (AutoCloseable autoCloseable =
 				ReflectionTestUtil.setFieldValueWithAutoCloseable(
 					(CompanyLocalServiceImpl)aopInvocationHandler.getTarget(),
 					"_dlFileEntryTypeLocalService", null)) {
 
-			company = _companyLocalService.addCompany(
+			company = companyLocalService.addCompany(
 				RandomTestUtil.randomLong(), "test.com", "test.com", "test.com",
 				0, true, null, null, null, null, null, null);
 
@@ -185,7 +184,7 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 		finally {
 			if (company != null) {
-				_companyLocalService.deleteCompany(company);
+				companyLocalService.deleteCompany(company);
 			}
 		}
 	}
@@ -198,7 +197,7 @@ public class CompanyLocalServiceDBPartitionTest
 
 		Assert.assertEquals(_JOBS_COUNT + 1, _getJobsCount(_defaultCompanyId));
 
-		_companyLocalService.extractDBPartitionCompany(company.getCompanyId());
+		companyLocalService.extractDBPartitionCompany(company.getCompanyId());
 
 		Assert.assertEquals(_JOBS_COUNT, _getJobsCount(_defaultCompanyId));
 		Assert.assertEquals(1, _getJobsCount(company.getCompanyId()));
@@ -210,7 +209,7 @@ public class CompanyLocalServiceDBPartitionTest
 		boolean standaloneDBPartition = true;
 
 		try {
-			company = _companyLocalService.addDBPartitionCompany(
+			company = companyLocalService.addDBPartitionCompany(
 				company.getCompanyId(), name, virtualHostName, webId);
 
 			standaloneDBPartition = false;
@@ -231,7 +230,7 @@ public class CompanyLocalServiceDBPartitionTest
 				removeDBPartitions(new long[] {company.getCompanyId()});
 			}
 			else {
-				_companyLocalService.deleteCompany(company);
+				companyLocalService.deleteCompany(company);
 			}
 		}
 	}
@@ -249,7 +248,7 @@ public class CompanyLocalServiceDBPartitionTest
 		boolean standaloneDBPartition = false;
 
 		try {
-			_companyLocalService.extractDBPartitionCompany(
+			companyLocalService.extractDBPartitionCompany(
 				company.getCompanyId());
 
 			standaloneDBPartition = true;
@@ -257,11 +256,11 @@ public class CompanyLocalServiceDBPartitionTest
 			Assert.assertEquals(_JOBS_COUNT, _getJobsCount(_defaultCompanyId));
 			Assert.assertEquals(1, _getJobsCount(company.getCompanyId()));
 
-			Company defaultCompany = _companyLocalService.getCompany(
+			Company defaultCompany = companyLocalService.getCompany(
 				_defaultCompanyId);
 
 			try {
-				_companyLocalService.addDBPartitionCompany(
+				companyLocalService.addDBPartitionCompany(
 					company.getCompanyId(), null, null,
 					defaultCompany.getWebId());
 
@@ -287,7 +286,7 @@ public class CompanyLocalServiceDBPartitionTest
 				removeDBPartitions(new long[] {company.getCompanyId()});
 			}
 			else {
-				_companyLocalService.deleteCompany(company);
+				companyLocalService.deleteCompany(company);
 			}
 		}
 	}
@@ -305,7 +304,7 @@ public class CompanyLocalServiceDBPartitionTest
 		boolean standaloneDBPartition = false;
 
 		try {
-			_companyLocalService.extractDBPartitionCompany(
+			companyLocalService.extractDBPartitionCompany(
 				company.getCompanyId());
 
 			standaloneDBPartition = true;
@@ -331,7 +330,7 @@ public class CompanyLocalServiceDBPartitionTest
 								return method.invoke(dbPartitionDB, args);
 							}))) {
 
-				company = _companyLocalService.addDBPartitionCompany(
+				company = companyLocalService.addDBPartitionCompany(
 					company.getCompanyId(), null, null, null);
 
 				standaloneDBPartition = false;
@@ -356,7 +355,7 @@ public class CompanyLocalServiceDBPartitionTest
 				removeDBPartitions(new long[] {company.getCompanyId()});
 			}
 			else {
-				_companyLocalService.deleteCompany(company);
+				companyLocalService.deleteCompany(company);
 			}
 		}
 	}
@@ -371,7 +370,7 @@ public class CompanyLocalServiceDBPartitionTest
 
 		int dbPartitionsCount = _getDBPartitionsCount();
 
-		_companyLocalService.deleteCompany(company);
+		companyLocalService.deleteCompany(company);
 
 		Assert.assertFalse(
 			ArrayUtil.contains(_getCompanyIdsBySQL(), company.getCompanyId()));
@@ -403,7 +402,7 @@ public class CompanyLocalServiceDBPartitionTest
 							return method.invoke(dbPartitionDB, args);
 						}))) {
 
-			_companyLocalService.deleteCompany(_company);
+			companyLocalService.deleteCompany(_company);
 
 			Assert.fail();
 		}
@@ -427,7 +426,7 @@ public class CompanyLocalServiceDBPartitionTest
 		boolean standaloneDBPartition = false;
 
 		try {
-			_companyLocalService.extractDBPartitionCompany(
+			companyLocalService.extractDBPartitionCompany(
 				company.getCompanyId());
 
 			Assert.assertFalse(
@@ -447,7 +446,7 @@ public class CompanyLocalServiceDBPartitionTest
 				removeDBPartitions(new long[] {company.getCompanyId()});
 			}
 			else {
-				_companyLocalService.deleteCompany(company);
+				companyLocalService.deleteCompany(company);
 			}
 		}
 	}
@@ -485,7 +484,7 @@ public class CompanyLocalServiceDBPartitionTest
 							return method.invoke(dbPartitionDB, args);
 						}))) {
 
-			_companyLocalService.extractDBPartitionCompany(
+			companyLocalService.extractDBPartitionCompany(
 				company.getCompanyId());
 
 			standaloneDBPartition = true;
@@ -508,7 +507,7 @@ public class CompanyLocalServiceDBPartitionTest
 				removeDBPartitions(new long[] {company.getCompanyId()});
 			}
 			else {
-				_companyLocalService.deleteCompany(company);
+				companyLocalService.deleteCompany(company);
 			}
 		}
 	}
@@ -637,9 +636,6 @@ public class CompanyLocalServiceDBPartitionTest
 	private static final String _JOB_NAME = "test";
 
 	private static final int _JOBS_COUNT = 2;
-
-	@Inject
-	private static CompanyLocalService _companyLocalService;
 
 	private static long _defaultCompanyId;
 

--- a/modules/apps/on-demand-admin/on-demand-admin-test/src/testIntegration/java/com/liferay/on/demand/admin/ticket/generator/test/OnDemandAdminTicketGeneratorDBPartitionTest.java
+++ b/modules/apps/on-demand-admin/on-demand-admin-test/src/testIntegration/java/com/liferay/on/demand/admin/ticket/generator/test/OnDemandAdminTicketGeneratorDBPartitionTest.java
@@ -37,7 +37,7 @@ public class OnDemandAdminTicketGeneratorDBPartitionTest
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		enableDBPartition();
+		BaseDBPartitionTestCase.setUpClass();
 
 		addDBPartitions();
 
@@ -54,8 +54,6 @@ public class OnDemandAdminTicketGeneratorDBPartitionTest
 		deletePartitionRequiredData();
 
 		removeDBPartitions();
-
-		disableDBPartition();
 	}
 
 	@Test

--- a/modules/apps/on-demand-admin/on-demand-admin-test/src/testIntegration/java/com/liferay/on/demand/admin/ticket/generator/test/OnDemandAdminTicketGeneratorDBPartitionTest.java
+++ b/modules/apps/on-demand-admin/on-demand-admin-test/src/testIntegration/java/com/liferay/on/demand/admin/ticket/generator/test/OnDemandAdminTicketGeneratorDBPartitionTest.java
@@ -15,7 +15,6 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserWrapper;
 import com.liferay.portal.kernel.search.IndexStatusManagerThreadLocal;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalServiceUtil;
 import com.liferay.portal.security.DefaultAdminUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -108,7 +107,7 @@ public class OnDemandAdminTicketGeneratorDBPartitionTest
 			}
 
 			Ticket ticket = _onDemandAdminTicketGenerator.generate(
-				_companyLocalService.getCompany(targetCompanyId), null, user);
+				companyLocalService.getCompany(targetCompanyId), null, user);
 
 			Assert.assertNotNull(ticket);
 			Assert.assertNotEquals(user.getCompanyId(), ticket.getCompanyId());
@@ -118,9 +117,6 @@ public class OnDemandAdminTicketGeneratorDBPartitionTest
 	private void _assertCompanyId(long companyId) {
 		Assert.assertEquals(companyId, (long)CompanyThreadLocal.getCompanyId());
 	}
-
-	@Inject
-	private CompanyLocalService _companyLocalService;
 
 	@Inject
 	private OnDemandAdminTicketGenerator _onDemandAdminTicketGenerator;

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
@@ -71,6 +71,8 @@ public abstract class BaseDBPartitionTestCase {
 			PermissionCheckerMethodTestRule.INSTANCE);
 
 	public static void assume() {
+		Assume.assumeTrue(DBPartition.isPartitionEnabled());
+
 		db = DBManagerUtil.getDB();
 
 		Assume.assumeTrue(db.isSupportsDBPartition());

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
@@ -104,10 +104,6 @@ public abstract class BaseDBPartitionTestCase {
 		db.runSQL(getCreateIndexSQL(tableName));
 	}
 
-	protected static void createTable(String tableName) throws Exception {
-		db.runSQL(getCreateTableSQL(tableName));
-	}
-
 	protected static void createUniqueIndex(String tableName) throws Exception {
 		db.runSQL(
 			StringBundler.concat(

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
@@ -8,10 +8,6 @@ package com.liferay.portal.db.partition.test.util;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.dao.init.DBInitUtil;
-import com.liferay.portal.dao.jdbc.util.ConnectionWrapper;
-import com.liferay.portal.dao.jdbc.util.DataSourceWrapper;
 import com.liferay.portal.db.partition.db.DBPartitionDB;
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.dao.db.DB;
@@ -25,8 +21,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.UserConstants;
-import com.liferay.portal.kernel.module.util.BundleUtil;
-import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -35,15 +29,12 @@ import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.portal.util.PropsUtil;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
-import java.sql.SQLException;
 import java.sql.Statement;
 
 import javax.sql.DataSource;
@@ -51,12 +42,6 @@ import javax.sql.DataSource;
 import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Rule;
-
-import org.osgi.framework.Bundle;
-import org.osgi.service.component.runtime.ServiceComponentRuntime;
-import org.osgi.util.promise.Promise;
-
-import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 
 /**
  * @author Alberto Chaparro
@@ -142,30 +127,6 @@ public abstract class BaseDBPartitionTestCase {
 		}
 	}
 
-	protected static void disableDBPartition() throws Exception {
-		DataAccess.cleanUp(connection);
-
-		if (_dbPartitionEnabled) {
-			return;
-		}
-
-		_disableComponents(
-			"com.liferay.portal.db.partition",
-			"com.liferay.portal.db.partition.internal.operation." +
-				"DBPartitionExtractVirtualInstanceOperation",
-			"com.liferay.portal.db.partition.internal.operation." +
-				"DBPartitionInsertVirtualInstanceOperation");
-
-		PropsUtil.set(
-			"database.partition.enabled", _originalDatabasePartitionEnabled);
-
-		_lazyConnectionDataSourceProxy.setTargetDataSource(_currentDataSource);
-
-		ReflectionTestUtil.setFieldValue(
-			DBPartitionUtil.class, "_DATABASE_PARTITION_SCHEMA_NAME_PREFIX",
-			StringPool.BLANK);
-	}
-
 	protected static void dropIndex(String tableName) throws Exception {
 		db.runSQL(
 			StringBundler.concat(
@@ -181,58 +142,6 @@ public abstract class BaseDBPartitionTestCase {
 
 	protected static void dropTable(String tableName) throws Exception {
 		db.runSQL("drop table if exists " + tableName + " cascade");
-	}
-
-	protected static void enableDBPartition() throws Exception {
-		CompanyThreadLocal.setCompanyId(
-			PortalInstancePool.getDefaultCompanyId());
-
-		_dbPartitionEnabled = DBPartition.isPartitionEnabled();
-
-		if (!_dbPartitionEnabled) {
-			_originalDatabasePartitionEnabled = PropsUtil.get(
-				"database.partition.enabled");
-
-			PropsUtil.set("database.partition.enabled", "true");
-
-			ReflectionTestUtil.setFieldValue(
-				DBPartitionUtil.class, "_DATABASE_PARTITION_SCHEMA_NAME_PREFIX",
-				_DATABASE_PARTITION_SCHEMA_NAME_PREFIX);
-			ReflectionTestUtil.setFieldValue(
-				DBPartitionUtil.class,
-				"_DATABASE_PARTITION_THREAD_POOL_ENABLED", true);
-
-			DBPartitionUtil.setDefaultCompanyId(portal.getDefaultCompanyId());
-
-			_lazyConnectionDataSourceProxy =
-				(LazyConnectionDataSourceProxy)DBInitUtil.getDataSource();
-
-			_currentDataSource =
-				_lazyConnectionDataSourceProxy.getTargetDataSource();
-
-			DataSource dataSource = DBPartitionUtil.wrapDataSource(
-				_currentDataSource);
-
-			defaultPartitionName = ReflectionTestUtil.getFieldValue(
-				DBPartitionUtil.class, "_defaultPartitionName");
-
-			DataSource dbPartitionDataSource = _wrapDataSource(dataSource);
-
-			_lazyConnectionDataSourceProxy.setTargetDataSource(
-				dbPartitionDataSource);
-
-			_restartComponent(
-				"com.liferay.portal.db.partition",
-				"com.liferay.portal.db.partition.internal.component.enabler." +
-					"DBPartitionComponentEnabler");
-		}
-
-		connection = DataAccess.getConnection();
-
-		dbInspector = new DBInspector(connection);
-
-		dbPartitionDB = ReflectionTestUtil.getFieldValue(
-			DBPartitionUtil.class, "_dbPartitionDB");
 	}
 
 	protected static void extractDBPartitions() throws Exception {
@@ -261,16 +170,12 @@ public abstract class BaseDBPartitionTestCase {
 			return defaultPartitionName;
 		}
 
-		if (_dbPartitionEnabled) {
-			String databasePartitionSchemaNamePrefix =
-				ReflectionTestUtil.getFieldValue(
-					DBPartitionUtil.class,
-					"_DATABASE_PARTITION_SCHEMA_NAME_PREFIX");
+		String databasePartitionSchemaNamePrefix =
+			ReflectionTestUtil.getFieldValue(
+				DBPartitionUtil.class,
+				"_DATABASE_PARTITION_SCHEMA_NAME_PREFIX");
 
-			return databasePartitionSchemaNamePrefix + companyId;
-		}
-
-		return _DATABASE_PARTITION_SCHEMA_NAME_PREFIX + companyId;
+		return databasePartitionSchemaNamePrefix + companyId;
 	}
 
 	protected static void insertDBPartitions() throws Exception {
@@ -404,6 +309,21 @@ public abstract class BaseDBPartitionTestCase {
 		_executeOnDBPartitions(companyIds, DBPartitionUtil::removeDBPartition);
 	}
 
+	protected static void setUpClass() throws Exception {
+		CompanyThreadLocal.setCompanyId(
+			PortalInstancePool.getDefaultCompanyId());
+
+		connection = DataAccess.getConnection();
+
+		dbInspector = new DBInspector(connection);
+
+		dbPartitionDB = ReflectionTestUtil.getFieldValue(
+			DBPartitionUtil.class, "_dbPartitionDB");
+
+		defaultPartitionName = ReflectionTestUtil.getFieldValue(
+			DBPartitionUtil.class, "_defaultPartitionName");
+	}
+
 	protected void createAndPopulateControlTable(String tableName)
 		throws Exception {
 
@@ -455,22 +375,6 @@ public abstract class BaseDBPartitionTestCase {
 	@Inject
 	protected static Portal portal;
 
-	private static void _disableComponents(
-			String bundleSymbolicName, String... components)
-		throws Exception {
-
-		Bundle bundle = BundleUtil.getBundle(
-			SystemBundleUtil.getBundleContext(), bundleSymbolicName);
-
-		for (String component : components) {
-			Promise<?> promise = _serviceComponentRuntime.disableComponent(
-				_serviceComponentRuntime.getComponentDescriptionDTO(
-					bundle, component));
-
-			promise.getValue();
-		}
-	}
-
 	private static void _executeOnDBPartitions(
 			long[] companyIds,
 			UnsafeFunction<Long, Boolean, PortalException> unsafeFunction)
@@ -496,71 +400,5 @@ public abstract class BaseDBPartitionTestCase {
 				defaultCurrentConnection);
 		}
 	}
-
-	private static void _restartComponent(
-			String bundleSymbolicName, String component)
-		throws Exception {
-
-		Bundle bundle = BundleUtil.getBundle(
-			SystemBundleUtil.getBundleContext(), bundleSymbolicName);
-
-		Promise<?> promise = _serviceComponentRuntime.disableComponent(
-			_serviceComponentRuntime.getComponentDescriptionDTO(
-				bundle, component));
-
-		promise.getValue();
-
-		promise = _serviceComponentRuntime.enableComponent(
-			_serviceComponentRuntime.getComponentDescriptionDTO(
-				bundle, component));
-
-		promise.getValue();
-	}
-
-	private static DataSource _wrapDataSource(DataSource dataSource) {
-		return new DataSourceWrapper(dataSource) {
-
-			@Override
-			public Connection getConnection() throws SQLException {
-				return _wrapConnection(super.getConnection());
-			}
-
-			@Override
-			public Connection getConnection(String userName, String password)
-				throws SQLException {
-
-				return _wrapConnection(super.getConnection());
-			}
-
-			private Connection _wrapConnection(Connection connection) {
-				return new ConnectionWrapper(connection) {
-
-					@Override
-					public void close() throws SQLException {
-						dbPartitionDB.setPartition(
-							connection, defaultPartitionName);
-
-						super.close();
-					}
-
-				};
-			}
-
-		};
-	}
-
-	private static final String _DATABASE_PARTITION_SCHEMA_NAME_PREFIX =
-		"ltest_";
-
-	private static DataSource _currentDataSource;
-	private static boolean _dbPartitionEnabled;
-	private static LazyConnectionDataSourceProxy _lazyConnectionDataSourceProxy;
-	private static String _originalDatabasePartitionEnabled;
-
-	@Inject
-	private static Props _props;
-
-	@Inject
-	private static ServiceComponentRuntime _serviceComponentRuntime;
 
 }

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
@@ -366,6 +366,9 @@ public abstract class BaseDBPartitionTestCase {
 
 	protected static final String TEST_TABLE_NAME = "TestTable";
 
+	@Inject
+	protected static CompanyLocalService companyLocalService;
+
 	protected static Connection connection;
 	protected static DB db;
 	protected static DBInspector dbInspector;

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
@@ -10,12 +10,15 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.db.partition.db.DBPartitionDB;
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
+import com.liferay.portal.kernel.cache.PortalCacheHelperUtil;
+import com.liferay.portal.kernel.cache.PortalCacheManagerNames;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
@@ -23,12 +26,15 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.UserConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.model.impl.CompanyImpl;
+import com.liferay.portal.model.impl.VirtualHostImpl;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -77,6 +83,8 @@ public abstract class BaseDBPartitionTestCase {
 			for (long companyId : COMPANY_IDS) {
 				DBPartitionUtil.addDBPartition(companyId);
 			}
+
+			_clearCaches();
 		}
 		finally {
 			ReflectionTestUtil.setFieldValue(
@@ -301,6 +309,8 @@ public abstract class BaseDBPartitionTestCase {
 
 	protected static void removeDBPartitions() throws Exception {
 		removeDBPartitions(COMPANY_IDS);
+
+		_clearCaches();
 	}
 
 	protected static void removeDBPartitions(long[] companyIds)
@@ -377,6 +387,16 @@ public abstract class BaseDBPartitionTestCase {
 
 	@Inject
 	protected static Portal portal;
+
+	private static void _clearCaches() throws Exception {
+		EntityCacheUtil.clearCache(CompanyImpl.class);
+		EntityCacheUtil.clearCache(VirtualHostImpl.class);
+
+		for (long companyId : COMPANY_IDS) {
+			PortalCacheHelperUtil.removePortalCaches(
+				PortalCacheManagerNames.MULTI_VM, companyId);
+		}
+	}
 
 	private static void _executeOnDBPartitions(
 			long[] companyIds,

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/BaseVirtualInstanceOperationTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/BaseVirtualInstanceOperationTestCase.java
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.felix.cm.PersistenceManager;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 
@@ -42,12 +41,7 @@ public abstract class BaseVirtualInstanceOperationTestCase
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		enableDBPartition();
-	}
-
-	@AfterClass
-	public static void tearDownClass() throws Exception {
-		disableDBPartition();
+		BaseDBPartitionTestCase.setUpClass();
 	}
 
 	@After

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/messaging/test/BaseDBPartitionMessageBusInterceptorTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/messaging/test/BaseDBPartitionMessageBusInterceptorTestCase.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.util.PortalInstances;
-import com.liferay.portal.util.PropsUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -67,9 +66,6 @@ public abstract class BaseDBPartitionMessageBusInterceptorTestCase
 		}
 
 		_serviceRegistrations.clear();
-
-		PropsUtil.set(
-			"database.partition.enabled", _originalDatabasePartitionEnabled);
 
 		_companyLocalService.deleteCompany(_company);
 
@@ -259,11 +255,6 @@ public abstract class BaseDBPartitionMessageBusInterceptorTestCase
 
 		_activeCompanyIds = companyIds.toArray(new Long[0]);
 
-		_originalDatabasePartitionEnabled = PropsUtil.get(
-			"database.partition.enabled");
-
-		PropsUtil.set("database.partition.enabled", "true");
-
 		_testDBPartitionMessageListener = new TestDBPartitionMessageListener();
 
 		Destination destination = _destinationFactory.createDestination(
@@ -307,7 +298,6 @@ public abstract class BaseDBPartitionMessageBusInterceptorTestCase
 	@Inject
 	private static MessageBus _messageBus;
 
-	private static String _originalDatabasePartitionEnabled;
 	private static String _originalName;
 	private static final List<ServiceRegistration<?>> _serviceRegistrations =
 		new ArrayList<>();

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/messaging/test/BaseDBPartitionMessageBusInterceptorTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/messaging/test/BaseDBPartitionMessageBusInterceptorTestCase.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.scheduler.SchedulerEngine;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
-import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -67,7 +66,7 @@ public abstract class BaseDBPartitionMessageBusInterceptorTestCase
 
 		_serviceRegistrations.clear();
 
-		_companyLocalService.deleteCompany(_company);
+		companyLocalService.deleteCompany(_company);
 
 		PrincipalThreadLocal.setName(_originalName);
 	}
@@ -246,7 +245,7 @@ public abstract class BaseDBPartitionMessageBusInterceptorTestCase
 
 		Set<Long> companyIds = new TreeSet<>();
 
-		_companyLocalService.forEachCompany(
+		companyLocalService.forEachCompany(
 			company -> {
 				if (company.isActive()) {
 					companyIds.add(company.getCompanyId());
@@ -281,10 +280,6 @@ public abstract class BaseDBPartitionMessageBusInterceptorTestCase
 
 	private static Long[] _activeCompanyIds;
 	private static Company _company;
-
-	@Inject
-	private static CompanyLocalService _companyLocalService;
-
 	private static volatile CountDownLatch _countDownLatch;
 
 	@Inject(

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -9,22 +9,19 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
-import com.liferay.portal.kernel.dao.orm.EntityCache;
-import com.liferay.portal.kernel.dao.orm.FinderCache;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
-import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
 import com.liferay.portal.model.DefaultModelHintsImpl;
-import com.liferay.portal.model.impl.ClassNameImpl;
 import com.liferay.portal.model.impl.ResourceActionImpl;
 import com.liferay.portal.service.impl.ClassNameLocalServiceImpl;
 import com.liferay.portal.service.impl.ResourceActionLocalServiceImpl;
@@ -59,23 +56,11 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		entityCache.removeCache(ClassNameImpl.class.getName());
-		entityCache.removeCache(ResourceActionImpl.class.getName());
-		finderCache.removeCache(ClassNameImpl.class.getName());
-		finderCache.removeCache(ResourceActionImpl.class.getName());
 		BaseDBPartitionTestCase.setUpClass();
 
 		createControlTable(TEST_CONTROL_TABLE_NAME);
 
 		addDBPartitions();
-
-		_resourceActions = ReflectionTestUtil.getFieldValue(
-			ResourceActionLocalServiceImpl.class, "_resourceActions");
-
-		_resourceActions.clear();
-
-		DBPartitionUtil.forEachCompanyId(
-			companyId -> _resourceActionLocalService.checkResourceActions());
 
 		insertPartitionRequiredData();
 	}
@@ -87,18 +72,6 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 		removeDBPartitions();
 
 		dropTable(TEST_CONTROL_TABLE_NAME);
-		entityCache.removeCache(ClassNameImpl.class.getName());
-		entityCache.removeCache(ResourceActionImpl.class.getName());
-
-		finderCache.removeCache(ClassNameImpl.class.getName());
-		finderCache.removeCache(ResourceActionImpl.class.getName());
-
-		if (_resourceActions != null) {
-			_resourceActions.clear();
-		}
-
-		DBPartitionUtil.forEachCompanyId(
-			companyId -> _resourceActionLocalService.checkResourceActions());
 	}
 
 	@After
@@ -194,6 +167,14 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 	@Test
 	public void testCopyResourceAction() throws Exception {
+		EntityCacheUtil.clearCache(ResourceActionImpl.class);
+
+		Map<String, ResourceAction> resourceActions =
+			ReflectionTestUtil.getFieldValue(
+				ResourceActionLocalServiceImpl.class, "_resourceActions");
+
+		resourceActions.clear();
+
 		String actionId = "";
 		long bitwiseValue = 0;
 		String name = "";
@@ -217,19 +198,34 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 		String finalName = name;
 		long finalResourceActionId = resourceActionId;
 
-		DBPartitionUtil.forEachCompanyId(
-			companyId -> {
-				ResourceAction resourceAction =
-					_resourceActionLocalService.fetchResourceAction(
-						finalName, finalActionId);
+		try {
+			DBPartitionUtil.forEachCompanyId(
+				companyId ->
+					_resourceActionLocalService.checkResourceActions());
 
-				Assert.assertNotNull(resourceAction);
-				Assert.assertEquals(
-					finalBitwiseValue, resourceAction.getBitwiseValue());
-				Assert.assertEquals(
-					finalResourceActionId,
-					resourceAction.getResourceActionId());
-			});
+			DBPartitionUtil.forEachCompanyId(
+				companyId -> {
+					ResourceAction resourceAction =
+						_resourceActionLocalService.fetchResourceAction(
+							finalName, finalActionId);
+
+					Assert.assertNotNull(resourceAction);
+					Assert.assertEquals(
+						finalBitwiseValue, resourceAction.getBitwiseValue());
+					Assert.assertEquals(
+						finalResourceActionId,
+						resourceAction.getResourceActionId());
+				});
+		}
+		finally {
+			EntityCacheUtil.clearCache(ResourceActionImpl.class);
+
+			resourceActions.clear();
+
+			DBPartitionUtil.forEachCompanyId(
+				companyId ->
+					_resourceActionLocalService.checkResourceActions());
+		}
 	}
 
 	@Test
@@ -419,25 +415,16 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 	}
 
-	@Inject
-	protected static EntityCache entityCache;
-
-	@Inject
-	protected static FinderCache finderCache;
-
 	private static final String _CLASS_NAME_VALUE = "class.name.test";
 
 	@Inject
 	private static ResourceActionLocalService _resourceActionLocalService;
-
-	private static Map<String, ResourceAction> _resourceActions;
 
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
 
 	@Inject
 	private CompanyLocalService _companyLocalService;
-
 	private class ClassNameModelHints extends DefaultModelHintsImpl {
 
 		@Override

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -59,13 +59,11 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		enableDBPartition();
-
 		entityCache.removeCache(ClassNameImpl.class.getName());
 		entityCache.removeCache(ResourceActionImpl.class.getName());
-
 		finderCache.removeCache(ClassNameImpl.class.getName());
 		finderCache.removeCache(ResourceActionImpl.class.getName());
+		BaseDBPartitionTestCase.setUpClass();
 
 		createControlTable(TEST_CONTROL_TABLE_NAME);
 
@@ -89,9 +87,6 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 		removeDBPartitions();
 
 		dropTable(TEST_CONTROL_TABLE_NAME);
-
-		disableDBPartition();
-
 		entityCache.removeCache(ClassNameImpl.class.getName());
 		entityCache.removeCache(ResourceActionImpl.class.getName());
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -251,7 +251,7 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 							"class.name.test"))));
 
 			Assert.assertEquals(
-				classNames.toString(), _companyLocalService.getCompaniesCount(),
+				classNames.toString(), companyLocalService.getCompaniesCount(),
 				classNames.size());
 		}
 		finally {
@@ -290,7 +290,7 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 			Assert.assertEquals(
 				resourceActions.toString(),
-				_companyLocalService.getCompaniesCount(),
+				companyLocalService.getCompaniesCount(),
 				resourceActions.size());
 		}
 		finally {
@@ -423,8 +423,6 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
 
-	@Inject
-	private CompanyLocalService _companyLocalService;
 	private class ClassNameModelHints extends DefaultModelHintsImpl {
 
 		@Override

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -44,12 +43,7 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		enableDBPartition();
-	}
-
-	@AfterClass
-	public static void tearDownClass() throws Exception {
-		disableDBPartition();
+		BaseDBPartitionTestCase.setUpClass();
 	}
 
 	@Before

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedControlTableTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedControlTableTest.java
@@ -37,7 +37,7 @@ public class UpgradePartitionedControlTableTest
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		enableDBPartition();
+		BaseDBPartitionTestCase.setUpClass();
 
 		addDBPartitions();
 
@@ -49,8 +49,6 @@ public class UpgradePartitionedControlTableTest
 		deletePartitionRequiredData();
 
 		removeDBPartitions();
-
-		disableDBPartition();
 	}
 
 	@Test

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DatabasePartitionUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DatabasePartitionUpgradeProcessTest.java
@@ -7,10 +7,11 @@ package com.liferay.portal.upgrade.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.function.UnsafeConsumer;
-import com.liferay.portal.db.partition.util.DBPartitionUtil;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.db.partition.DBPartition;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -22,9 +23,9 @@ import java.sql.DatabaseMetaData;
 
 import java.util.concurrent.FutureTask;
 
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,26 +40,20 @@ public class DatabasePartitionUpgradeProcessTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
 
-	@BeforeClass
-	public static void setUpClass() {
-		_originalDatabasePartitionEnabled = PropsUtil.get(
-			"database.partition.enabled");
-		_originalDatabasePartitionThreadPoolEnabled =
-			ReflectionTestUtil.getFieldValue(
-				DBPartitionUtil.class,
-				"_DATABASE_PARTITION_THREAD_POOL_ENABLED");
+	public static void assume() {
+		Assume.assumeTrue(DBPartition.isPartitionEnabled());
+
+		DB db = DBManagerUtil.getDB();
+
+		Assume.assumeTrue(db.isSupportsDBPartition());
 	}
 
-	@AfterClass
-	public static void tearDownClass() {
-		ReflectionTestUtil.setFieldValue(
-			DBPartitionUtil.class, "_DATABASE_PARTITION_THREAD_POOL_ENABLED",
-			_originalDatabasePartitionThreadPoolEnabled);
-
-		PropsUtil.set(
-			"database.partition.enabled", _originalDatabasePartitionEnabled);
+	@After
+	public void tearDown() {
+		PropsUtil.set("database.partition.enabled", "true");
 	}
 
 	@Test
@@ -66,10 +61,6 @@ public class DatabasePartitionUpgradeProcessTest {
 		throws UpgradeException {
 
 		PropsUtil.set("database.partition.enabled", "false");
-
-		ReflectionTestUtil.setFieldValue(
-			DBPartitionUtil.class, "_DATABASE_PARTITION_THREAD_POOL_ENABLED",
-			true);
 
 		UpgradeProcess upgradeProcess = new AssertConnectionUpgradeProcess();
 
@@ -82,17 +73,10 @@ public class DatabasePartitionUpgradeProcessTest {
 
 		PropsUtil.set("database.partition.enabled", "true");
 
-		ReflectionTestUtil.setFieldValue(
-			DBPartitionUtil.class, "_DATABASE_PARTITION_THREAD_POOL_ENABLED",
-			true);
-
 		UpgradeProcess upgradeProcess = new AssertConnectionUpgradeProcess();
 
 		upgradeProcess.upgrade();
 	}
-
-	private static String _originalDatabasePartitionEnabled;
-	private static boolean _originalDatabasePartitionThreadPoolEnabled;
 
 	private class AssertConnectionUpgradeProcess extends DummyUpgradeProcess {
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeProcessDBPartitionTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeProcessDBPartitionTest.java
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith;
  * @author Luis Ortiz
  */
 @RunWith(Arquillian.class)
-public class DatabasePartitionUpgradeProcessTest {
+public class UpgradeProcessDBPartitionTest {
 
 	@ClassRule
 	@Rule

--- a/test.properties
+++ b/test.properties
@@ -4634,8 +4634,7 @@
     test.batch.class.names.includes[db-partition]=\
         **/testIntegration/**/*DBPartitionTest.java,\
         **/portal-db-partition-test/**/*Test.java,\
-        **/portal-tools-db-partition*/**/*Test.java,\
-        **/testIntegration/**/*DatabasePartition*Test.java
+        **/portal-tools-db-partition*/**/*Test.java
 
     test.batch.dist.app.servers[db-partition]=tomcat
 

--- a/test.properties
+++ b/test.properties
@@ -4632,6 +4632,8 @@
     #
 
     test.batch.class.names.includes[db-partition]=\
+        **/company-test/**/CompanyLocalServiceDBPartitionTest.java,\
+        **/on-demand-admin-test/**/OnDemandAdminTicketGeneratorDBPartitionTest.java,\
         **/portal-db-partition-test/**/*Test.java,\
         **/portal-tools-db-partition*/**/*Test.java,\
         **/testIntegration/**/*DatabasePartitionUpgrade*Test.java

--- a/test.properties
+++ b/test.properties
@@ -4632,9 +4632,9 @@
     #
 
     test.batch.class.names.includes[db-partition]=\
-        **/testIntegration/**/*DBPartitionTest.java,\
         **/portal-db-partition-test/**/*Test.java,\
-        **/portal-tools-db-partition*/**/*Test.java
+        **/portal-tools-db-partition*/**/*Test.java,\
+        **/testIntegration/**/*DBPartitionTest.java
 
     test.batch.dist.app.servers[db-partition]=tomcat
 

--- a/test.properties
+++ b/test.properties
@@ -4632,11 +4632,10 @@
     #
 
     test.batch.class.names.includes[db-partition]=\
-        **/company-test/**/CompanyLocalServiceDBPartitionTest.java,\
-        **/on-demand-admin-test/**/OnDemandAdminTicketGeneratorDBPartitionTest.java,\
+        **/testIntegration/**/*DBPartitionTest.java,\
         **/portal-db-partition-test/**/*Test.java,\
         **/portal-tools-db-partition*/**/*Test.java,\
-        **/testIntegration/**/*DatabasePartitionUpgrade*Test.java
+        **/testIntegration/**/*DatabasePartition*Test.java
 
     test.batch.dist.app.servers[db-partition]=tomcat
 

--- a/test.properties
+++ b/test.properties
@@ -3163,6 +3163,7 @@
     test.batch.size[lpkg-startup-mysql57-jdk8]=1
     test.batch.size[modules-compile-jdk8]=2
     test.batch.size[modules-integration-aws-s3-mysql57-jdk8]=20
+    test.batch.size[modules-integration-db-partition-mysql57-jdk8]=20
     test.batch.size[modules-integration-db2111-jdk8]=20
     test.batch.size[modules-integration-db2115-jdk8]=20
     test.batch.size[modules-integration-hypersonic20-jdk8]=20

--- a/test.properties
+++ b/test.properties
@@ -3164,6 +3164,7 @@
     test.batch.size[modules-compile-jdk8]=2
     test.batch.size[modules-integration-aws-s3-mysql57-jdk8]=20
     test.batch.size[modules-integration-db-partition-mysql57-jdk8]=20
+    test.batch.size[modules-integration-db-partition-postgresql153-jdk8]=20
     test.batch.size[modules-integration-db2111-jdk8]=20
     test.batch.size[modules-integration-db2115-jdk8]=20
     test.batch.size[modules-integration-hypersonic20-jdk8]=20

--- a/test.properties
+++ b/test.properties
@@ -4643,8 +4643,8 @@
         functional-tomcat90-postgresql153-jdk8,\
         functional-upgrade-tomcat90-mysql57-jdk8,\
         functional-upgrade-tomcat90-postgresql153-jdk8,\
-        modules-integration-mysql57-jdk8,\
-        modules-integration-postgresql153-jdk8
+        modules-integration-db-partition-mysql57-jdk8,\
+        modules-integration-db-partition-postgresql153-jdk8
         modules-unit-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][db-partition]=\

--- a/test.properties
+++ b/test.properties
@@ -4646,7 +4646,7 @@
         functional-upgrade-tomcat90-mysql57-jdk8,\
         functional-upgrade-tomcat90-postgresql153-jdk8,\
         modules-integration-db-partition-mysql57-jdk8,\
-        modules-integration-db-partition-postgresql153-jdk8
+        modules-integration-db-partition-postgresql153-jdk8,\
         modules-unit-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][db-partition]=\


### PR DESCRIPTION
@marianoalvarosaiz @vicnate5 please review these commits:
- https://github.com/liferay-uniform/liferay-portal/pull/1800/commits/567259b30266936a8818244feef2fe4d6099f007 is this ok?
- https://github.com/liferay-uniform/liferay-portal/pull/1800/commits/c84f2524ac4bdb36967ea1d834d88b2361eeda27 the filter has been simplified for easier maintenance but, what happens if a class is found by two filters? For example DBPartitionTest class matches **/portal-db-partition-test/**/*Test.java and **/testIntegration/**/*DBPartitionTest.java, will be executed twice?

Thanks.