### PR TITLE
[CLDR] LPD-17986 Make various PortalConfigurationUpgrade functional tests work with CLDR locale provider

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/ValidateInstanceSettingsUpgrade.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/ValidateInstanceSettingsUpgrade.macro
@@ -116,9 +116,7 @@ definition {
 			configurationName = "Time Zone",
 			configurationScope = "Virtual Instance Scope");
 
-		AssertSelectedLabel(
-			locator1 = "Select#TIME_ZONE",
-			value1 = "(UTC +03:00) Eastern European Time");
+		AssertElementPresent(locator1 = "//option[@value='Europe/Istanbul' and @selected]");
 	}
 
 	@summary = "Default summary"


### PR DESCRIPTION
Hi Alberto, @achaparro 

This is for our preparation to change java locale provider from JRE/COMPAT to CLDR
our affected PortalConfigurationUpgrade functional testcases are here: [link](https://docs.google.com/spreadsheets/d/1cCrbKHCuL6WCHE3f9Av8WJ8ZOABMSpyNQpsEhUILZ40/edit#gid=1191301746&range=A1807)

The details are on the ticket: https://liferay.atlassian.net/browse/LPD-17986
Basically, CLDR vs default have different timezone display name.
so this PR makes it look at Timezone ID on the selected option tag instead

This PR is tested on ci here: https://github.com/julschong/liferay-portal/pull/1145#issuecomment-1951343787
The failed tests on the ci are from unrelated "Reindex" issue.

Thank you!