### PR TITLE
LPD-1766 just run the query then send result,  no need for extra logic

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseCompanyIdUpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseCompanyIdUpgradeProcess.java
@@ -97,11 +97,28 @@ public abstract class BaseCompanyIdUpgradeProcess extends UpgradeProcess {
 				return String.valueOf(companyIds.get(0));
 			}
 
-			return StringBundler.concat(
-				"select max(companyId) from ", foreignTableName, " where ",
-				foreignTableName, ".", foreignColumnName, " > 0 and ",
-				foreignTableName, ".", foreignColumnName, " = ", _tableName,
-				".", _columnName);
+			companyIds.clear();
+
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						StringBundler.concat(
+							"select max(companyId) from ", foreignTableName,
+							" where ", foreignTableName, ".", foreignColumnName,
+							" > 0 and ", foreignTableName, ".",
+							foreignColumnName, " = ", _tableName, ".",
+							_columnName));
+				ResultSet resultSet = preparedStatement.executeQuery()) {
+
+				while (resultSet.next()) {
+					companyIds.add(resultSet.getLong("max"));
+				}
+			}
+
+			if (companyIds.isEmpty()) {
+				throw new SQLException("No valid companies found");
+			}
+
+			return String.valueOf(companyIds.get(0));
 		}
 
 		protected String getUpdateSQL(


### PR DESCRIPTION
Ticket:
[LPD-1766](https://liferay.atlassian.net/browse/LPD-1766)

Issue:
This is a flaky issue within our upgrade suite.  At random,  the upgrade could fail indicating that an aggregate function is not valid within a sql query,  this only really occurs for Postgres and we do not have concrete root cause besides the documentation.  

I tried finding an alternative query that is supported, but I think it's more robust to run the select query before sending it to the update query. We can avoid using transform or the map since it's mainly just getting the max value. 


From the previous PR:
_Find why it works sometimes, I think it is related to the database version (the old query works for me with PostgreSQL 15.4 and [Cristina says it works with Java 11](https://help.liferay.com/hc/es/articles/17366316889741-ERROR-aggregate-functions-are-not-allowed-in-UPDATE-Position-54-when-upgrading-a-PostgreSQL-database))_

The strange thing is that all the environment variables are consistent for CI:  java, postgres, os ,etc. 
So if it was due to the environment, it would be consistent, and to add,  customers can use either java 8 or 11.