### PR TITLE
LPD-17671 Indexes should be dropped before the column is dropped.

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -423,6 +423,36 @@ public class DBTest {
 	}
 
 	@Test
+	public void testAlterTableDropIndexedColumnWithDuplicateColumn()
+		throws Exception {
+
+		db.runSQL(
+			"create table " + DBTest._TABLE_NAME_3 +
+				" (id1 LONG not null, id2 LONG not null)");
+
+		db.runSQL(
+			"CREATE UNIQUE INDEX IX_TEMP ON " + _TABLE_NAME_3 + " (id1,id2)");
+
+		db.runSQL("INSERT into " + _TABLE_NAME_3 + " (id1,id2) values (1,1)");
+
+		db.runSQL("INSERT into " + _TABLE_NAME_3 + " (id1,id2) values (1,2)");
+
+		db.alterTableDropColumn(connection, _TABLE_NAME_3, "id2");
+
+		Assert.assertFalse(dbInspector.hasColumn(_TABLE_NAME_3, "id2"));
+
+		List<IndexMetadata> indexMetadatas = ReflectionTestUtil.invoke(
+			db, "getIndexes",
+			new Class<?>[] {
+				Connection.class, String.class, String.class, boolean.class
+			},
+			connection, _TABLE_NAME_3, "id2", false);
+
+		Assert.assertEquals(
+			indexMetadatas.toString(), 0, indexMetadatas.size());
+	}
+
+	@Test
 	public void testAlterTableName() throws Exception {
 		db.runSQL(
 			StringBundler.concat(

--- a/portal-impl/src/com/liferay/portal/dao/db/MariaDBDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MariaDBDB.java
@@ -6,12 +6,6 @@
 package com.liferay.portal.dao.db;
 
 import com.liferay.portal.kernel.dao.db.DBType;
-import com.liferay.portal.kernel.dao.db.IndexMetadata;
-import com.liferay.portal.kernel.util.ArrayUtil;
-
-import java.sql.Connection;
-
-import java.util.List;
 
 /**
  * @author Preston Crary
@@ -20,39 +14,6 @@ public class MariaDBDB extends MySQLDB {
 
 	public MariaDBDB(int majorVersion, int minorVersion) {
 		super(DBType.MARIADB, majorVersion, minorVersion);
-	}
-
-	@Override
-	public void alterTableDropColumn(
-			Connection connection, String tableName, String columnName)
-		throws Exception {
-
-		String[] primaryKeyColumnNames = getPrimaryKeyColumnNames(
-			connection, tableName);
-
-		boolean primaryKey = ArrayUtil.contains(
-			primaryKeyColumnNames, columnName);
-
-		if (primaryKey && (primaryKeyColumnNames.length > 1)) {
-			removePrimaryKey(connection, tableName);
-
-			addPrimaryKey(
-				connection, tableName,
-				ArrayUtil.remove(primaryKeyColumnNames, columnName));
-		}
-
-		List<IndexMetadata> uniqueIndexes = getIndexes(
-			connection, tableName, columnName, true);
-
-		for (IndexMetadata uniqueIndex : uniqueIndexes) {
-			String[] columnNames = uniqueIndex.getColumnNames();
-
-			if (columnNames.length > 1) {
-				runSQL(uniqueIndex.getDropSQL());
-			}
-		}
-
-		super.alterTableDropColumn(connection, tableName, columnName);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -85,7 +85,7 @@ public class MySQLDB extends BaseDB {
 		}
 
 		List<IndexMetadata> uniqueIndexes = getIndexes(
-			connection, tableName, columnName, true);
+			connection, tableName, columnName, false);
 
 		for (IndexMetadata uniqueIndex : uniqueIndexes) {
 			String[] columnNames = uniqueIndex.getColumnNames();

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -66,6 +66,39 @@ public class MySQLDB extends BaseDB {
 	}
 
 	@Override
+	public void alterTableDropColumn(
+			Connection connection, String tableName, String columnName)
+		throws Exception {
+
+		String[] primaryKeyColumnNames = getPrimaryKeyColumnNames(
+			connection, tableName);
+
+		boolean primaryKey = ArrayUtil.contains(
+			primaryKeyColumnNames, columnName);
+
+		if (primaryKey && (primaryKeyColumnNames.length > 1)) {
+			removePrimaryKey(connection, tableName);
+
+			addPrimaryKey(
+				connection, tableName,
+				ArrayUtil.remove(primaryKeyColumnNames, columnName));
+		}
+
+		List<IndexMetadata> uniqueIndexes = getIndexes(
+			connection, tableName, columnName, true);
+
+		for (IndexMetadata uniqueIndex : uniqueIndexes) {
+			String[] columnNames = uniqueIndex.getColumnNames();
+
+			if (columnNames.length > 1) {
+				runSQL(uniqueIndex.getDropSQL());
+			}
+		}
+
+		super.alterTableDropColumn(connection, tableName, columnName);
+	}
+
+	@Override
 	public String buildSQL(String template) throws IOException {
 		template = replaceTemplate(template);
 


### PR DESCRIPTION
Issue:
If an index has a duplicate entry after dropping a column, then the index will prevent the column from being dropped.

Solution:
Drop the index before dropping the column.

The same solution that was applied for MariaDB was applied for MySQL after testing the other databases.

